### PR TITLE
[codex] add vulture static analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,22 @@ jobs:
       run: |
         ruff format --check .
 
+  vulture:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
     - name: Check for unused code with vulture
       run: |
         vulture . --config pyproject.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
       run: |
         ruff format --check .
 
+    - name: Check for unused code with vulture
+      run: |
+        vulture . --config pyproject.toml
+
   mypy:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A small Flask application that displays Linear issues and GitHub pull request st
 ```bash
 python -m venv venv
 source venv/bin/activate
-pip install -r requirements.txt  # includes ruff for linting, import sorting, and formatting
+pip install -r requirements.txt  # includes ruff and vulture for static analysis
 ```
 
 To lint, format, and type check your code before committing:
@@ -20,6 +20,7 @@ To lint, format, and type check your code before committing:
 ruff check .
 ruff check . --fix
 ruff format .
+vulture . --config pyproject.toml
 mypy .
 ```
 

--- a/app.py
+++ b/app.py
@@ -160,8 +160,6 @@ def _apply_proxy_fix(flask_app: Flask) -> None:
 
 _apply_proxy_fix(app)
 
-# Maximum number of distinct _build_index_context results to cache.
-# This can be increased or made configurable based on production usage patterns.
 INDEX_CONTEXT_CACHE_MAXSIZE = 16
 DEFAULT_ASTRO_UI_BASE_URL = "https://cloud.astronomer.io/cljsvo8d800yz01giqt70a7e7"
 AIRFLOW_REQUIRED_ENV_VARS = ("AIRFLOW_API_BASE_URL", "AIRFLOW_API_TOKEN")
@@ -186,9 +184,6 @@ def _add_missing_airflow_config_details(payload: dict[str, Any]) -> dict[str, An
         }
     )
     return updated_payload
-
-
-PERSON_PRIORITY_SUPPORT_TEAM_KEYS = {"SUP", "CUS"}
 
 
 def _get_airflow_fleet_health_payload(
@@ -481,22 +476,6 @@ def mmdd_filter(date_str: str) -> str:
 ResultType = TypeVar("ResultType")
 
 
-class IndexFutures(TypedDict):
-    """Named collection of futures used for building the index view."""
-
-    created_priority: Future[list]
-    open_priority: Future[list]
-    completed_priority: Future[list]
-    completed_bugs: Future[list]
-    completed_new_features: Future[list]
-    completed_technical_changes: Future[list]
-    open_bugs: Future[list]
-    open_new_features: Future[list]
-    open_technical_changes: Future[list]
-    merged_prs_by_reviewer: Future[dict]
-    merged_prs_by_author: Future[dict]
-
-
 def get_future_result_with_timeout(
     future: Future[ResultType], default_value: ResultType, timeout: int = INDEX_FUTURE_TIMEOUT
 ) -> ResultType:
@@ -515,153 +494,6 @@ def get_future_result_with_timeout(
         return future.result(timeout=timeout)
     except TimeoutError:
         return default_value
-
-
-def _submit_index_futures(
-    executor: ThreadPoolExecutor,
-    days: int,
-) -> IndexFutures:
-    """
-    Submit all futures required to build the index context.
-
-    This helper isolates the responsibility of scheduling concurrent work
-    away from `_build_index_context`, improving readability and testability.
-    """
-    created_priority_future = executor.submit(get_created_issues, 2, "Bug", days)
-    open_priority_future = executor.submit(get_open_issues, 2, "Bug")
-    completed_priority_future = executor.submit(get_completed_issues_summary, 2, "Bug", days)
-    completed_bugs_future = executor.submit(get_completed_issues_summary, 5, "Bug", days)
-    completed_new_features_future = executor.submit(
-        get_completed_issues_summary, 5, "New Feature", days
-    )
-    completed_technical_changes_future = executor.submit(
-        get_completed_issues_summary, 5, "Technical Change", days
-    )
-    open_bugs_future = executor.submit(get_open_issues, 5, "Bug")
-    open_new_features_future = executor.submit(get_open_issues, 5, "New Feature")
-    open_technical_changes_future = executor.submit(get_open_issues, 5, "Technical Change")
-    reviews_future = executor.submit(merged_prs_by_reviewer, days)
-    authored_prs_future = executor.submit(merged_prs_by_author, days)
-
-    return {
-        "created_priority": created_priority_future,
-        "open_priority": open_priority_future,
-        "completed_priority": completed_priority_future,
-        "completed_bugs": completed_bugs_future,
-        "completed_new_features": completed_new_features_future,
-        "completed_technical_changes": completed_technical_changes_future,
-        "open_bugs": open_bugs_future,
-        "open_new_features": open_new_features_future,
-        "open_technical_changes": open_technical_changes_future,
-        "merged_prs_by_reviewer": reviews_future,
-        "merged_prs_by_author": authored_prs_future,
-    }
-
-
-def _get_priority_bugs_from_futures(
-    created_priority_future: Future[list],
-    open_priority_future: Future[list],
-    completed_priority_future: Future[list],
-) -> tuple[list, list, list]:
-    """
-    Retrieve priority bug data from futures and filter completed issues.
-
-    Only non-project issues are included in the completed list.
-    """
-    created_priority_bugs = get_future_result_with_timeout(created_priority_future, [])
-    open_priority_bugs = get_future_result_with_timeout(open_priority_future, [])
-
-    # Only include non-project issues in the index summary
-    completed_priority_result = get_future_result_with_timeout(completed_priority_future, [])
-    completed_priority_bugs = [
-        issue for issue in completed_priority_result if not issue.get("project")
-    ]
-
-    return created_priority_bugs, open_priority_bugs, completed_priority_bugs
-
-
-@lru_cache(maxsize=INDEX_CONTEXT_CACHE_MAXSIZE)
-def _build_index_context(days: int, _cache_epoch: int) -> dict:
-    with ThreadPoolExecutor(max_workers=INDEX_THREADPOOL_MAX_WORKERS) as executor:
-        futures = _submit_index_futures(executor, days)
-
-    (
-        created_priority_bugs,
-        open_priority_bugs,
-        completed_priority_bugs,
-    ) = _get_priority_bugs_from_futures(
-        futures["created_priority"],
-        futures["open_priority"],
-        futures["completed_priority"],
-    )
-    completed_bugs_result = get_future_result_with_timeout(futures["completed_bugs"], [])
-    completed_bugs = [issue for issue in completed_bugs_result if not issue.get("project")]
-    completed_new_features_result = get_future_result_with_timeout(
-        futures["completed_new_features"], []
-    )
-    completed_new_features = [
-        issue for issue in completed_new_features_result if not issue.get("project")
-    ]
-    completed_technical_changes_result = get_future_result_with_timeout(
-        futures["completed_technical_changes"], []
-    )
-    completed_technical_changes = [
-        issue for issue in completed_technical_changes_result if not issue.get("project")
-    ]
-    open_bugs_result = get_future_result_with_timeout(futures["open_bugs"], [])
-    open_new_features_result = get_future_result_with_timeout(futures["open_new_features"], [])
-    open_technical_changes_result = get_future_result_with_timeout(
-        futures["open_technical_changes"], []
-    )
-    open_work = open_bugs_result + open_new_features_result + open_technical_changes_result
-    time_data = get_time_data(completed_priority_bugs)
-    fixes_per_day = (
-        len(completed_bugs + completed_new_features + completed_technical_changes) / days
-    )
-
-    merged_reviews = get_future_result_with_timeout(futures["merged_prs_by_reviewer"], {})
-    merged_authored_prs = get_future_result_with_timeout(futures["merged_prs_by_author"], {})
-    leaderboard_entries = _build_leaderboard_entries(
-        days=days,
-        completed_bugs=completed_bugs,
-        completed_new_features=completed_new_features,
-        completed_technical_changes=completed_technical_changes,
-        merged_reviews=merged_reviews,
-        merged_authored_prs=merged_authored_prs,
-    )
-
-    total_completed_issues = len(
-        completed_bugs + completed_new_features + completed_technical_changes
-    )
-
-    if total_completed_issues:
-        priority_percentage = int(
-            round(len(completed_priority_bugs) / total_completed_issues * 100)
-        )
-    else:
-        priority_percentage = 0
-
-    return {
-        "days": days,
-        "priority_issues": sorted(open_priority_bugs, key=lambda x: x["createdAt"]),
-        "issue_count": len(created_priority_bugs),
-        "priority_percentage": priority_percentage,
-        "leaderboard_entries": leaderboard_entries,
-        "all_issues": created_priority_bugs + open_priority_bugs,
-        "issues_by_platform": by_platform(created_priority_bugs),
-        "lead_time_data": time_data["lead"],
-        "queue_time_data": time_data["queue"],
-        "open_assigned_work": sorted(
-            [
-                issue
-                for issue in open_work
-                if issue["assignee"] is not None and issue["priority"] > 2
-            ],
-            key=lambda x: x["createdAt"],
-            reverse=True,
-        ),
-        "fixes_per_day": fixes_per_day,
-    }
 
 
 def _build_leaderboard_entries(

--- a/jobs.py
+++ b/jobs.py
@@ -63,17 +63,6 @@ def _read_positive_int_env(name: str, default: int) -> int:
     return parsed if parsed > 0 else default
 
 
-def _parse_linear_dt(value: str | None) -> datetime | None:
-    if not value:
-        return None
-    for fmt in ("%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%SZ"):
-        try:
-            return datetime.strptime(value, fmt).replace(tzinfo=timezone.utc)
-        except ValueError:
-            continue
-    return None
-
-
 def _is_inactive_project(project: dict) -> bool:
     status_name = ((project.get("status") or {}).get("name") or "").strip().lower()
     return bool(project.get("completedAt")) or status_name in INACTIVE_PROJECT_STATUS_NAMES

--- a/linear/issues.py
+++ b/linear/issues.py
@@ -334,27 +334,6 @@ def by_assignee(issues):
     )
 
 
-def by_reviewer(issues):
-    issues_by_approver = {}
-    for issue in issues:
-        for attachment in issue["attachments"]["nodes"]:
-            metadata = attachment["metadata"]
-            if metadata.get("reviews"):
-                for review in metadata["reviews"]:
-                    if review["state"] == "approved":
-                        author = review["reviewerLogin"]
-                        if author not in issues_by_approver:
-                            issues_by_approver[author] = []
-                        issues_by_approver[author].append(issue)
-    return dict(
-        sorted(
-            issues_by_approver.items(),
-            key=lambda x: len(x[1]),
-            reverse=True,
-        )
-    )
-
-
 def get_stale_issues_by_assignee(issues, days=30):
     """Return issues not updated in `days` days, grouped by assignee."""
     stale_issues = {}
@@ -510,89 +489,6 @@ def get_open_issues_for_person(login: str):
         issue["daysUpdated"] = (
             datetime.utcnow() - datetime.strptime(issue["updatedAt"], "%Y-%m-%dT%H:%M:%S.%fZ")
         ).days
-    return issues
-
-
-def get_open_issues_in_projects(project_names):
-    """Return open issues across the team limited to specified Linear project names.
-
-    project_names: iterable of project name strings to include.
-    """
-
-    # Ensure we work with a list for GraphQL variables
-    project_names = list(project_names)
-    team_key = get_linear_team_key()
-
-    query = gql(
-        """
-        query OpenIssuesInProjects(
-          $projectNames: [String!],
-          $team_key: String!,
-          $cursor: String
-        ) {
-          issues(
-            first: 50
-            after: $cursor
-            filter: {
-              team: { key: { eq: $team_key } }
-              state: { type: { nin: [\"completed\", \"canceled\"] } }
-              project: { name: { in: $projectNames } }
-            }
-            orderBy: updatedAt
-          ) {
-            nodes {
-              id
-              identifier
-              title
-              url
-              updatedAt
-              createdAt
-              dueDate
-              slaType
-              slaStartedAt
-              slaMediumRiskAt
-              slaHighRiskAt
-              slaBreachesAt
-              state { name type }
-              assignee { displayName }
-              project { name }
-              parent { id }
-              children(first: 50) {
-                nodes {
-                  id
-                  identifier
-                  title
-                  url
-                  state { name type }
-                  assignee { displayName }
-                  dueDate
-                  slaType
-                  slaStartedAt
-                  slaMediumRiskAt
-                  slaHighRiskAt
-                  slaBreachesAt
-                }
-              }
-            }
-            pageInfo { hasNextPage endCursor }
-          }
-        }
-        """,
-    )
-
-    cursor = None
-    issues = []
-    while True:
-        params = {
-            "projectNames": project_names,
-            "team_key": team_key,
-            "cursor": cursor,
-        }
-        data = _execute(query, variable_values=params)
-        issues += data["issues"]["nodes"]
-        if not data["issues"]["pageInfo"]["hasNextPage"]:
-            break
-        cursor = data["issues"]["pageInfo"]["endCursor"]
     return issues
 
 

--- a/linear/projects.py
+++ b/linear/projects.py
@@ -75,20 +75,3 @@ def get_projects():
             break
     sorted_projects = sorted(projects, key=lambda project: project.get("name", ""))
     return _normalize_project_members(sorted_projects)
-
-
-def update_project_description(project_id: str, description: str) -> None:
-    """Update a Linear project's description."""
-    mutation = gql(
-        """
-        mutation ProjectUpdate($id: String!, $input: ProjectUpdateInput!) {
-          projectUpdate(id: $id, input: $input) {
-            success
-          }
-        }
-        """
-    )
-    _execute(
-        mutation,
-        variable_values={"id": project_id, "input": {"description": description}},
-    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,9 @@ exclude = [
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
+
+[tool.vulture]
+exclude = ["venv", ".venv", "env", ".env", "__pycache__", ".git", "static", "templates", ".tox", "build", "dist", "*.egg-info", "tests"]
+ignore_decorators = ["@app.route", "@app.template_filter"]
+ignore_names = ["breakdown", "post_weekly_changelog"]
+min_confidence = 60

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ openai==2.29.0
 mypy==1.20.0
 types-PyYAML==6.0.12.20260408
 types-requests==2.33.0.20260408
+vulture==2.16


### PR DESCRIPTION
## What changed
- added `vulture` to the repo dependencies and documented the local command
- configured `vulture` in `pyproject.toml` with narrow Flask-specific ignores
- added a CI step to run `vulture . --config pyproject.toml`
- removed unused helpers that were only adding noise to the initial dead-code baseline

## Why
- this adds dead-code detection to the existing lint/type-check workflow
- cleaning up the obvious unused code keeps the first `vulture` run actionable instead of failing on stale helpers and framework-discovered entry points

## Impact
- contributors can run `vulture` locally alongside `ruff` and `mypy`
- CI will now catch newly introduced unused code

## Validation
- `ruff check .`
- `ruff format --check .`
- `vulture . --config pyproject.toml`
- `mypy .`
- `python -m unittest discover -s tests -p 'test_*.py'`
