### PR TITLE
Sort on-call list alphabetically

### DIFF
--- a/app.py
+++ b/app.py
@@ -269,11 +269,13 @@ def team():
         ],
         key=lambda d: d["name"],
     )
-    on_call_support = [
-        format_name(name)
-        for name, person in config.get("people", {}).items()
-        if person.get("on_call_support")
-    ]
+    on_call_support = sorted(
+        [
+            format_name(name)
+            for name, person in config.get("people", {}).items()
+            if person.get("on_call_support")
+        ]
+    )
     cycle_projects = get_projects()
     # attach start/target date info and compute days left
     for proj in cycle_projects:

--- a/templates/team.html
+++ b/templates/team.html
@@ -67,11 +67,11 @@
       </ul>
       <hr />
       <h3>On Call Support</h3>
-      <p>
+      <ul>
       {%- for name in on_call_support -%}
-        {{ name|first_name }}{% if not loop.last %}, {% endif %}
+        <li>{{ name|first_name }}</li>
       {%- endfor -%}
-      </p>
+      </ul>
       <hr />
       <h3>Everyone</h3>
       <p>


### PR DESCRIPTION
## Summary
- alphabetize on-call support list and render it as bullets

## Testing
- `flake8 | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_686e8c9940808324b23efdc05d368dd2