### PR TITLE
Link engineering team members to person pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -122,9 +122,12 @@ def team():
             {"name": format_name(dev), "lead": False} for dev in developers
         ]
         platform_teams[slug] = members
-    developers = sorted(
-        {format_name(person) for person in config.get("people", {})}
-    )
+
+    developers = [
+        {"name": format_name(person), "slug": person}
+        for person in config.get("people", {})
+    ]
+    developers = sorted(developers, key=lambda d: d["name"])
     on_call_support = [
         format_name(name)
         for name, person in config.get("people", {}).items()

--- a/templates/team.html
+++ b/templates/team.html
@@ -30,7 +30,11 @@
       </ul>
       <hr />
       <h3>All Developers</h3>
-      <p>{{ ', '.join(developers) }}</p>
+      <p>
+      {% for developer in developers %}
+        <a href="{{ url_for('person', person_id=developer.slug) }}">{{ developer.name }}</a>{% if not loop.last %}, {% endif %}
+      {% endfor %}
+      </p>
       <hr />
       <h3>On Call Support</h3>
       <p>{{ ', '.join(on_call_support) }}</p>


### PR DESCRIPTION
## Summary
- pass developer slugs to the engineering team template
- link each developer name in the All Developers list to their `/person/<id>` page

## Testing
- `python -m py_compile app.py linear.py github.py jobs.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_685f471120548324957936eab926f7b7