### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Bug Board is a Flask app that aggregates Linear issues, GitHub PR stats, and Airflow fleet health into an internal engineering dashboard. It also has a worker process (`jobs.py`) that posts scheduled summaries to Slack. There is no database; all data is fetched live from external APIs.
+
+### Running the application
+
+```bash
+source venv/bin/activate
+gunicorn app:app --bind 127.0.0.1:8000 --workers 1
+```
+
+The app starts and serves pages without any API keys configured. Routes like `/`, `/team`, `/healthz`, and `/failing-dags` all return 200 even without `LINEAR_API_KEY` or `GITHUB_TOKEN` — the HTMX partials that fetch live data will fail gracefully. The `/healthz` endpoint always returns `{"status": "ok"}`.
+
+### Lint, type check, and test commands
+
+All standard — see `README.md`. Quick reference:
+
+- **Lint:** `flake8 *.py`
+- **Type check:** `mypy .`
+- **Unit tests:** `python -m unittest discover -s tests -p 'test_*.py'`
+
+CI (`.github/workflows/ci.yml`) uses Python 3.12. The `.python-version` file says 3.13 but 3.12 works and is what CI uses.
+
+### Environment variables
+
+The app runs without any env vars for basic page rendering. External-API-dependent features (leaderboard data, team member views, Airflow fleet health) require `LINEAR_API_KEY`, `GITHUB_TOKEN`, `AIRFLOW_API_BASE_URL`, and `AIRFLOW_API_TOKEN`. The worker process (`python jobs.py`) requires `SLACK_WEBHOOK_URL` and `APP_URL`. See `README.md` for the full list.
+
+### Gotchas
+
+- The venv must be activated before running any commands (`source venv/bin/activate`).
+- `python3.12-venv` system package is required to create the venv (installed via `sudo apt-get install -y python3.12-venv`).
+- mypy produces advisory notes about untyped function bodies — these are informational, not errors.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents working in this repository.

### What's included

- Overview of the Bug Board application (Flask web dashboard + worker process)
- How to run the application locally (`gunicorn app:app`)
- Quick reference for lint (`flake8`), type check (`mypy`), and test commands
- Environment variable requirements and which are optional vs required
- Development gotchas (venv activation, `python3.12-venv` system dependency, mypy advisory notes)

### Environment verification

All checks pass:

- **Lint:** `flake8 *.py` — clean
- **Type check:** `mypy .` — success (advisory notes only)
- **Unit tests:** 51 tests pass
- **App startup:** gunicorn serves all routes with 200 status

[Bug Board homepage](https://cursor.com/agents/bc-6336e050-d340-49da-8d83-98e7b4896dd4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbug_board_homepage.webp)
[Healthz endpoint returning ok](https://cursor.com/agents/bc-6336e050-d340-49da-8d83-98e7b4896dd4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhealthz_endpoint.webp)
[Failing DAGs dashboard](https://cursor.com/agents/bc-6336e050-d340-49da-8d83-98e7b4896dd4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffailing_dags_dashboard.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6336e050-d340-49da-8d83-98e7b4896dd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6336e050-d340-49da-8d83-98e7b4896dd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

