### PR TITLE
Add personal PR metrics and platform chart

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,12 +15,17 @@ from linear import (
     get_time_data,
     get_projects,
 )
+from github import (
+    get_merged_pr_count_for_user,
+    get_approved_pr_count_for_user,
+)
 
 app = Flask(__name__)
 
-@app.template_filter('first_name')
+
+@app.template_filter("first_name")
 def first_name_filter(name: str) -> str:
-    parts = re.split(r'[.\-\s]+', name)
+    parts = re.split(r"[.\-\s]+", name)
     if parts and parts[0]:
         return parts[0].title()
     return name.title()
@@ -50,9 +55,10 @@ def index():
         + get_open_issues(5, "Technical Change")
     )
     time_data = get_time_data(completed_priority_bugs)
-    fixes_per_day = len(
-        completed_bugs + completed_new_features + completed_technical_changes
-    ) / days
+    fixes_per_day = (
+        len(completed_bugs + completed_new_features + completed_technical_changes)
+        / days
+    )
 
     config_data = load_config()
     username_to_slug = {
@@ -67,17 +73,11 @@ def index():
         issue_count=len(created_priority_bugs),
         priority_percentage=int(
             len(completed_priority_bugs)
-            / len(
-                completed_bugs
-                + completed_new_features
-                + completed_technical_changes
-            )
+            / len(completed_bugs + completed_new_features + completed_technical_changes)
             * 100
         ),
         completed_issues_by_assignee=by_assignee(
-            completed_bugs
-            + completed_new_features
-            + completed_technical_changes
+            completed_bugs + completed_new_features + completed_technical_changes
         ),
         all_issues=created_priority_bugs + open_priority_bugs,
         issues_by_platform=by_platform(created_priority_bugs),
@@ -127,8 +127,12 @@ def team_slug(slug):
         else:
             projects_by_initiative.setdefault("No Initiative", []).append(project)
     # Sort initiatives alphabetically
-    projects_by_initiative = dict(sorted(projects_by_initiative.items(), key=lambda x: x[0]))
-    current_projects = projects_by_initiative.get(cycle_initiative, []) if cycle_initiative else []
+    projects_by_initiative = dict(
+        sorted(projects_by_initiative.items(), key=lambda x: x[0])
+    )
+    current_projects = (
+        projects_by_initiative.get(cycle_initiative, []) if cycle_initiative else []
+    )
     current_names = [proj.get("name") for proj in current_projects]
 
     if person_cfg.get("on_call_support"):
@@ -154,6 +158,11 @@ def team_slug(slug):
             if proj not in current_names
         }
 
+    github_username = person_cfg.get("github_username")
+    merged_prs = get_merged_pr_count_for_user(github_username, days)
+    approved_prs = get_approved_pr_count_for_user(github_username, days)
+    completed_by_platform = by_platform(completed_items)
+
     return render_template(
         "person.html",
         person_slug=slug,
@@ -162,6 +171,9 @@ def team_slug(slug):
         open_current_cycle=open_current_cycle,
         open_other=open_other,
         completed_by_project=completed_by_project,
+        completed_by_platform=completed_by_platform,
+        merged_prs=merged_prs,
+        approved_prs=approved_prs,
         on_call_support=person_cfg.get("on_call_support"),
     )
 

--- a/templates/person.html
+++ b/templates/person.html
@@ -5,6 +5,23 @@
 {% block header_nav %}{% endblock %}
 
 {% block content %}
+      <div class="grid">
+        <div>
+          <article>
+            <header>PRs Merged</header>
+            <h1>{{ merged_prs }}</h1>
+          </article>
+        </div>
+        <div>
+          <article>
+            <header>PRs Approved</header>
+            <h1>{{ approved_prs }}</h1>
+          </article>
+        </div>
+      </div>
+      <article>
+        <canvas id="platformChart"></canvas>
+      </article>
       <h2>{{ 'Current Support Work' if on_call_support else 'Current Cycle Work' }}</h2>
       {% if open_current_cycle %}
       {% for project, issues in open_current_cycle.items() %}
@@ -56,4 +73,35 @@
         {% endfor %}
       </details>
       {% endfor %}
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+  const ctx = document.getElementById('platformChart');
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: [
+        {% for platform in completed_by_platform %}
+        '{{ platform }}',
+        {% endfor %}
+      ],
+      datasets: [{
+        label: 'Completed Issues',
+        data: [
+          {% for platform in completed_by_platform %}
+          {{ completed_by_platform[platform] | length }},
+          {% endfor %}
+        ],
+        borderWidth: 1
+      }]
+    },
+    options: {
+      scales: {
+        y: { beginAtZero: true, ticks: { stepSize: 1 } }
+      }
+    }
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add GitHub PR stats helpers
- show PR metrics and completed issue chart on person page

## Testing
- `flake8`
- `black app.py github.py`

------
https://chatgpt.com/codex/tasks/task_e_6860ccafb920832480d993387bf652ab