### PR TITLE
Add Zach to people config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -106,6 +106,11 @@ people:
     linear_username: rumesh.lahiru
     github_username:
     available_for_support: true
+  zach:
+    slack_id: U0BLNNPAB
+    linear_username: zach
+    github_username: solideo-gloria
+    available_for_support: true
 
 
 platforms:


### PR DESCRIPTION
## Summary
- add Linear username for Zach
- mark Zach available for support

## Testing
- `flake8 *.py && echo 'flake8 passed'`
- `mypy . >/tmp/mypy.log && tail -n 20 /tmp/mypy.log`


------
https://chatgpt.com/codex/tasks/task_e_68bc5bb5938c83249afed1b518ee7625