### PR TITLE
Add project dates to team page

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from flask import Flask, render_template, request, abort
 
 from config import load_config
 import re
+from datetime import datetime
 
 from linear import (
     by_assignee,
@@ -130,6 +131,17 @@ def team_slug(slug):
     # Determine current cycle initiative projects
     cycle_initiative = config.get("cycle_initiative")
     cycle_projects = get_projects()
+    # attach start/target date info and compute days left
+    for proj in cycle_projects:
+        target = proj.get("targetDate")
+        days_left = None
+        if target:
+            try:
+                target_dt = datetime.fromisoformat(target).date()
+                days_left = (target_dt - datetime.utcnow().date()).days
+            except ValueError:
+                pass
+        proj["days_left"] = days_left
     projects_by_initiative = {}
     for project in cycle_projects:
         nodes = project.get("initiatives", {}).get("nodes", [])

--- a/linear.py
+++ b/linear.py
@@ -486,6 +486,8 @@ def get_projects():
                   url
                   health
                   progress
+                  startDate
+                  targetDate
                   lead {
                     displayName
                   }

--- a/templates/team.html
+++ b/templates/team.html
@@ -36,7 +36,14 @@
               {% endif %}
               <span class="health-icon" title="{{ project.health }}">{{ icon }}</span>
             {% endif %}
-            <a href="{{ project.url }}">{{ project.name }}{% if project.progress is not none %} ({{ (project.progress * 100) | round(0) | int }}%){% endif %}</a>:
+            <a href="{{ project.url }}">{{ project.name }}{% if project.progress is not none %} ({{ (project.progress * 100) | round(0) | int }}%){% endif %}</a>
+            {% if project.startDate or project.targetDate %}
+              <small>
+                {% if project.startDate %}{{ project.startDate }}{% endif %}
+                {% if project.targetDate %} → {{ project.targetDate }}{% endif %}
+                {% if project.days_left is not none %} ({{ project.days_left }}d left){% endif %}
+              </small>
+            {% endif %}:
             {% set members = project.members %}
             {% if project.lead %}
               {% set members = members | reject("equalto", project.lead.displayName) | list %}


### PR DESCRIPTION
## Summary
- load `startDate` and `targetDate` for projects
- compute remaining days to target and show on the teams page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6864b37b06e08324ab848ccc7d8b832c