### PR TITLE
Add PR metrics to person pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from linear import (
     get_time_data,
     get_projects,
 )
+from github import merged_prs_by_author, merged_prs_by_reviewer
 
 app = Flask(__name__)
 
@@ -193,6 +194,12 @@ def team_slug(slug):
         }
 
     work_by_platform = by_platform(open_items + completed_items)
+    github_username = person_cfg.get("github_username")
+    prs_merged = 0
+    prs_reviewed = 0
+    if github_username:
+        prs_merged = len(merged_prs_by_author(days).get(github_username, []))
+        prs_reviewed = len(merged_prs_by_reviewer(days).get(github_username, []))
 
     return render_template(
         "person.html",
@@ -204,6 +211,8 @@ def team_slug(slug):
         completed_by_project=completed_by_project,
         on_call_support=person_cfg.get("on_call_support"),
         work_by_platform=work_by_platform,
+        prs_merged=prs_merged,
+        prs_reviewed=prs_reviewed,
     )
 
 

--- a/templates/person.html
+++ b/templates/person.html
@@ -48,6 +48,20 @@
           <option value="30" {{ 'selected' if days == 30 else '' }}>30d</option>
         </select>
       </form>
+      <div class="grid">
+        <div>
+          <article>
+            <header>PRs Merged</header>
+            <h1>{{ prs_merged }}</h1>
+          </article>
+        </div>
+        <div>
+          <article>
+            <header>PRs Reviewed</header>
+            <h1>{{ prs_reviewed }}</h1>
+          </article>
+        </div>
+      </div>
         {% for project, issues in completed_by_project.items() %}
         <details>
           <summary>{{ project }}</summary>


### PR DESCRIPTION
## Summary
- import GitHub helpers
- add functions to fetch merged PRs per author and reviewer
- display PRs merged/reviewed counts on person pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686554931d748324b8c95f558c3ccf36