### PR TITLE
Add BetterStack logs link to footer

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -40,6 +40,9 @@
         <li>
           <a href="https://differential-ka.sentry.io/issues">Sentry Issues</a>
         </li>
+        <li>
+          <a href="https://telemetry.betterstack.com/team/278287/tail?s=1201580">BetterStack Logs</a>
+        </li>
       </ul>
     </footer>
     {% block extra_scripts %}{% endblock %}


### PR DESCRIPTION
## Summary
- link BetterStack Logs in the footer for quick access

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689674d12ba083248645763df83465e5