### PR TITLE
Hide empty Other Work section

### DIFF
--- a/templates/person.html
+++ b/templates/person.html
@@ -23,6 +23,7 @@
       {% else %}
         <p>(Empty)</p>
       {% endif %}
+      {% if open_other %}
       <h2>Other Work</h2>
       {% for project, issues in open_other.items() %}
       <details>
@@ -37,6 +38,7 @@
         {% endfor %}
       </details>
       {% endfor %}
+      {% endif %}
       <hr />
       <h2>Completed</h2>
       <form method="get" style="display:inline-block; margin-bottom: 0.5em;">


### PR DESCRIPTION
## Summary
- avoid showing the Other Work section on a person page when there are no items

## Testing
- `flake8` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68618656412c8324b0931d89d92f5fef