### PR TITLE
Fix notification to alert only on-call support

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -70,14 +70,11 @@ def post_priority_bugs():
             platform_slug = platform.lower().replace(" ", "-")
             lead = config["platforms"][platform_slug]["lead"]
             lead_info = config["people"][lead]
-            notified.add(
-                f"<@{lead_info['slack_id']}> ({platform} Lead)"
-            )
+            notified.add(f"<@{lead_info['slack_id']}> ({platform} Lead)")
             for developer in config["platforms"][platform_slug]["developers"]:
                 person = config["people"][developer]
-                if (
-                    person["linear_username"] not in assigned
-                    and not person.get("on_call_support", False)
+                if person["linear_username"] not in assigned and person.get(
+                    "on_call_support", False
                 ):
                     notified.add(f"<@{person['slack_id']}>")
         if notified:


### PR DESCRIPTION
## Summary
- ensure unassigned issue alerts only mention support developers

## Testing
- `flake8 jobs.py` *(fails: E501, F841)*
- `python -m py_compile jobs.py`

------
https://chatgpt.com/codex/tasks/task_e_685d5d8d1ec88324b5750fd0e8d87bb3