### PR TITLE
Refactor Linear helpers into package

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from config import load_config
 import re
 from datetime import datetime
 
-from linear import (
+from linear.issues import (
     by_assignee,
     by_platform,
     by_project,
@@ -14,8 +14,8 @@ from linear import (
     get_open_issues,
     get_open_issues_for_person,
     get_time_data,
-    get_projects,
 )
+from linear.projects import get_projects
 from github import merged_prs_by_author, merged_prs_by_reviewer
 
 app = Flask(__name__)

--- a/jobs.py
+++ b/jobs.py
@@ -13,12 +13,12 @@ from github import (
     get_prs_waiting_for_review_by_reviewer,
     get_prs_with_changes_requested_by_reviewer,
 )
-from linear import (
+from linear.issues import (
     get_completed_issues,
     get_open_issues,
-    get_projects,
     get_stale_issues_by_assignee,
 )
+from linear.projects import get_projects
 from openai_client import get_chat_function_call
 
 load_dotenv()

--- a/linear/client.py
+++ b/linear/client.py
@@ -1,0 +1,46 @@
+import os
+from datetime import datetime
+from functools import lru_cache
+
+from dotenv import load_dotenv
+from gql import Client
+from gql.transport.aiohttp import AIOHTTPTransport
+
+load_dotenv()
+
+
+def _compute_assignee_time_to_fix(issue, assignee_name):
+    """Return days between last assignment to `assignee_name` and completion."""
+    history = issue.get("history", {}).get("edges", [])
+    last_assigned = None
+    for edge in history:
+        node = edge.get("node", {})
+        to_assignee = node.get("toAssignee")
+        if not to_assignee:
+            continue
+        if to_assignee.get("displayName") == assignee_name:
+            updated = node.get("updatedAt")
+            if updated and (last_assigned is None or updated > last_assigned):
+                last_assigned = updated
+    if not last_assigned:
+        return None
+    completed_at = issue.get("completedAt")
+    if not completed_at:
+        return None
+    try:
+        completed_dt = datetime.strptime(completed_at, "%Y-%m-%dT%H:%M:%S.%fZ")
+        assigned_dt = datetime.strptime(last_assigned, "%Y-%m-%dT%H:%M:%S.%fZ")
+        return (completed_dt - assigned_dt).days
+    except ValueError:
+        return None
+
+
+@lru_cache(maxsize=1)
+def _get_client():
+    headers = {"Authorization": os.getenv("LINEAR_API_KEY")}
+    transport = AIOHTTPTransport(
+        url="https://api.linear.app/graphql",
+        headers=headers,
+    )
+    return Client(transport=transport, fetch_schema_from_transport=True)
+

--- a/linear/projects.py
+++ b/linear/projects.py
@@ -1,0 +1,55 @@
+from gql import gql
+
+from .client import _get_client
+
+
+def get_projects():
+    """Return all Linear projects under the Apollos team, ordered by name."""
+    query = gql(
+        """
+        query {
+          teams(filter: { name: { eq: \"Apollos\" } }, first: 1) {
+            nodes {
+              projects(first: 50) {
+                nodes {
+                  id
+                  name
+                  url
+                  health
+                  status {
+                    name
+                  }
+                  startDate
+                  targetDate
+                  lead {
+                    displayName
+                  }
+                  initiatives(first: 50) {
+                    nodes {
+                      id
+                      name
+                    }
+                  }
+                  members(first: 50) {
+                    nodes {
+                      displayName
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+    )
+    data = _get_client().execute(query)
+    teams = data.get("teams", {}).get("nodes", []) or []
+    if not teams:
+        return []
+    projects = teams[0].get("projects", {}).get("nodes", []) or []
+    sorted_projects = sorted(projects, key=lambda project: project.get("name", ""))
+    for project in sorted_projects:
+        nodes = project.get("members", {}).get("nodes", [])
+        project["members"] = [m["displayName"] for m in nodes if m.get("displayName")]
+    return sorted_projects
+


### PR DESCRIPTION
## Summary
- split Linear API logic into `linear` package
- move client and helpers to `linear/client.py`
- put issue queries and helpers in `linear/issues.py`
- isolate project queries in `linear/projects.py`
- update application code to import from new modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a82984ab88324a4b62c6208a2b307