### PR TITLE
Remove Dennis from select platform teams

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -132,7 +132,6 @@ platforms:
       - jimmy
       - aleks
       - vitor
-      - dennis
       - john
       - rumesh
   tv:
@@ -141,12 +140,10 @@ platforms:
       - jimmy
       - aleks
       - vitor
-      - dennis
       - john
   roku:
     lead: andy
     developers:
-      - dennis
       - jimmy
   web:
     lead: nathan
@@ -179,7 +176,6 @@ platforms:
       - rajuran
       - jimmy
       - cameron
-      - dennis
   transcriptions:
     lead: vincent
     developers:


### PR DESCRIPTION
## Summary
- update the mobile, TV, Roku, and shovel platform rosters to remove Dennis from their developer lists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e554ae12bc8324b4b5a71ea4501767