### PR TITLE
Add cached config loader

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template, request, abort
-import yaml
+
+from config import load_config
 import re
 
 from linear import (
@@ -53,8 +54,7 @@ def index():
         completed_bugs + completed_new_features + completed_technical_changes
     ) / days
 
-    with open("config.yml", "r") as file:
-        config_data = yaml.safe_load(file)
+    config_data = load_config()
     username_to_slug = {
         info.get("linear_username"): slug
         for slug, info in config_data.get("people", {}).items()
@@ -101,8 +101,7 @@ def index():
 def team_slug(slug):
     """Display open and completed work for a team member."""
     days = request.args.get("days", default=30, type=int)
-    with open("config.yml", "r") as file:
-        config = yaml.safe_load(file)
+    config = load_config()
     person_cfg = config.get("people", {}).get(slug)
     if not person_cfg:
         abort(404)
@@ -169,8 +168,7 @@ def team_slug(slug):
 
 @app.route("/team")
 def team():
-    with open("config.yml", "r") as file:
-        config = yaml.safe_load(file)
+    config = load_config()
 
     def format_name(key):
         data = config["people"].get(key, {})

--- a/config.py
+++ b/config.py
@@ -1,7 +1,15 @@
+from functools import lru_cache
 import yaml
 
 
+@lru_cache(maxsize=1)
+def load_config(path="config.yml"):
+    """Load configuration data from ``path`` and cache the result."""
+    with open(path, "r") as f:
+        return yaml.safe_load(f)
+
+
 def get_platforms():
-    with open("config.yml", "r") as file:
-        config = yaml.safe_load(file)
+    """Return platform configuration from the cached config."""
+    config = load_config()
     return config.get("platforms", [])

--- a/jobs.py
+++ b/jobs.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 import requests
 import schedule
-import yaml
+from config import load_config
 from dotenv import load_dotenv
 
 from github import (
@@ -49,8 +49,7 @@ def with_retries(func):
 
 
 def get_slack_markdown_by_linear_username(username):
-    with open("config.yml", "r") as file:
-        config = yaml.safe_load(file)
+    config = load_config()
     for person in config["people"]:
         if config["people"][person]["linear_username"] == username:
             return f"<@{config['people'][person]['slack_id']}>"
@@ -59,8 +58,7 @@ def get_slack_markdown_by_linear_username(username):
 
 # @with_retries
 def post_priority_bugs():
-    with open("config.yml", "r") as file:
-        config = yaml.safe_load(file)
+    config = load_config()
     open_priority_bugs = get_open_issues(2, "Bug")
     unassigned = [bug for bug in open_priority_bugs if bug["assignee"] is None]
     at_risk = [
@@ -179,8 +177,7 @@ def post_leaderboard():
 
 # @with_retries
 def post_stale():
-    with open("config.yml", "r") as file:
-        config = yaml.safe_load(file)
+    config = load_config()
     people_by_github_username = {
         person["github_username"]: person
         for person in config["people"].values()


### PR DESCRIPTION
## Summary
- create `load_config` helper in `config.py`
- use new helper in the Flask app and scheduled jobs

## Testing
- `python -m py_compile app.py jobs.py config.py github.py linear.py`
- `flake8` *(fails: E501 line too long etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686088533ca88324b93c7026cbbc217e