### PR TITLE
Sort tech lead platforms alphabetically

### DIFF
--- a/templates/team.html
+++ b/templates/team.html
@@ -19,7 +19,7 @@
       <h2>Engineering Team</h2>
       <h3>Tech Leads</h3>
       <ul>
-      {% for platform, lead in leads.items() %}
+      {% for platform, lead in leads|dictsort %}
         <li>{{ platform.replace('-', ' ').title() }}: {{ lead }}</li>
       {% endfor %}
       </ul>


### PR DESCRIPTION
## Summary
- sort platforms in the Tech Leads section alphabetically using Jinja's `dictsort`

## Testing
- `pytest -q`
- `python -m py_compile app.py config.py github.py jobs.py linear.py`


------
https://chatgpt.com/codex/tasks/task_e_685f0081ea208324bfa8aa2daaada1ec