### PR TITLE
Fix flake8 line length issue in jobs.py

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -339,7 +339,11 @@ def post_friday_deadlines():
         projects = [
             p
             for p in projects
-            if cycle_init in {node.get("name") for node in p.get("initiatives", {}).get("nodes", [])}
+            if cycle_init
+            in {
+                node.get("name")
+                for node in p.get("initiatives", {}).get("nodes", [])
+            }
         ]
 
     upcoming = []


### PR DESCRIPTION
## Summary
- fix long line in `post_friday_deadlines`

## Testing
- `flake8 *.py`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_6899e27064808324a7f7f860c9e33a08