### PR TITLE
Exclude unprioritized issues from priority bug stats

### DIFF
--- a/linear/issues.py
+++ b/linear/issues.py
@@ -46,7 +46,9 @@ def get_open_issues(priority, label):
     )
 
     data = _get_client().execute(query, variable_values=params)
-    issues = data["issues"]["nodes"]
+    issues = [
+        issue for issue in data["issues"]["nodes"] if issue.get("priority") is not None
+    ]
     for issue in issues:
         platforms = [
             tag["name"]
@@ -151,6 +153,8 @@ def get_completed_issues(priority, label, days=30):
             break
         cursor = data["issues"]["pageInfo"]["endCursor"]
 
+    issues = [issue for issue in issues if issue.get("priority") is not None]
+
     for issue in issues:
         proj = issue.get("project", {}).get("name") if issue.get("project") else None
         issue["project"] = proj
@@ -212,6 +216,7 @@ def get_created_issues(priority, label, days=30):
         if not data["issues"]["pageInfo"]["hasNextPage"]:
             break
         cursor = data["issues"]["pageInfo"]["endCursor"]
+    issues = [issue for issue in issues if issue.get("priority") is not None]
     for issue in issues:
         platforms = [
             tag["name"]


### PR DESCRIPTION
## Summary
- ignore Linear issues lacking a priority in open, completed, and created issue queries

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4ebac09d08324aa709bdcd76e3094