### PR TITLE
Update team listing and support links

### DIFF
--- a/app.py
+++ b/app.py
@@ -265,16 +265,18 @@ def team():
     developers = sorted(
         [
             {"slug": slug, "name": format_name(slug)}
-            for slug in config.get("people", {})
+            for slug, person in config.get("people", {}).items()
+            if not person.get("on_call_support")
         ],
         key=lambda d: d["name"],
     )
     on_call_support = sorted(
         [
-            format_name(name)
+            {"slug": name, "name": format_name(name)}
             for name, person in config.get("people", {}).items()
             if person.get("on_call_support")
-        ]
+        ],
+        key=lambda d: d["name"],
     )
     cycle_projects = get_projects()
     # attach start/target date info and compute days left

--- a/templates/team.html
+++ b/templates/team.html
@@ -68,15 +68,15 @@
       <hr />
       <h3>On Call Support</h3>
       <ul>
-      {%- for name in on_call_support -%}
-        <li>{{ name|first_name }}</li>
+      {%- for person in on_call_support -%}
+        <li><a href="{{ url_for('team_slug', slug=person.slug) }}">{{ person.name|first_name }}</a></li>
       {%- endfor -%}
       </ul>
       <hr />
-      <h3>Everyone</h3>
-      <p>
+      <h3>Cycle</h3>
+      <ul>
       {% for dev in developers %}
-        <a href="{{ url_for('team_slug', slug=dev.slug) }}">{{ dev.name|first_name }}</a>{% if not loop.last %}, {% endif %}
+        <li><a href="{{ url_for('team_slug', slug=dev.slug) }}">{{ dev.name|first_name }}</a></li>
       {% endfor %}
-      </p>
+      </ul>
 {% endblock %}


### PR DESCRIPTION
## Summary
- link support folks to person pages
- show non-support people under a `Cycle` list

## Testing
- `python -m py_compile app.py jobs.py config.py github.py linear.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e8eedeed48324881db529c7e2f53f