### PR TITLE
Show open priority bugs on support section

### DIFF
--- a/app.py
+++ b/app.py
@@ -369,6 +369,20 @@ def team():
         key=lambda d: d["name"],
     )
 
+    # Map open priority bug issues to on-call support members
+    priority_bugs = get_open_issues(2, "Bug")
+    bugs_by_assignee = by_assignee(priority_bugs)
+    support_issues = {}
+    for assignee, data in bugs_by_assignee.items():
+        slug = name_to_slug.get(normalize(assignee)) or name_to_slug.get(
+            normalize(assignee).split()[0]
+        )
+        if slug:
+            support_issues[slug] = [
+                {"title": issue["title"], "url": issue["url"]}
+                for issue in data["issues"]
+            ]
+
     return render_template(
         "team.html",
         platform_teams=platform_teams,
@@ -376,6 +390,7 @@ def team():
         developer_projects=member_projects,
         cycle_projects_by_initiative=projects_by_initiative,
         on_call_support=on_call_support,
+        support_issues=support_issues,
     )
 
 

--- a/templates/team.html
+++ b/templates/team.html
@@ -68,7 +68,13 @@
       <h3>Support</h3>
       <ul>
       {%- for person in on_call_support -%}
-        <li><a href="{{ url_for('team_slug', slug=person.slug) }}">{{ person.name|first_name }}</a></li>
+        <li>
+          <a href="{{ url_for('team_slug', slug=person.slug) }}">{{ person.name|first_name }}</a>
+          {% set issues = support_issues.get(person.slug) %}
+          {% if issues %}&ndash;{% for issue in issues %}
+            <a href="{{ issue.url }}">{{ issue.title }}</a>{% if not loop.last %}, {% endif %}
+          {% endfor %}{% endif %}
+        </li>
       {%- endfor -%}
       </ul>
       <hr />


### PR DESCRIPTION
## Summary
- display issues assigned to support members on the Team page
- gather priority bug issues by assignee in the `team` route

## Testing
- `python -m py_compile app.py linear.py config.py github.py jobs.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f0d6784a08324944774f55a43c13a