### PR TITLE
Adjust urgent bug scoring and deadlines

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -8,4 +8,5 @@
 # 3 = Medium
 # 4 = Low
 # 5 = Very Low
-PRIORITY_TO_SCORE = {1: 10, 2: 10, 3: 5, 4: 1, 5: 1}
+# Urgent bugs (priority 1) are worth double
+PRIORITY_TO_SCORE = {1: 20, 2: 10, 3: 5, 4: 1, 5: 1}

--- a/jobs.py
+++ b/jobs.py
@@ -75,7 +75,7 @@ def post_priority_bugs():
     at_risk = [
         bug
         for bug in urgent_bugs
-        if bug["daysOpen"] > 0 and bug["daysOpen"] <= 1
+        if bug["daysOpen"] >= 0 and bug["daysOpen"] <= 1
     ] + [
         bug
         for bug in high_bugs

--- a/templates/index.html
+++ b/templates/index.html
@@ -106,7 +106,7 @@
         Scores
         <small
           id="score-tooltip"
-          data-tooltip="10pts for high, 5pts for medium, 1pt for low"
+          data-tooltip="20pts for urgent, 10pts for high, 5pts for medium, 1pt for low"
           style="font-size: 0.8em; opacity: 0.6;"
           >ⓘ</small>
       </h4>


### PR DESCRIPTION
## Summary
- double the score for urgent bugs
- make urgent bugs due in one day
- update at-risk/overdue thresholds for urgent bugs
- clarify scoring in leaderboard tooltip

## Testing
- `flake8 *.py jobs.py linear`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_688be3e31788832486205b7c90555d8c