### PR TITLE
Add engineering team page link

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,15 +95,13 @@ def team():
         name = data.get("linear_username", key)
         return name.replace(".", " ").replace("-", " ").title()
 
-    team_info = {}
-    for slug, info in config.get("platforms", {}).items():
-        team_info[slug] = {
-            "lead": format_name(info.get("lead")),
-            "developers": [
-                format_name(dev) for dev in info.get("developers", [])
-            ],
-        }
-
+    leads = {
+        slug: format_name(info.get("lead"))
+        for slug, info in config.get("platforms", {}).items()
+    }
+    developers = sorted(
+        {format_name(person) for person in config.get("people", {})}
+    )
     on_call_support = [
         format_name(name)
         for name, person in config.get("people", {}).items()
@@ -112,7 +110,8 @@ def team():
 
     return render_template(
         "team.html",
-        team=team_info,
+        leads=leads,
+        developers=developers,
         on_call_support=on_call_support,
     )
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -177,5 +177,8 @@
         }
       });
     </script>
+    <footer class="container">
+      <small><a href="{{ url_for('team') }}">Engineering Team</a></small>
+    </footer>
   </body>
 </html>

--- a/templates/team.html
+++ b/templates/team.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    <link rel="stylesheet" href="{{ url_for('static', filename='pico.min.css') }}" />
+    <title>Engineering Team</title>
+  </head>
+  <body>
+    <header class="container">
+      <nav>
+        <ul>
+          <li><a href="{{ url_for('index') }}">Bug Board</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main class="container">
+      <h2>Engineering Team</h2>
+      <h3>Platforms</h3>
+      {% for platform, info in team.items() %}
+      <details>
+        <summary>{{ platform.replace('-', ' ').title() }}</summary>
+        <p><strong>Lead:</strong> {{ info.lead }}</p>
+        <p><strong>Team:</strong> {{ ', '.join(info.developers) }}</p>
+      </details>
+      {% endfor %}
+      <hr />
+      <h3>On Call Support</h3>
+      <p>{{ ', '.join(on_call_support) }}</p>
+    </main>
+    <footer class="container">
+      <small><a href="{{ url_for('team') }}">Engineering Team</a></small>
+    </footer>
+  </body>
+</html>

--- a/templates/team.html
+++ b/templates/team.html
@@ -17,14 +17,15 @@
     </header>
     <main class="container">
       <h2>Engineering Team</h2>
-      <h3>Platforms</h3>
-      {% for platform, info in team.items() %}
-      <details>
-        <summary>{{ platform.replace('-', ' ').title() }}</summary>
-        <p><strong>Lead:</strong> {{ info.lead }}</p>
-        <p><strong>Team:</strong> {{ ', '.join(info.developers) }}</p>
-      </details>
+      <h3>Tech Leads</h3>
+      <ul>
+      {% for platform, lead in leads.items() %}
+        <li>{{ platform.replace('-', ' ').title() }}: {{ lead }}</li>
       {% endfor %}
+      </ul>
+      <hr />
+      <h3>All Developers</h3>
+      <p>{{ ', '.join(developers) }}</p>
       <hr />
       <h3>On Call Support</h3>
       <p>{{ ', '.join(on_call_support) }}</p>


### PR DESCRIPTION
## Summary
- add a footer link to the new Engineering Team page
- show platform leads, team members, and on-call support

## Testing
- `flake8`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685eec785b308324a8e98aa81c8590f6