### PR TITLE
Relocate home page timescale selector

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -16,9 +16,9 @@
     <h2>Priority Bug Stats</h2>
     <form method="get" style="display:inline-block; margin-bottom: 0.5em;">
       <select name="days" onchange="this.form.submit()">
-        <option value="1"  {{ 'selected' if days == 1 else '' }}>1d</option>
         <option value="7"  {{ 'selected' if days == 7 else '' }}>7d</option>
         <option value="30" {{ 'selected' if days == 30 else '' }}>30d</option>
+        <option value="90" {{ 'selected' if days == 90 else '' }}>90d</option>
       </select>
     </form>
       <div class="grid">

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,6 +13,7 @@
 {% block header_nav %}{% endblock %}
 
 {% block content %}
+    <h2>Priority Bug Stats</h2>
     <form method="get" style="display:inline-block; margin-bottom: 0.5em;">
       <select name="days" onchange="this.form.submit()">
         <option value="1"  {{ 'selected' if days == 1 else '' }}>1d</option>
@@ -20,7 +21,6 @@
         <option value="30" {{ 'selected' if days == 30 else '' }}>30d</option>
       </select>
     </form>
-    <h2>Priority Bug Stats ({{ days }}d)</h2>
       <div class="grid">
         <div>
           <article>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,16 +10,17 @@
 </style>
 {% endblock %}
 
-{% block header_nav %}
-<ul>
-  <li><a href="{{ url_for('index', days=7) }}">7d</a></li>
-  <li><a href="{{ url_for('index', days=30) }}">30d</a></li>
-  <li><a href="{{ url_for('index', days=90) }}">90d</a></li>
-</ul>
-{% endblock %}
+{% block header_nav %}{% endblock %}
 
 {% block content %}
-      <h2>Priority Bug Stats ({{ days }}d)</h2>
+    <form method="get" style="display:inline-block; margin-bottom: 0.5em;">
+      <select name="days" onchange="this.form.submit()">
+        <option value="1"  {{ 'selected' if days == 1 else '' }}>1d</option>
+        <option value="7"  {{ 'selected' if days == 7 else '' }}>7d</option>
+        <option value="30" {{ 'selected' if days == 30 else '' }}>30d</option>
+      </select>
+    </form>
+    <h2>Priority Bug Stats ({{ days }}d)</h2>
       <div class="grid">
         <div>
           <article>

--- a/templates/person.html
+++ b/templates/person.html
@@ -2,13 +2,7 @@
 
 {% block title %}{{ person_name|first_name }}{% endblock %}
 
-{% block header_nav %}
-<ul>
-  <li><a href="{{ url_for('team_slug', slug=person_slug, days=7) }}">7d</a></li>
-  <li><a href="{{ url_for('team_slug', slug=person_slug, days=30) }}">30d</a></li>
-  <li><a href="{{ url_for('team_slug', slug=person_slug, days=90) }}">90d</a></li>
-</ul>
-{% endblock %}
+{% block header_nav %}{% endblock %}
 
 {% block content %}
       <h2>Current Focus</h2>
@@ -38,7 +32,14 @@
       </details>
       {% endfor %}
       <hr />
-      <h2>Completed ({{ days }}d)</h2>
+      <h2>Completed</h2>
+      <form method="get" style="display:inline-block; margin-bottom: 0.5em;">
+        <select name="days" onchange="this.form.submit()">
+          <option value="1"  {{ 'selected' if days == 1 else '' }}>1d</option>
+          <option value="7"  {{ 'selected' if days == 7 else '' }}>7d</option>
+          <option value="30" {{ 'selected' if days == 30 else '' }}>30d</option>
+        </select>
+      </form>
       {% for project, issues in completed_by_project.items() %}
       <details>
         <summary>{{ project }}</summary>


### PR DESCRIPTION
## Summary
- clear the `header_nav` block in the index template
- add a days dropdown just above the Priority Bug Stats heading

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68607f8594588324b77c67f827b0fefd