### PR TITLE
Add platform whitelists for unassigned bug notifications

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,6 +14,8 @@ people:
     slack_id: U080E70RQ4U
     linear_username: andy.smith
     github_username: AndySmith1965
+    platform_whitelist:
+      - roku
   nathan:
     team: engineering
     slack_id: U022N4RTD40

--- a/jobs.py
+++ b/jobs.py
@@ -218,6 +218,33 @@ def get_slack_markdown_by_github_username(username):
     return username
 
 
+def _normalize_platform_name(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower().replace(" ", "-")
+    return normalized or None
+
+
+def _person_matches_any_unassigned_platform(person: dict, bugs: list[dict]) -> bool:
+    platform_whitelist = person.get("platform_whitelist")
+    if platform_whitelist is None:
+        return True
+
+    allowed_platforms = {
+        normalized
+        for normalized in (
+            _normalize_platform_name(platform) for platform in platform_whitelist
+        )
+        if normalized
+    }
+    if not allowed_platforms:
+        return False
+
+    return any(
+        _normalize_platform_name(bug.get("platform")) in allowed_platforms for bug in bugs
+    )
+
+
 def _get_pr_diffs(issue):
     """Return a list of diffs for PRs linked in the issue attachments."""
 
@@ -337,6 +364,8 @@ def post_priority_bugs():
             if not person:
                 continue
             if person.get("linear_username") in assigned:
+                continue
+            if not _person_matches_any_unassigned_platform(person, unassigned):
                 continue
             slack_id = person.get("slack_id")
             if not slack_id:

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -453,6 +453,70 @@ class PostPriorityBugsTest(unittest.TestCase):
         self.assertNotIn("<@U1>", posted[0])
         self.assertNotIn("Lead)", posted[0])
 
+    def test_unassigned_priority_bug_only_notifies_matching_platform_whitelists(self):
+        posted = []
+        bugs = [
+            {
+                "id": "unassigned-bug",
+                "title": "Unassigned mobile bug",
+                "assignee": None,
+                "url": "https://linear.app/issue/unassigned-bug",
+                "platform": "Mobile",
+                "daysOpen": 14,
+                "priority": 2,
+                "slaMediumRiskAt": "2026-03-14T08:00:00.000Z",
+                "slaHighRiskAt": "2026-03-16T10:00:00.000Z",
+                "slaBreachesAt": "2026-03-17T12:00:00.000Z",
+            },
+            {
+                "id": "assigned-bug",
+                "title": "Assigned bug",
+                "assignee": {"displayName": "Alex"},
+                "url": "https://linear.app/issue/assigned-bug",
+                "platform": "Web",
+                "daysOpen": 3,
+                "priority": 2,
+                "slaMediumRiskAt": "2026-03-14T08:00:00.000Z",
+                "slaHighRiskAt": "2026-03-16T10:00:00.000Z",
+                "slaBreachesAt": "2026-03-17T12:00:00.000Z",
+            },
+        ]
+        config = {
+            "people": {
+                "alex": {"linear_username": "Alex", "slack_id": "U1"},
+                "blair": {
+                    "linear_username": "Blair",
+                    "slack_id": "U2",
+                    "platform_whitelist": ["mobile"],
+                },
+                "casey": {
+                    "linear_username": "Casey",
+                    "slack_id": "U3",
+                    "platform_whitelist": ["web"],
+                },
+                "devon": {"linear_username": "Devon", "slack_id": "U4"},
+            },
+            "platforms": {},
+        }
+
+        with patch.object(jobs_module, "load_config", return_value=config):
+            with patch.object(jobs_module, "get_open_issues", return_value=bugs):
+                with patch.object(
+                    jobs_module,
+                    "get_support_slugs",
+                    return_value={"alex", "blair", "casey", "devon"},
+                ):
+                    with patch.object(
+                        jobs_module, "post_to_slack", side_effect=posted.append
+                    ):
+                        with patch.object(jobs_module, "datetime", FixedDateTime):
+                            jobs_module.post_priority_bugs()
+
+        self.assertEqual(len(posted), 1)
+        self.assertIn("attn:\n\n<@U2>\n<@U4>", posted[0])
+        self.assertNotIn("<@U1>", posted[0])
+        self.assertNotIn("<@U3>", posted[0])
+
 
 class PostOverdueProjectsTest(unittest.TestCase):
     def test_posts_only_engineering_led_active_projects_with_past_target_dates(self):


### PR DESCRIPTION
## Summary
- add optional per-person `platform_whitelist` filtering to unassigned priority bug Slack mentions
- keep the existing broad notification behavior for support engineers without a whitelist
- configure Andy to only receive unassigned bug pages for `roku` and cover the new behavior with tests

## Why
- some support engineers should only be tagged for unassigned bugs that match the platforms they cover
- the current notifier pages every support engineer for every unassigned bug, which creates irrelevant Slack noise

## Proof
Validated locally with `python3.11 -m unittest tests.test_jobs` because the workspace `venv` is pinned to Python 3.9.6 and cannot import the repo's existing PEP 604 (`|`) type syntax. This change only affects the background Slack job path; no end-to-end Slack artifact was captured locally.