### PR TITLE
Add chart by platform to person page

### DIFF
--- a/app.py
+++ b/app.py
@@ -167,6 +167,8 @@ def team_slug(slug):
             if proj not in current_names
         }
 
+    work_by_platform = by_platform(open_items + completed_items)
+
     return render_template(
         "person.html",
         person_slug=slug,
@@ -176,6 +178,7 @@ def team_slug(slug):
         open_other=open_other,
         completed_by_project=completed_by_project,
         on_call_support=person_cfg.get("on_call_support"),
+        work_by_platform=work_by_platform,
     )
 
 

--- a/linear.py
+++ b/linear.py
@@ -355,6 +355,11 @@ def get_open_issues_for_person(login: str):
               updatedAt
               createdAt
               project { name }
+              labels {
+                nodes {
+                  name
+                }
+              }
             }
             pageInfo {
               hasNextPage
@@ -376,6 +381,12 @@ def get_open_issues_for_person(login: str):
         cursor = data["issues"]["pageInfo"]["endCursor"]
 
     for issue in issues:
+        platforms = [
+            tag["name"]
+            for tag in issue.get("labels", {}).get("nodes", [])
+            if tag["name"].lower().replace(" ", "-") in get_platforms()
+        ]
+        issue["platform"] = platforms[0] if platforms else None
         issue["daysOpen"] = (
             datetime.utcnow()
             - datetime.strptime(issue["createdAt"], "%Y-%m-%dT%H:%M:%S.%fZ")
@@ -409,6 +420,11 @@ def get_completed_issues_for_person(login: str, days=30):
               url
               completedAt
               project { name }
+              labels {
+                nodes {
+                  name
+                }
+              }
             }
             pageInfo {
               hasNextPage
@@ -429,6 +445,12 @@ def get_completed_issues_for_person(login: str, days=30):
             break
         cursor = data["issues"]["pageInfo"]["endCursor"]
     for issue in issues:
+        platforms = [
+            tag["name"]
+            for tag in issue.get("labels", {}).get("nodes", [])
+            if tag["name"].lower().replace(" ", "-") in get_platforms()
+        ]
+        issue["platform"] = platforms[0] if platforms else None
         issue["daysCompleted"] = (
             datetime.utcnow()
             - datetime.strptime(issue["completedAt"], "%Y-%m-%dT%H:%M:%S.%fZ")

--- a/templates/person.html
+++ b/templates/person.html
@@ -46,17 +46,61 @@
           <option value="30" {{ 'selected' if days == 30 else '' }}>30d</option>
         </select>
       </form>
-      {% for project, issues in completed_by_project.items() %}
-      <details>
-        <summary>{{ project }}</summary>
-        {% for issue in issues %}
-        <div class="card">
-          <article>
-            <a href="{{ issue.url }}">{{ issue.title }}</a>
-            <small style="opacity: 0.6">({{ issue.daysCompleted }}d)</small>
-          </article>
-        </div>
+        {% for project, issues in completed_by_project.items() %}
+        <details>
+          <summary>{{ project }}</summary>
+          {% for issue in issues %}
+          <div class="card">
+            <article>
+              <a href="{{ issue.url }}">{{ issue.title }}</a>
+              <small style="opacity: 0.6">({{ issue.daysCompleted }}d)</small>
+            </article>
+          </div>
+          {% endfor %}
+        </details>
         {% endfor %}
-      </details>
-      {% endfor %}
+        <hr />
+        <h2>Work by Platform</h2>
+        <article>
+          <div>
+  <canvas id="platformChart"></canvas>
+  </div>
+  </article>
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+  const ctx = document.getElementById('platformChart');
+
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: [
+        {% for platform in work_by_platform %}
+        '{{ platform }}',
+        {% endfor %}
+      ],
+      datasets: [{
+        label: 'Work by Platform',
+        data: [
+          {% for platform in work_by_platform %}
+          {{ work_by_platform[platform] | length }},
+          {% endfor %}
+        ],
+        borderWidth: 1
+      }]
+    },
+    options: {
+      scales: {
+        y: {
+          beginAtZero: true,
+          ticks: {
+            stepSize: 1,
+          }
+        }
+      }
+    }
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- visualize all work grouped by platform on the person's page
- expose platform label for personal issue queries
- compute work totals by platform in the person route

## Testing
- `python -m py_compile linear.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_6861663d6df0832484124ee822889cb9