### PR TITLE
Enhance on-call support list with high priority bugs

### DIFF
--- a/app.py
+++ b/app.py
@@ -250,11 +250,27 @@ def team():
         ],
         key=lambda d: d["name"],
     )
-    on_call_support = [
-        format_name(name)
-        for name, person in config.get("people", {}).items()
-        if person.get("on_call_support")
-    ]
+    username_to_slug = {
+        info.get("linear_username"): slug
+        for slug, info in config.get("people", {}).items()
+    }
+    open_support_bugs = get_open_issues(2, "Bug")
+    support_dict = {}
+    for slug, person in config.get("people", {}).items():
+        if not person.get("on_call_support"):
+            continue
+        support_dict[slug] = {
+            "name": format_name(slug),
+            "issues": [],
+        }
+    for issue in open_support_bugs:
+        assignee = issue.get("assignee")
+        if not assignee:
+            continue
+        slug = username_to_slug.get(assignee.get("name"))
+        if slug in support_dict:
+            support_dict[slug]["issues"].append(issue)
+    on_call_support = list(support_dict.values())
     cycle_projects = get_projects()
     # attach start/target date info and compute days left
     for proj in cycle_projects:

--- a/app.py
+++ b/app.py
@@ -250,27 +250,27 @@ def team():
         ],
         key=lambda d: d["name"],
     )
-    username_to_slug = {
-        info.get("linear_username"): slug
-        for slug, info in config.get("people", {}).items()
-    }
-    open_support_bugs = get_open_issues(2, "Bug")
-    support_dict = {}
+    on_call_support = []
     for slug, person in config.get("people", {}).items():
         if not person.get("on_call_support"):
             continue
-        support_dict[slug] = {
+        login = person.get("linear_username", slug)
+        open_items = get_open_issues_for_person(login)
+        high_priority_bugs = []
+        for issue in open_items:
+            if (
+                issue.get("project", {}).get("name") == "Customer Success"
+                and issue.get("priority", 3) <= 2
+                and any(
+                    label.get("name", "").lower() == "bug"
+                    for label in issue.get("labels", {}).get("nodes", [])
+                )
+            ):
+                high_priority_bugs.append(issue)
+        on_call_support.append({
             "name": format_name(slug),
-            "issues": [],
-        }
-    for issue in open_support_bugs:
-        assignee = issue.get("assignee")
-        if not assignee:
-            continue
-        slug = username_to_slug.get(assignee.get("name"))
-        if slug in support_dict:
-            support_dict[slug]["issues"].append(issue)
-    on_call_support = list(support_dict.values())
+            "issues": high_priority_bugs,
+        })
     cycle_projects = get_projects()
     # attach start/target date info and compute days left
     for proj in cycle_projects:

--- a/linear.py
+++ b/linear.py
@@ -352,6 +352,7 @@ def get_open_issues_for_person(login: str):
               id
               title
               url
+              priority
               updatedAt
               createdAt
               project { name }

--- a/templates/team.html
+++ b/templates/team.html
@@ -67,11 +67,19 @@
       </ul>
       <hr />
       <h3>On Call Support</h3>
-      <p>
-      {%- for name in on_call_support -%}
-        {{ name|first_name }}{% if not loop.last %}, {% endif %}
-      {%- endfor -%}
-      </p>
+      <ul>
+      {% for member in on_call_support %}
+        <li>
+          {{ member.name|first_name }}
+          {% if member.issues %}
+            -
+            {% for issue in member.issues %}
+              <a href="{{ issue.url }}">{{ issue.title }}</a>{% if not loop.last %}, {% endif %}
+            {% endfor %}
+          {% endif %}
+        </li>
+      {% endfor %}
+      </ul>
       <hr />
       <h3>Everyone</h3>
       <p>


### PR DESCRIPTION
## Summary
- include `priority` in `get_open_issues_for_person`
- show each on-call engineer's high priority bugs on the team page

## Testing
- `python -m py_compile app.py linear.py`

------
https://chatgpt.com/codex/tasks/task_e_686d77e2e88483249033421ce9e362c0