### PR TITLE
Add Platforms team listing on team page

### DIFF
--- a/app.py
+++ b/app.py
@@ -113,10 +113,6 @@ def team():
         name = data.get("linear_username", key)
         return name.replace(".", " ").replace("-", " ").title()
 
-    leads = {
-        slug: format_name(info.get("lead"))
-        for slug, info in config.get("platforms", {}).items()
-    }
     platform_teams = {
         slug: [
             {"name": format_name(info.get("lead")), "lead": True}
@@ -139,7 +135,6 @@ def team():
 
     return render_template(
         "team.html",
-        leads=leads,
         platform_teams=platform_teams,
         developers=developers,
         on_call_support=on_call_support,

--- a/app.py
+++ b/app.py
@@ -113,17 +113,15 @@ def team():
         name = data.get("linear_username", key)
         return name.replace(".", " ").replace("-", " ").title()
 
-    platform_teams = {
-        slug: [
-            {"name": format_name(info.get("lead")), "lead": True}
+    platform_teams = {}
+    for slug, info in config.get("platforms", {}).items():
+        lead = info.get("lead")
+        developers = [dev for dev in info.get("developers", []) if dev != lead]
+        developers = sorted(developers, key=lambda d: format_name(d))
+        members = [{"name": format_name(lead), "lead": True}] + [
+            {"name": format_name(dev), "lead": False} for dev in developers
         ]
-        + [
-            {"name": format_name(dev), "lead": False}
-            for dev in info.get("developers", [])
-            if dev != info.get("lead")
-        ]
-        for slug, info in config.get("platforms", {}).items()
-    }
+        platform_teams[slug] = members
     developers = sorted(
         {format_name(person) for person in config.get("people", {})}
     )

--- a/app.py
+++ b/app.py
@@ -119,10 +119,10 @@ def team():
     }
     platform_teams = {
         slug: [
-            format_name(info.get("lead"))
+            {"name": format_name(info.get("lead")), "lead": True}
         ]
         + [
-            format_name(dev)
+            {"name": format_name(dev), "lead": False}
             for dev in info.get("developers", [])
             if dev != info.get("lead")
         ]

--- a/app.py
+++ b/app.py
@@ -117,6 +117,17 @@ def team():
         slug: format_name(info.get("lead"))
         for slug, info in config.get("platforms", {}).items()
     }
+    platform_teams = {
+        slug: [
+            format_name(info.get("lead"))
+        ]
+        + [
+            format_name(dev)
+            for dev in info.get("developers", [])
+            if dev != info.get("lead")
+        ]
+        for slug, info in config.get("platforms", {}).items()
+    }
     developers = sorted(
         {format_name(person) for person in config.get("people", {})}
     )
@@ -129,6 +140,7 @@ def team():
     return render_template(
         "team.html",
         leads=leads,
+        platform_teams=platform_teams,
         developers=developers,
         on_call_support=on_call_support,
     )

--- a/config.yml
+++ b/config.yml
@@ -121,7 +121,6 @@ platforms:
   marketing-site:
     lead: nathan
     developers:
-      - michael
       - vitor
       - sherange
       - bruno
@@ -142,7 +141,6 @@ platforms:
   mobile:
     lead: darryl
     developers:
-      - michael
       - sherange
       - jimmy
       - aleks
@@ -152,7 +150,6 @@ platforms:
   tv:
     lead: darryl
     developers:
-      - michael
       - sherange
       - jimmy
       - aleks
@@ -162,12 +159,10 @@ platforms:
   roku:
     lead: andy
     developers:
-      - michael
       - dennis
   web:
     lead: nathan
     developers:
-      - michael
       - sherange
       - jimmy
       - bruno
@@ -175,7 +170,6 @@ platforms:
   admin:
     lead: nathan
     developers:
-      - michael
       - sherange
       - jimmy
       - bruno
@@ -184,7 +178,6 @@ platforms:
   cluster:
     lead: vincent
     developers:
-      - michael
       - jimmy
       - aleks
       - cameron
@@ -197,7 +190,6 @@ platforms:
   shovel:
     lead: vincent
     developers:
-      - michael
       - rajuran
       - jimmy
       - bruno
@@ -206,7 +198,6 @@ platforms:
   transcriptions:
     lead: vincent
     developers:
-      - michael
       - jimmy
       - bruno
       - dennis

--- a/templates/index.html
+++ b/templates/index.html
@@ -185,7 +185,7 @@
       });
     </script>
     <footer class="container">
-      <small><a href="{{ url_for('team') }}">Engineering Team</a></small>
+      <small><a href="{{ url_for('team') }}">Engineering Teams</a></small>
     </footer>
   </body>
 </html>

--- a/templates/team.html
+++ b/templates/team.html
@@ -17,6 +17,13 @@
     </header>
     <main class="container">
       <h2>Engineering Team</h2>
+      <h3>Platforms</h3>
+      <ul>
+      {% for platform, members in platform_teams|dictsort %}
+        <li>{{ platform.replace('-', ' ').title() }}: {{ ', '.join(members) }}</li>
+      {% endfor %}
+      </ul>
+      <hr />
       <h3>Tech Leads</h3>
       <ul>
       {% for platform, lead in leads|dictsort %}

--- a/templates/team.html
+++ b/templates/team.html
@@ -20,14 +20,19 @@
       <h3>Platforms</h3>
       <ul>
       {% for platform, members in platform_teams|dictsort %}
-        <li>{{ platform.replace('-', ' ').title() }}: {{ ', '.join(members) }}</li>
+        <li>
+          {{ platform.replace('-', ' ').title() }}:
+          {% for member in members %}
+            {{ member.name }}{% if member.lead %} (Lead){% endif %}{% if not loop.last %}, {% endif %}
+          {% endfor %}
+        </li>
       {% endfor %}
       </ul>
       <hr />
       <h3>Tech Leads</h3>
       <ul>
       {% for platform, lead in leads|dictsort %}
-        <li>{{ platform.replace('-', ' ').title() }}: {{ lead }}</li>
+        <li>{{ platform.replace('-', ' ').title() }}: {{ lead }} (Lead)</li>
       {% endfor %}
       </ul>
       <hr />

--- a/templates/team.html
+++ b/templates/team.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
     <link rel="stylesheet" href="{{ url_for('static', filename='pico.min.css') }}" />
-    <title>Engineering Team</title>
+    <title>Engineering Teams</title>
   </head>
   <body>
     <header class="container">
@@ -16,7 +16,7 @@
       </nav>
     </header>
     <main class="container">
-      <h2>Engineering Team</h2>
+      <h2>Engineering Teams</h2>
       <h3>Platforms</h3>
       <ul>
       {% for platform, members in platform_teams|dictsort %}
@@ -29,13 +29,6 @@
       {% endfor %}
       </ul>
       <hr />
-      <h3>Tech Leads</h3>
-      <ul>
-      {% for platform, lead in leads|dictsort %}
-        <li>{{ platform.replace('-', ' ').title() }}: {{ lead }} (Lead)</li>
-      {% endfor %}
-      </ul>
-      <hr />
       <h3>All Developers</h3>
       <p>{{ ', '.join(developers) }}</p>
       <hr />
@@ -43,7 +36,7 @@
       <p>{{ ', '.join(on_call_support) }}</p>
     </main>
     <footer class="container">
-      <small><a href="{{ url_for('team') }}">Engineering Team</a></small>
+      <small><a href="{{ url_for('team') }}">Engineering Teams</a></small>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- include a list of team members per platform with the lead first
- render the new section in the team page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f327390e48324989fdcb13d30358c