### PR TITLE
Remove dataset label from person chart

### DIFF
--- a/templates/person.html
+++ b/templates/person.html
@@ -116,6 +116,7 @@
         {% endfor %}
       ],
       datasets: [{
+        label: '',
         data: [
           {% for platform in work_by_platform %}
           {{ work_by_platform[platform] | length }},
@@ -125,6 +126,11 @@
       }]
     },
     options: {
+      plugins: {
+        legend: {
+          display: false
+        }
+      },
       scales: {
         y: {
           beginAtZero: true,

--- a/templates/person.html
+++ b/templates/person.html
@@ -116,7 +116,6 @@
         {% endfor %}
       ],
       datasets: [{
-        label: 'Work by Platform',
         data: [
           {% for platform in work_by_platform %}
           {{ work_by_platform[platform] | length }},


### PR DESCRIPTION
## Summary
- remove the dataset label from the person page bar chart

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686edd4b9864832492324f8b527f22e9