### PR TITLE
Remove Bruno from on-call support

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -49,7 +49,7 @@ people:
     slack_id: U07MLGM93D0
     linear_username: bruno.arndt
     github_username: bfarndt
-    on_call_support: true
+    on_call_support: false
   vitor:
     slack_id: U07KCR739QR
     linear_username: vitor.lelis


### PR DESCRIPTION
## Summary
- update configuration so Bruno is no longer on-call support

## Testing
- `flake8 *.py` *(fails: command not found)*
- `pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687e80a46c988324993da79cb8c8cfde