### PR TITLE
Mark incomplete projects as completed on teams page

### DIFF
--- a/app.py
+++ b/app.py
@@ -321,12 +321,12 @@ def team():
             if name == current_init
         }
 
-    # Separate completed projects from the cycle initiatives
+    # Separate completed or incomplete projects from the cycle initiatives
     completed_projects = []
     for name, projects in list(projects_by_initiative.items()):
         remaining = []
         for project in projects:
-            if project.get("status", {}).get("name") == "Completed":
+            if project.get("status", {}).get("name") in {"Completed", "Incomplete"}:
                 completed_projects.append(project)
             else:
                 remaining.append(project)

--- a/templates/team.html
+++ b/templates/team.html
@@ -46,7 +46,7 @@
       <ul>
       {% for initiative, projects in cycle_projects_by_initiative.items() %}
         {% for project in projects %}
-          {% set is_completed = project.status and project.status.name == 'Completed' %}
+          {% set is_completed = project.status and project.status.name in ['Completed', 'Incomplete'] %}
           <li>
             {% if project.health and not is_completed %}
               {% if project.health == 'onTrack' %}


### PR DESCRIPTION
## Summary
- Treat Linear projects with status `Incomplete` the same as `Completed`
- Strike through incomplete projects on the Engineering Teams page

## Testing
- `flake8 *.py`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_6890e597a0c0832489bcb4116e247b99