### PR TITLE
Add person page to view user work

### DIFF
--- a/app.py
+++ b/app.py
@@ -100,6 +100,7 @@ def person(person_id):
         days=days,
         open_by_project=by_project(open_items),
         completed_by_project=by_project(completed_items),
+    )
 
 
 @app.route("/team")

--- a/app.py
+++ b/app.py
@@ -3,9 +3,12 @@ from flask import Flask, render_template, request
 from linear import (
     by_assignee,
     by_platform,
+    by_project,
     get_completed_issues,
+    get_completed_issues_for_person,
     get_created_issues,
     get_open_issues,
+    get_open_issues_for_person,
     get_time_data,
 )
 
@@ -81,6 +84,21 @@ def index():
             reverse=True,
         ),
         fixes_per_day=fixes_per_day,
+    )
+
+
+@app.route("/person/<person_id>")
+def person(person_id):
+    """Display open and completed work for a person."""
+    days = request.args.get("days", default=30, type=int)
+    open_items = get_open_issues_for_person(person_id)
+    completed_items = get_completed_issues_for_person(person_id, days)
+    return render_template(
+        "person.html",
+        person_id=person_id,
+        days=days,
+        open_by_project=by_project(open_items),
+        completed_by_project=by_project(completed_items),
     )
 
 

--- a/templates/person.html
+++ b/templates/person.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    <link rel="stylesheet" href="{{ url_for('static', filename='pico.min.css') }}" />
+    <title>Person Work</title>
+  </head>
+  <body>
+    <header class="container">
+      <nav>
+        <ul>
+          <li><a href="{{ url_for('index') }}">Bug Board</a></li>
+        </ul>
+        <ul>
+          <li><a href="{{ url_for('person', person_id=person_id, days=7) }}">7d</a></li>
+          <li><a href="{{ url_for('person', person_id=person_id, days=30) }}">30d</a></li>
+          <li><a href="{{ url_for('person', person_id=person_id, days=90) }}">90d</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main class="container">
+      <h2>Ongoing Work</h2>
+      {% for project, issues in open_by_project.items() %}
+      <details open>
+        <summary>{{ project }}</summary>
+        {% for issue in issues %}
+        <div class="card">
+          <article>
+            <a href="{{ issue.url }}">{{ issue.title }}</a>
+            <small>(+{{ issue.daysOpen }}d)</small>
+          </article>
+        </div>
+        {% endfor %}
+      </details>
+      {% endfor %}
+      <hr />
+      <h2>Completed ({{ days }}d)</h2>
+      {% for project, issues in completed_by_project.items() %}
+      <details>
+        <summary>{{ project }}</summary>
+        {% for issue in issues %}
+        <div class="card">
+          <article>
+            <a href="{{ issue.url }}">{{ issue.title }}</a>
+          </article>
+        </div>
+        {% endfor %}
+      </details>
+      {% endfor %}
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- support grouping Linear issues by project
- expose routes to fetch open and completed issues for a person
- create `/person/<person_id>` page to show a user's work

## Testing
- `python -m py_compile app.py linear.py github.py jobs.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_685edbfb2aa48324bb38580dd6da23b3