### PR TITLE
Rename input arg

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -401,9 +401,9 @@ def post_weekly_changelog():
     try:
         changelog_data = get_chat_function_call(
             instructions,
-            input_text,
-            function_spec,
-            "generate_changelog",
+            user_input=input_text,
+            functions=function_spec,
+            function_call_name="generate_changelog",
         )
     except Exception as e:
         logging.error(

--- a/openai_client.py
+++ b/openai_client.py
@@ -10,7 +10,7 @@ client = OpenAI()
 
 
 def get_chat_function_call(
-    instructions, input, functions, function_call_name, model="gpt-4o", temperature=0.2
+    instructions, user_input, functions, function_call_name, model="gpt-4o", temperature=0.2
 ):
     """Call OpenAI chat completion with function calling and return the parsed JSON arguments."""
     # Ensure functions is a list of function specifications
@@ -20,7 +20,7 @@ def get_chat_function_call(
         model=model,
         messages=[
             {"role": "system", "content": instructions},
-            {"role": "user", "content": input},
+            {"role": "user", "content": user_input},
         ],
         functions=functions,
         function_call={"name": function_call_name},


### PR DESCRIPTION
## Summary
- rename `input` argument in `openai_client.get_chat_function_call` to `user_input`
- update function call in `jobs.py`

## Testing
- `pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a827efbe88324bc5a1b7e2b1cd31b