### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -214,7 +214,10 @@ def _get_airflow_fleet_health_payload(
         return evaluate_fleet_health()
     except AirflowFleetHealthError as exc:
         payload = _add_missing_airflow_config_details(
-            {"status": "unknown", "error_message": str(exc)}
+            {
+                "status": "unknown",
+                "error_message": "Unable to evaluate airflow fleet health",
+            }
         )
         if payload.get("error_type") == "missing_airflow_credentials":
             logging.warning(

--- a/app.py
+++ b/app.py
@@ -212,7 +212,7 @@ def _get_airflow_fleet_health_payload(
 
     try:
         return evaluate_fleet_health()
-    except AirflowFleetHealthError as exc:
+    except AirflowFleetHealthError:
         payload = _add_missing_airflow_config_details(
             {
                 "status": "unknown",


### PR DESCRIPTION
Potential fix for [https://github.com/ApollosProject/bug-board/security/code-scanning/6](https://github.com/ApollosProject/bug-board/security/code-scanning/6)

General fix: do not include raw exception text (`str(exc)`, stack traces, or internal error objects) in API responses. Log details server-side, return a stable generic error message to clients.

Best fix in `app.py` (inside `_get_airflow_fleet_health_payload`, lines ~215–218): replace `"error_message": str(exc)` with a generic message such as `"error_message": "Unable to evaluate airflow fleet health"`, while retaining current logging behavior (`logging.exception(...)`) so operators still get diagnostics without exposing internals. No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
