### PR TITLE
Sort PR review notification by wait time

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -219,6 +219,7 @@ def post_stale():
             else:
                 reviewer_slack_markdown = reviewer
             markdown += f"\n{reviewer_slack_markdown}:\n\n"
+            pr_days = []
             for pr in unique_prs:
                 events = [
                     ev for ev in pr.get("timelineItems", {}).get("nodes", [])
@@ -232,6 +233,9 @@ def post_stale():
                     days_waiting = (datetime.now() - dt).days
                 else:
                     days_waiting = 0
+                pr_days.append((days_waiting, pr))
+
+            for days_waiting, pr in sorted(pr_days, key=lambda x: x[0], reverse=True):
                 markdown += f"- <{pr['url']}|{pr['title']}> (+{days_waiting}d)\n"
         markdown += "\n\n"
 


### PR DESCRIPTION
## Summary
- sort PRs waiting for review in slack notification by how long they've been waiting

## Testing
- `python -m py_compile jobs.py`

------
https://chatgpt.com/codex/tasks/task_e_68615f3bf5608324b341da3d8f0c070e