### PR TITLE
[codex] Show failed DAGs from latest terminal run

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,11 @@ The endpoint:
 
 For humans, `GET /failing-dags` renders the same fleet-health data as an internal dashboard page
 and links back to the Astro filtered DAG view. The dashboard always serves cached fleet-health
-data and never performs a live full-fleet Airflow scan during a web request. Without a fresh
-Redis-backed cache value, it renders the unavailable/setup-required state instead.
+data and never performs a live full-fleet Airflow scan during a web request in deployed
+environments. In local debug mode, if `REDIS_URL` is not configured, the dashboard falls back
+to a live evaluation so the page can be validated without a worker/cache setup. Without a fresh
+Redis-backed cache value outside local debug mode, it renders the unavailable/setup-required
+state instead.
 
 This checker is intentionally not highly configurable. It uses fixed settings:
 

--- a/airflow_fleet_health.py
+++ b/airflow_fleet_health.py
@@ -15,14 +15,17 @@ REQUEST_TIMEOUT_SECONDS = 20
 # Airflow caps /dags responses at 100 items even when a higher limit is requested.
 DAG_PAGE_SIZE = 100
 DAG_QUERY_WORKERS = 30
+DAG_RUN_PAGE_SIZE = 10
 FAILURE_THRESHOLD_RATIO = 0.10
 MIN_EVALUATED_DAGS = 20
 TOP_FAILED_DAGS_LIMIT = 10
 
 
-class DagRunSummary(TypedDict):
-    state: str
+class DagRunEvaluation(TypedDict):
+    latest_state: str
+    latest_terminal_state: str
     dag_run_id: str
+    has_runs: bool
 
 
 class FailedDagEntry(TypedDict):
@@ -115,11 +118,11 @@ def _fetch_active_dags(session: requests.Session, base_url: str) -> set[str]:
 
 def _fetch_latest_runs_by_dag(
     base_url: str, api_token: str, active_dags: set[str]
-) -> tuple[dict[str, DagRunSummary], int]:
+) -> tuple[dict[str, DagRunEvaluation], int]:
     if not active_dags:
         return {}, 0
 
-    latest_run_by_dag: dict[str, DagRunSummary] = {}
+    latest_run_by_dag: dict[str, DagRunEvaluation] = {}
     failures = 0
     worker_count = min(DAG_QUERY_WORKERS, len(active_dags))
 
@@ -135,37 +138,57 @@ def _fetch_latest_runs_by_dag(
             except AirflowFleetHealthError:
                 failures += 1
                 continue
-            if latest_run["state"]:
-                latest_run_by_dag[dag_id] = latest_run
+            latest_run_by_dag[dag_id] = latest_run
 
     return latest_run_by_dag, failures
 
 
-def _fetch_last_run_for_dag(base_url: str, api_token: str, dag_id: str) -> DagRunSummary:
+def _fetch_last_run_for_dag(base_url: str, api_token: str, dag_id: str) -> DagRunEvaluation:
     session = _build_session(api_token)
     dag_id_encoded = quote(dag_id, safe="")
     payload = _request_json(
         session,
         f"{base_url}{DAGS_ENDPOINT}/{dag_id_encoded}/dagRuns",
-        params={"limit": 1, "offset": 0, "order_by": "-logical_date"},
+        params={"limit": DAG_RUN_PAGE_SIZE, "offset": 0, "order_by": "-logical_date"},
     )
     dag_runs = _extract_dag_runs(payload)
     if not dag_runs:
-        return {"state": "", "dag_run_id": ""}
+        return {
+            "latest_state": "",
+            "latest_terminal_state": "",
+            "dag_run_id": "",
+            "has_runs": False,
+        }
 
-    latest_run = dag_runs[0]
+    latest_state = _extract_state(dag_runs[0])
+    latest_terminal_run = next(
+        (run for run in dag_runs if _extract_state(run) in TERMINAL_STATES),
+        None,
+    )
+    if latest_terminal_run is None:
+        return {
+            "latest_state": latest_state,
+            "latest_terminal_state": "",
+            "dag_run_id": "",
+            "has_runs": True,
+        }
+
     return {
-        "state": _extract_state(latest_run),
-        "dag_run_id": _extract_dag_run_id(latest_run),
+        "latest_state": latest_state,
+        "latest_terminal_state": _extract_state(latest_terminal_run),
+        "dag_run_id": _extract_dag_run_id(latest_terminal_run),
+        "has_runs": True,
     }
 
 
 def _build_stats(
     active_dags: set[str],
-    latest_run_by_dag: dict[str, DagRunSummary],
+    latest_run_by_dag: dict[str, DagRunEvaluation],
     failed_fetches: int,
 ) -> FleetStats:
-    evaluated_dags = len(latest_run_by_dag)
+    evaluated_dags = sum(
+        1 for latest_run in latest_run_by_dag.values() if latest_run["latest_terminal_state"]
+    )
     failed_dags: list[FailedDagEntry] = [
         {
             "dag_id": dag_id,
@@ -173,11 +196,13 @@ def _build_stats(
             "dag_run_id": latest_run["dag_run_id"],
         }
         for dag_id, latest_run in sorted(latest_run_by_dag.items())
-        if latest_run["state"] == "failed"
+        if latest_run["latest_terminal_state"] == "failed"
     ]
     failed_runs = len(failed_dags)
     non_terminal_dags = sum(
-        1 for latest_run in latest_run_by_dag.values() if latest_run["state"] not in TERMINAL_STATES
+        1
+        for latest_run in latest_run_by_dag.values()
+        if latest_run["has_runs"] and latest_run["latest_state"] not in TERMINAL_STATES
     )
     failure_ratio = failed_runs / evaluated_dags if evaluated_dags else 0.0
     insufficient_volume = evaluated_dags < MIN_EVALUATED_DAGS
@@ -187,7 +212,7 @@ def _build_stats(
         active_dags_total=len(active_dags),
         evaluated_dags=evaluated_dags,
         failed_fetches=failed_fetches,
-        dags_without_runs=max(0, len(active_dags) - evaluated_dags),
+        dags_without_runs=sum(1 for latest_run in latest_run_by_dag.values() if not latest_run["has_runs"]),
         non_terminal_dags=non_terminal_dags,
         failed_dags=failed_dags,
         failed_runs=failed_runs,

--- a/airflow_fleet_health.py
+++ b/airflow_fleet_health.py
@@ -154,39 +154,51 @@ def _fetch_latest_runs_by_dag(
 def _fetch_last_run_for_dag(base_url: str, api_token: str, dag_id: str) -> DagRunEvaluation:
     session = _build_session(api_token)
     dag_id_encoded = quote(dag_id, safe="")
-    payload = _request_json(
-        session,
-        f"{base_url}{DAGS_ENDPOINT}/{dag_id_encoded}/dagRuns",
-        params={"limit": DAG_RUN_PAGE_SIZE, "offset": 0, "order_by": "-logical_date"},
-    )
-    dag_runs = _extract_dag_runs(payload)
-    if not dag_runs:
-        return {
-            "latest_state": "",
-            "latest_terminal_state": "",
-            "dag_run_id": "",
-            "has_runs": False,
-        }
+    dag_runs_url = f"{base_url}{DAGS_ENDPOINT}/{dag_id_encoded}/dagRuns"
+    offset = 0
+    latest_state = ""
+    has_runs = False
 
-    latest_state = _extract_state(dag_runs[0])
-    latest_terminal_run = next(
-        (run for run in dag_runs if _extract_state(run) in TERMINAL_STATES),
-        None,
-    )
-    if latest_terminal_run is None:
-        return {
-            "latest_state": latest_state,
-            "latest_terminal_state": "",
-            "dag_run_id": "",
-            "has_runs": True,
-        }
+    while True:
+        payload = _request_json(
+            session,
+            dag_runs_url,
+            params={"limit": DAG_RUN_PAGE_SIZE, "offset": offset, "order_by": "-logical_date"},
+        )
+        dag_runs = _extract_dag_runs(payload)
+        if not dag_runs:
+            return {
+                "latest_state": latest_state,
+                "latest_terminal_state": "",
+                "dag_run_id": "",
+                "has_runs": has_runs,
+            }
 
-    return {
-        "latest_state": latest_state,
-        "latest_terminal_state": _extract_state(latest_terminal_run),
-        "dag_run_id": _extract_dag_run_id(latest_terminal_run),
-        "has_runs": True,
-    }
+        if not has_runs:
+            has_runs = True
+            latest_state = _extract_state(dag_runs[0])
+
+        latest_terminal_run = next(
+            (run for run in dag_runs if _extract_state(run) in TERMINAL_STATES),
+            None,
+        )
+        if latest_terminal_run is not None:
+            return {
+                "latest_state": latest_state,
+                "latest_terminal_state": _extract_state(latest_terminal_run),
+                "dag_run_id": _extract_dag_run_id(latest_terminal_run),
+                "has_runs": True,
+            }
+
+        batch_size = len(dag_runs)
+        if not _has_more(batch_size, payload, offset, DAG_RUN_PAGE_SIZE):
+            return {
+                "latest_state": latest_state,
+                "latest_terminal_state": "",
+                "dag_run_id": "",
+                "has_runs": True,
+            }
+        offset += batch_size
 
 
 def _build_stats(

--- a/airflow_fleet_health.py
+++ b/airflow_fleet_health.py
@@ -21,17 +21,25 @@ MIN_EVALUATED_DAGS = 20
 TOP_FAILED_DAGS_LIMIT = 10
 
 
-class DagRunEvaluation(TypedDict):
-    latest_state: str
-    latest_terminal_state: str
-    dag_run_id: str
-    has_runs: bool
+DagRunEvaluation = TypedDict(
+    "DagRunEvaluation",
+    {
+        "latest_state": str,
+        "latest_terminal_state": str,
+        "dag_run_id": str,
+        "has_runs": bool,
+    },
+)
 
 
-class FailedDagEntry(TypedDict):
-    dag_id: str
-    state: str
-    dag_run_id: str
+FailedDagEntry = TypedDict(
+    "FailedDagEntry",
+    {
+        "dag_id": str,
+        "state": str,
+        "dag_run_id": str,
+    },
+)
 
 
 class AirflowFleetHealthError(RuntimeError):
@@ -212,7 +220,9 @@ def _build_stats(
         active_dags_total=len(active_dags),
         evaluated_dags=evaluated_dags,
         failed_fetches=failed_fetches,
-        dags_without_runs=sum(1 for latest_run in latest_run_by_dag.values() if not latest_run["has_runs"]),
+        dags_without_runs=sum(
+            1 for latest_run in latest_run_by_dag.values() if not latest_run["has_runs"]
+        ),
         non_terminal_dags=non_terminal_dags,
         failed_dags=failed_dags,
         failed_runs=failed_runs,

--- a/app.py
+++ b/app.py
@@ -165,6 +165,24 @@ DEFAULT_ASTRO_UI_BASE_URL = "https://cloud.astronomer.io/cljsvo8d800yz01giqt70a7
 AIRFLOW_REQUIRED_ENV_VARS = ("AIRFLOW_API_BASE_URL", "AIRFLOW_API_TOKEN")
 
 
+def _is_truthy_env_var(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _is_development_mode() -> bool:
+    if app.debug:
+        return True
+    if _is_truthy_env_var("FLASK_DEBUG"):
+        return True
+    if _is_truthy_env_var("DEBUG"):
+        return True
+    return os.getenv("FLASK_ENV", "").strip().lower() == "development"
+
+
+def _should_allow_live_airflow_eval_for_dashboard() -> bool:
+    return not should_use_redis_cache() and _is_development_mode()
+
+
 def _get_missing_airflow_env_vars() -> list[str]:
     return [
         env_name for env_name in AIRFLOW_REQUIRED_ENV_VARS if not os.getenv(env_name, "").strip()
@@ -325,7 +343,9 @@ def airflow_fleet_health():
 
 @app.route("/failing-dags")
 def failing_dags_dashboard():
-    payload, status = _get_airflow_fleet_health_payload(allow_live_eval=False)
+    payload, status = _get_airflow_fleet_health_payload(
+        allow_live_eval=_should_allow_live_airflow_eval_for_dashboard()
+    )
     failed_dags, is_partial_list = _get_failed_dag_entries(payload)
     failed_runs = payload.get("failed_runs")
     missing_airflow_env_vars = [

--- a/tests/test_failing_dags.py
+++ b/tests/test_failing_dags.py
@@ -578,9 +578,10 @@ class FailingDagsDashboardTest(unittest.TestCase):
             app_module.os.environ.pop("AIRFLOW_FLEET_MONITOR_TOKEN", None)
             app_module.os.environ.pop("REDIS_URL", None)
 
-            with patch.object(app_module, "should_use_redis_cache", return_value=False):
-                with patch.object(app_module, "evaluate_fleet_health") as evaluate_mock:
-                    response = self.client.get("/failing-dags")
+            with patch.object(app_module, "_is_development_mode", return_value=False):
+                with patch.object(app_module, "should_use_redis_cache", return_value=False):
+                    with patch.object(app_module, "evaluate_fleet_health") as evaluate_mock:
+                        response = self.client.get("/failing-dags")
 
         body = response.get_data(as_text=True)
         self.assertEqual(response.status_code, 200)
@@ -597,14 +598,74 @@ class FailingDagsDashboardTest(unittest.TestCase):
                 "AIRFLOW_FLEET_MONITOR_TOKEN": "secret",
             },
         ):
-            with patch.object(app_module, "should_use_redis_cache", return_value=False):
-                with patch.object(app_module, "evaluate_fleet_health") as evaluate_mock:
-                    response = self.client.get("/failing-dags")
+            with patch.object(app_module, "_is_development_mode", return_value=False):
+                with patch.object(app_module, "should_use_redis_cache", return_value=False):
+                    with patch.object(app_module, "evaluate_fleet_health") as evaluate_mock:
+                        response = self.client.get("/failing-dags")
 
         body = response.get_data(as_text=True)
         self.assertEqual(response.status_code, 200)
         self.assertIn("Failing DAG data is currently unavailable.", body)
         evaluate_mock.assert_not_called()
+
+    def test_dashboard_uses_live_eval_without_cache_in_debug_mode(self):
+        payload = {
+            "status": "degraded",
+            "checked_at": "2026-03-08T17:00:00+00:00",
+            "active_dags_total": 25,
+            "evaluated_dags": 21,
+            "failed_fetches": 1,
+            "dags_without_runs": 2,
+            "non_terminal_dags": 3,
+            "failed_runs": 4,
+            "failure_ratio": 4 / 21,
+            "threshold_ratio": 0.10,
+            "failed_dags": [
+                {
+                    "dag_id": "alpha_dag",
+                    "state": "failed",
+                    "dag_run_id": "run-alpha",
+                }
+            ],
+            "top_failed_dags": [
+                {
+                    "dag_id": "alpha_dag",
+                    "state": "failed",
+                    "dag_run_id": "run-alpha",
+                }
+            ],
+        }
+
+        with patch.dict(
+            app_module.os.environ,
+            {
+                "AIRFLOW_API_BASE_URL": "https://airflow.example.com",
+                "AIRFLOW_API_TOKEN": "token",
+            },
+            clear=False,
+        ):
+            app_module.os.environ.pop("AIRFLOW_FLEET_MONITOR_TOKEN", None)
+            app_module.os.environ.pop("REDIS_URL", None)
+
+            with patch.object(app_module, "_is_development_mode", return_value=True):
+                with patch.object(app_module, "should_use_redis_cache", return_value=False):
+                    with patch.object(
+                        app_module,
+                        "evaluate_fleet_health",
+                        return_value=(payload, 503),
+                    ) as evaluate_mock:
+                        response = self.client.get("/failing-dags")
+
+        body = response.get_data(as_text=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("alpha_dag", body)
+        self.assertIn("25", body)
+        self.assertIn("21", body)
+        self.assertIn("4", body)
+        self.assertIn("1", body)
+        self.assertIn("2", body)
+        self.assertIn("3", body)
+        evaluate_mock.assert_called_once_with()
 
     def test_dashboard_shows_setup_required_when_live_eval_is_disabled_and_creds_missing(self):
         with patch.dict(

--- a/tests/test_failing_dags.py
+++ b/tests/test_failing_dags.py
@@ -212,6 +212,56 @@ class FetchLastRunForDagTest(unittest.TestCase):
             },
         )
 
+    def test_paginates_until_terminal_run_is_found(self):
+        first_page = {
+            "dag_runs": [
+                {
+                    "dag_run_id": f"scheduled__2026-04-17T15:{index:02d}:00+00:00",
+                    "state": "running",
+                }
+                for index in range(10)
+            ],
+            "total_entries": 11,
+        }
+        second_page = {
+            "dag_runs": [
+                {
+                    "dag_run_id": "scheduled__2026-04-17T14:47:00+00:00",
+                    "state": "failed",
+                }
+            ],
+            "total_entries": 11,
+        }
+        seen_offsets: list[int] = []
+
+        def fake_request_json(session, url, params):
+            del session, url
+            seen_offsets.append(params["offset"])
+            return first_page if params["offset"] == 0 else second_page
+
+        with patch.object(airflow_fleet_health, "_build_session", return_value=object()):
+            with patch.object(
+                airflow_fleet_health,
+                "_request_json",
+                side_effect=fake_request_json,
+            ):
+                latest_run = airflow_fleet_health._fetch_last_run_for_dag(
+                    "https://airflow.example.com",
+                    "token",
+                    "one_church_planning_center_people_dag",
+                )
+
+        self.assertEqual(seen_offsets, [0, 10])
+        self.assertEqual(
+            latest_run,
+            {
+                "latest_state": "running",
+                "latest_terminal_state": "failed",
+                "dag_run_id": "scheduled__2026-04-17T14:47:00+00:00",
+                "has_runs": True,
+            },
+        )
+
 
 class FetchActiveDagsPaginationTest(unittest.TestCase):
     def test_fetch_active_dags_uses_actual_batch_size_when_total_entries_exceeds_api_cap(self):

--- a/tests/test_failing_dags.py
+++ b/tests/test_failing_dags.py
@@ -87,8 +87,10 @@ class EvaluateFleetHealthTest(unittest.TestCase):
         active_dags = {f"dag-{index:02d}" for index in range(1, 22)}
         latest_runs = {
             dag_id: {
-                "state": "failed" if dag_id <= "dag-11" else "success",
+                "latest_state": "failed" if dag_id <= "dag-11" else "success",
+                "latest_terminal_state": "failed" if dag_id <= "dag-11" else "success",
                 "dag_run_id": f"run-{dag_id}",
+                "has_runs": True,
             }
             for dag_id in active_dags
         }
@@ -121,6 +123,94 @@ class EvaluateFleetHealthTest(unittest.TestCase):
         self.assertEqual(payload["failed_dags"][0]["dag_run_id"], "run-dag-01")
         self.assertEqual(payload["failed_dags"][-1]["dag_id"], "dag-11")
         self.assertEqual(payload["failed_dags"][-1]["dag_run_id"], "run-dag-11")
+
+    def test_uses_latest_terminal_run_when_newest_run_is_still_running(self):
+        active_dags = {"one_church_planning_center_people_dag", "healthy_dag"}
+        latest_runs = {
+            "one_church_planning_center_people_dag": {
+                "latest_state": "running",
+                "latest_terminal_state": "failed",
+                "dag_run_id": "scheduled__2026-04-17T14:47:00+00:00",
+                "has_runs": True,
+            },
+            "healthy_dag": {
+                "latest_state": "success",
+                "latest_terminal_state": "success",
+                "dag_run_id": "scheduled__2026-04-17T15:17:00+00:00",
+                "has_runs": True,
+            },
+        }
+
+        with patch.object(airflow_fleet_health, "_require_env", side_effect=["x", "y"]):
+            with patch.object(airflow_fleet_health, "_build_session", return_value=object()):
+                with patch.object(
+                    airflow_fleet_health,
+                    "_fetch_active_dags",
+                    return_value=active_dags,
+                ):
+                    with patch.object(
+                        airflow_fleet_health,
+                        "_fetch_latest_runs_by_dag",
+                        return_value=(latest_runs, 0),
+                    ):
+                        with patch.object(
+                            airflow_fleet_health,
+                            "datetime",
+                            FixedDateTime,
+                        ):
+                            payload, status = airflow_fleet_health.evaluate_fleet_health()
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["failed_runs"], 1)
+        self.assertEqual(payload["non_terminal_dags"], 1)
+        self.assertEqual(
+            payload["failed_dags"],
+            [
+                {
+                    "dag_id": "one_church_planning_center_people_dag",
+                    "state": "failed",
+                    "dag_run_id": "scheduled__2026-04-17T14:47:00+00:00",
+                }
+            ],
+        )
+
+
+class FetchLastRunForDagTest(unittest.TestCase):
+    def test_uses_latest_terminal_run_when_latest_run_is_non_terminal(self):
+        payload = {
+            "dag_runs": [
+                {
+                    "dag_run_id": "scheduled__2026-04-17T15:17:00+00:00",
+                    "state": "running",
+                },
+                {
+                    "dag_run_id": "scheduled__2026-04-17T14:47:00+00:00",
+                    "state": "failed",
+                },
+            ]
+        }
+
+        with patch.object(airflow_fleet_health, "_build_session", return_value=object()):
+            with patch.object(
+                airflow_fleet_health,
+                "_request_json",
+                return_value=payload,
+            ):
+                latest_run = airflow_fleet_health._fetch_last_run_for_dag(
+                    "https://airflow.example.com",
+                    "token",
+                    "one_church_planning_center_people_dag",
+                )
+
+        self.assertEqual(
+            latest_run,
+            {
+                "latest_state": "running",
+                "latest_terminal_state": "failed",
+                "dag_run_id": "scheduled__2026-04-17T14:47:00+00:00",
+                "has_runs": True,
+            },
+        )
 
 
 class FetchActiveDagsPaginationTest(unittest.TestCase):


### PR DESCRIPTION
## What changed
- updated the Airflow fleet health evaluator to look at a DAG's latest terminal run instead of only the single newest run
- kept tracking the newest run state separately so currently running DAGs still count toward `non_terminal_dags`
- added regression tests covering a DAG whose newest run is `running` while its latest completed run is `failed`

## Why
The failed DAG list was dropping DAGs that were actively running even when their last completed run had failed. In the live case, `one_church_planning_center_people_dag` had a current `running` run and a latest terminal run of `failed`, so it should still have been surfaced in the failing DAGs view.

## Impact
The `/failing-dags` dashboard and fleet-health payload now keep showing DAGs whose last completed run failed, even if a retry or subsequent run is currently in progress.

## Validation
- `source .venv-ci/bin/activate && python -m unittest tests.test_failing_dags`
- `source .venv-ci/bin/activate && python -m unittest discover -s tests -p 'test_*.py'`
