### PR TITLE
Move engineering teams link to nav

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,8 @@
       <nav>
         <ul>
           <li><a href="{{ url_for('index') }}">Bug Board</a></li>
+        </ul>
+        <ul>
           <li><a href="{{ url_for('team') }}">Engineering Teams</a></li>
         </ul>
         {% block header_nav %}{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,7 @@
       <nav>
         <ul>
           <li><a href="{{ url_for('index') }}">Bug Board</a></li>
+          <li><a href="{{ url_for('team') }}">Engineering Teams</a></li>
         </ul>
         {% block header_nav %}{% endblock %}
       </nav>
@@ -20,9 +21,7 @@
     <main class="container">
       {% block content %}{% endblock %}
     </main>
-    <footer class="container">
-      <small><a href="{{ url_for('team') }}">Engineering Teams</a></small>
-    </footer>
+    <footer class="container"></footer>
     {% block extra_scripts %}{% endblock %}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- link to "Engineering Teams" in the navigation bar instead of the footer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860be981e0083248d22576eb3f30fae