### PR TITLE
Show only started projects in team cycle list

### DIFF
--- a/app.py
+++ b/app.py
@@ -327,6 +327,10 @@ def team():
     cycle_member_slugs = set()
     member_projects = {}
     for project in cycle_projects_filtered:
+        # Only include projects that have started (start date today or earlier)
+        starts_in = project.get("starts_in")
+        if starts_in is not None and starts_in > 0:
+            continue
         lead = (project.get("lead") or {}).get("displayName")
         participants = []
         if lead:


### PR DESCRIPTION
## Summary
- filter projects in `/team` route by start date

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f0b22e0a88324a2782af387709cb0