### PR TITLE
Add caching for API calls

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -1,0 +1,32 @@
+import time
+from functools import wraps
+from typing import Any, Callable, Tuple
+
+
+def ttl_cache(ttl_seconds: int) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Simple per-key TTL cache decorator."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        cache: dict[Tuple[Tuple[Any, ...], Tuple[Tuple[str, Any], ...]], Tuple[float, Any]] = {}
+
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            key = (args, tuple(sorted(kwargs.items())))
+            now = time.monotonic()
+            if key in cache:
+                expires, value = cache[key]
+                if now < expires:
+                    return value
+                if hasattr(func, "cache_clear"):
+                    func.cache_clear()  # type: ignore[attr-defined]
+            result = func(*args, **kwargs)
+            cache[key] = (now + ttl_seconds, result)
+            return result
+
+        def cache_clear() -> None:
+            cache.clear()
+
+        wrapper.cache_clear = cache_clear  # type: ignore[attr-defined]
+        return wrapper
+
+    return decorator

--- a/github.py
+++ b/github.py
@@ -2,6 +2,8 @@ import os
 from datetime import datetime, timedelta
 from functools import lru_cache
 
+from cache import ttl_cache
+
 from dotenv import load_dotenv
 from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
@@ -148,6 +150,7 @@ def prs_by_approver():
     return prs_by_approver
 
 
+@ttl_cache(300)
 @lru_cache(maxsize=4)
 def _get_merged_prs(days: int = 30):
     """Return merged PRs across all repos within the last ``days`` days."""

--- a/linear/issues.py
+++ b/linear/issues.py
@@ -2,11 +2,14 @@ from datetime import datetime
 
 from gql import gql
 
+from cache import ttl_cache
+
 from config import get_platforms
 from constants import PRIORITY_TO_SCORE
 from .client import _get_client, _compute_assignee_time_to_fix
 
 
+@ttl_cache(300)
 def get_open_issues(priority, label):
 
     params = {"priority": priority, "label": label}
@@ -62,6 +65,7 @@ def get_open_issues(priority, label):
     return issues
 
 
+@ttl_cache(300)
 def get_completed_issues(priority, label, days=30):
 
     query = gql(
@@ -157,6 +161,7 @@ def get_completed_issues(priority, label, days=30):
     return issues
 
 
+@ttl_cache(300)
 def get_created_issues(priority, label, days=30):
 
     query = gql(
@@ -343,6 +348,7 @@ def get_time_data(issues):
     return data
 
 
+@ttl_cache(300)
 def get_open_issues_for_person(login: str):
     """Return open issues assigned to a given Linear username across all projects."""
 
@@ -409,6 +415,7 @@ def get_open_issues_for_person(login: str):
     return issues
 
 
+@ttl_cache(300)
 def get_completed_issues_for_person(login: str, days=30):
     """Return completed issues for a user over the last `days` days, filtered by Linear username."""
 

--- a/linear/projects.py
+++ b/linear/projects.py
@@ -1,8 +1,10 @@
 from gql import gql
 
+from cache import ttl_cache
 from .client import _get_client
 
 
+@ttl_cache(300)
 def get_projects():
     """Return all Linear projects under the Apollos team, ordered by name."""
     query = gql(


### PR DESCRIPTION
## Summary
- add a simple TTL cache decorator
- cache expensive Linear issue queries
- cache Linear project retrieval
- cache GitHub merged PR queries

## Testing
- `flake8 *.py linear/*.py` *(fails: command not found)*
- `pip install -r requirements.dev.txt` *(fails: no matching distribution found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b629ec9b08324add6e5a24432dd4d