### PR TITLE
Include unassigned issues

### DIFF
--- a/app.py
+++ b/app.py
@@ -200,12 +200,12 @@ def team_slug(slug):
         open_current_cycle = {
             proj: issues
             for proj, issues in open_by_project.items()
-            if proj == "Customer Success"
+            if proj in ["Customer Success", "No Project"]
         }
         open_other = {
             proj: issues
             for proj, issues in open_by_project.items()
-            if proj != "Customer Success"
+            if proj not in ["Customer Success", "No Project"]
         }
     else:
         open_current_cycle = {

--- a/linear.py
+++ b/linear.py
@@ -56,9 +56,12 @@ def get_open_issues(priority, label):
           issues(
             filter: {
               labels: { name: { eq: $label } }
-              project: { name: { eq: "Customer Success" } }
               priority: { lte: $priority }
               state: { name: { nin: ["Done", "Canceled", "Duplicate"] } }
+              or: [
+                { project: { name: { eq: "Customer Success" } } },
+                { project: null }
+              ]
             }
             orderBy: createdAt
           ) {
@@ -118,10 +121,13 @@ def get_completed_issues(priority, label, days=30):
             after: $cursor
             filter: {
               labels: { name: { eq: $label } }
-              project: { name: { eq: "Customer Success" } }
               priority: { lte: $priority }
               state: { name: { in: ["Done"] } }
               completedAt:{gt: $days}
+              or: [
+                { project: { name: { eq: "Customer Success" } } },
+                { project: null }
+              ]
             }
             orderBy: updatedAt
           ) {
@@ -206,9 +212,12 @@ def get_created_issues(priority, label, days=30):
                 after: $cursor
                 filter: {
                     labels: { name: { eq: $label } }
-                    project: { name: { eq: "Customer Success" } }
                     priority: { lte: $priority }
                     createdAt:{gt: $days}
+                    or: [
+                        { project: { name: { eq: "Customer Success" } } },
+                        { project: null }
+                    ]
                 }
                 orderBy: createdAt
             ) {


### PR DESCRIPTION
## Summary
- include unassigned issues when fetching Customer Success queries
- display unassigned issues along with Customer Success items for on-call support

## Testing
- `python -m py_compile app.py linear.py`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_687955c4e520832489a737c59e75d35a