### PR TITLE
Subtle leaderboard tooltip

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -127,9 +127,8 @@
         Scores
         <small
           title="4pts for high, 2pts for medium, 1pt for low"
-          style="font-size: 0.8em; opacity: 0.75; cursor: help"
-          >ℹ️</small
-        >
+          style="font-size: 0.8em; opacity: 0.6;"
+          >ⓘ</small>
       </h4>
       <table>
         <tbody>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,11 @@
       href="{{ url_for('static', filename='pico.min.css') }}"
     />
     <title>Apollos Bug Board</title>
+    <style>
+      #score-tooltip[data-tooltip]::before {
+        font-size: 0.7em;
+      }
+    </style>
   </head>
   <body>
     <header class="container">
@@ -126,6 +131,7 @@
       <h4>
         Scores
         <small
+          id="score-tooltip"
           data-tooltip="4pts for high, 2pts for medium, 1pt for low"
           style="font-size: 0.8em; opacity: 0.6;"
           >ⓘ</small>

--- a/templates/index.html
+++ b/templates/index.html
@@ -125,7 +125,9 @@
       <h2>Leaderboard ({{ days }}d)</h2>
       <h4>
         Scores
-        <small data-tooltip="4pts for high, 2pts for medium, 1pt for low"
+        <small
+          title="4pts for high, 2pts for medium, 1pt for low"
+          style="font-size: 0.8em; opacity: 0.75; cursor: help"
           >ℹ️</small
         >
       </h4>

--- a/templates/index.html
+++ b/templates/index.html
@@ -126,7 +126,7 @@
       <h4>
         Scores
         <small
-          title="4pts for high, 2pts for medium, 1pt for low"
+          data-tooltip="4pts for high, 2pts for medium, 1pt for low"
           style="font-size: 0.8em; opacity: 0.6;"
           >ⓘ</small>
       </h4>


### PR DESCRIPTION
## Summary
- make the scoreboard tooltip subtler by using the native browser tooltip and dimming the icon

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ee7e4c43c8324b9a8f75485c17852