### PR TITLE
Sort work on person pages by recent activity

### DIFF
--- a/app.py
+++ b/app.py
@@ -107,12 +107,25 @@ def team_slug(slug):
         abort(404)
     login = person_cfg.get("linear_username", slug)
     person_name = login.replace(".", " ").replace("-", " ").title()
-    open_items = get_open_issues_for_person(login)
-    completed_items = get_completed_issues_for_person(login, days)
+    open_items = sorted(
+        get_open_issues_for_person(login),
+        key=lambda x: x["updatedAt"],
+        reverse=True,
+    )
+    completed_items = sorted(
+        get_completed_issues_for_person(login, days),
+        key=lambda x: x["completedAt"],
+        reverse=True,
+    )
 
     # Group open and completed items by project
     open_by_project = by_project(open_items)
     completed_by_project = by_project(completed_items)
+
+    for issues in open_by_project.values():
+        issues.sort(key=lambda x: x["updatedAt"], reverse=True)
+    for issues in completed_by_project.values():
+        issues.sort(key=lambda x: x["completedAt"], reverse=True)
 
     # Determine current cycle initiative projects
     cycle_initiative = config.get("cycle_initiative")

--- a/linear.py
+++ b/linear.py
@@ -352,6 +352,7 @@ def get_open_issues_for_person(login: str):
               id
               title
               url
+              updatedAt
               createdAt
               project { name }
             }
@@ -379,6 +380,10 @@ def get_open_issues_for_person(login: str):
             datetime.utcnow()
             - datetime.strptime(issue["createdAt"], "%Y-%m-%dT%H:%M:%S.%fZ")
         ).days
+        issue["daysUpdated"] = (
+            datetime.utcnow()
+            - datetime.strptime(issue["updatedAt"], "%Y-%m-%dT%H:%M:%S.%fZ")
+        ).days
     return issues
 
 
@@ -402,6 +407,7 @@ def get_completed_issues_for_person(login: str, days=30):
               id
               title
               url
+              completedAt
               project { name }
             }
             pageInfo {
@@ -422,6 +428,11 @@ def get_completed_issues_for_person(login: str, days=30):
         if not data["issues"]["pageInfo"]["hasNextPage"]:
             break
         cursor = data["issues"]["pageInfo"]["endCursor"]
+    for issue in issues:
+        issue["daysCompleted"] = (
+            datetime.utcnow()
+            - datetime.strptime(issue["completedAt"], "%Y-%m-%dT%H:%M:%S.%fZ")
+        ).days
     return issues
 
 

--- a/templates/person.html
+++ b/templates/person.html
@@ -14,6 +14,7 @@
         <div class="card">
           <article>
             <a href="{{ issue.url }}">{{ issue.title }}</a>
+            <small style="opacity: 0.6">({{ issue.daysUpdated }}d)</small>
           </article>
         </div>
         {% endfor %}
@@ -30,6 +31,7 @@
         <div class="card">
           <article>
             <a href="{{ issue.url }}">{{ issue.title }}</a>
+            <small style="opacity: 0.6">({{ issue.daysUpdated }}d)</small>
           </article>
         </div>
         {% endfor %}
@@ -51,6 +53,7 @@
         <div class="card">
           <article>
             <a href="{{ issue.url }}">{{ issue.title }}</a>
+            <small style="opacity: 0.6">({{ issue.daysCompleted }}d)</small>
           </article>
         </div>
         {% endfor %}


### PR DESCRIPTION
## Summary
- show updated timestamp for person work items
- sort open and completed work by latest activity

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68615fdedc68832481caf8e18223b17a