### PR TITLE
Fix Sherange GitHub username

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -13,7 +13,7 @@ people:
   sherange:
     slack_id: U05QRGANNDV
     linear_username: sherange.fonseka
-    github_username: sherange
+    github_username: Sherange
     on_call_support: true
   jimmy:
     slack_id: U019TA865C2


### PR DESCRIPTION
## Summary
- fix the capitalization for Sherange's GitHub username in `config.yml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68668e96b4d88324a74b1f47c5554acc