### PR TITLE
Skip waiting PRs with failed checks

### DIFF
--- a/github.py
+++ b/github.py
@@ -92,6 +92,29 @@ def get_prs(repo_id, pr_states):
                                     }
                                 }
                             }
+                            commits(last: 1) {
+                                nodes {
+                                    commit {
+                                        statusCheckRollup {
+                                            contexts(first: 100) {
+                                                nodes {
+                                                    __typename
+                                                    ... on CheckRun {
+                                                        name
+                                                        conclusion
+                                                        isRequired
+                                                    }
+                                                    ... on StatusContext {
+                                                        context
+                                                        state
+                                                        isRequired
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -103,6 +126,31 @@ def get_prs(repo_id, pr_states):
     prs = data["node"]["pullRequests"]["nodes"]
     non_draft_prs = [pr for pr in prs if not pr.get("isDraft", False)]
     return non_draft_prs
+
+
+def has_failing_required_checks(pr):
+    """Return True if the PR has any failing required checks."""
+
+    commits = pr.get("commits", {}).get("nodes", [])
+    if not commits:
+        return False
+    contexts = (
+        commits[0]
+        .get("commit", {})
+        .get("statusCheckRollup", {})
+        .get("contexts", {})
+        .get("nodes", [])
+    )
+    for ctx in contexts:
+        if not ctx.get("isRequired"):
+            continue
+        if ctx["__typename"] == "CheckRun":
+            if ctx.get("conclusion") != "SUCCESS":
+                return True
+        elif ctx["__typename"] == "StatusContext":
+            if ctx.get("state") != "SUCCESS":
+                return True
+    return False
 
 
 def prs_by_approver():
@@ -139,6 +187,9 @@ def get_prs_waiting_for_review_by_reviewer():
             continue
         if pr["reviews"]["nodes"]:
             # PR already has an approval
+            continue
+        if has_failing_required_checks(pr):
+            # waiting on author to fix checks
             continue
         for review in pr["timelineItems"]["nodes"]:
             if (


### PR DESCRIPTION
## Summary
- query PR status check rollups
- add `has_failing_required_checks` helper
- skip PRs with failed required checks in the waiting-for-review list

## Testing
- `python -m py_compile github.py jobs.py app.py linear.py config.py`
- `flake8` *(fails: E501 line length in linear.py)*

------
https://chatgpt.com/codex/tasks/task_e_68600c986c4c83249ac127beadd6685f