### PR TITLE
Centralize dotenv loading

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,6 @@
+from dotenv import load_dotenv
+load_dotenv()
+
 from flask import Flask, render_template, request, abort
 
 from config import load_config

--- a/github.py
+++ b/github.py
@@ -2,12 +2,8 @@ import os
 from datetime import datetime, timedelta
 from functools import lru_cache
 
-from dotenv import load_dotenv
 from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
-
-load_dotenv()
-
 
 token = os.getenv("GITHUB_TOKEN")
 headers = {"Authorization": f"bearer {token}"}

--- a/jobs.py
+++ b/jobs.py
@@ -7,6 +7,8 @@ import requests
 import schedule
 from dotenv import load_dotenv
 
+load_dotenv()
+
 from config import load_config
 from constants import PRIORITY_TO_SCORE
 from github import (
@@ -20,8 +22,6 @@ from linear.issues import (
 )
 from linear.projects import get_projects
 from openai_client import get_chat_function_call
-
-load_dotenv()
 
 
 def format_bug_line(bug):

--- a/linear/client.py
+++ b/linear/client.py
@@ -2,11 +2,9 @@ import os
 from datetime import datetime
 from functools import lru_cache
 
-from dotenv import load_dotenv
 from gql import Client
 from gql.transport.aiohttp import AIOHTTPTransport
 
-load_dotenv()
 
 
 def _compute_assignee_time_to_fix(issue, assignee_name):

--- a/openai_client.py
+++ b/openai_client.py
@@ -1,9 +1,5 @@
 import json
-
-from dotenv import load_dotenv
 from openai import OpenAI
-
-load_dotenv()
 
 # Initialize OpenAI client for chat-based function calling
 client = OpenAI()


### PR DESCRIPTION
## Summary
- centralize `load_dotenv` at application start
- drop duplicate dotenv calls in helper modules

## Testing
- `python -m py_compile app.py github.py jobs.py openai_client.py linear/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688a86cd20c08324977181d67bd800ce