### PR TITLE
Add Darrell to cluster developers

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -166,6 +166,7 @@ platforms:
       - jimmy
       - aleks
       - cameron
+      - darryl
       - vitor
       - dennis
   rock-plugin:


### PR DESCRIPTION
## Summary
- add Darrell to the cluster developers roster in the configuration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d41dc841c08324ada1db6325b8db62