### PR TITLE
Move Completed header below metrics

### DIFF
--- a/templates/person.html
+++ b/templates/person.html
@@ -40,7 +40,6 @@
       {% endfor %}
       {% endif %}
       <hr />
-      <h2>Completed</h2>
       <form method="get" style="display:inline-block; margin-bottom: 0.5em;">
         <select name="days" onchange="this.form.submit()">
           <option value="1"  {{ 'selected' if days == 1 else '' }}>1d</option>
@@ -80,6 +79,7 @@
           </article>
         </div>
       </div>
+      <h2>Completed</h2>
         {% for project, issues in completed_by_project.items() %}
         <details>
           <summary>{{ project }}</summary>


### PR DESCRIPTION
## Summary
- move the Completed section header to appear after the metrics cards on the person page

## Testing
- `python -m py_compile app.py github.py jobs.py linear.py`


------
https://chatgpt.com/codex/tasks/task_e_687058ae0e788324aa87381302700e8d