### PR TITLE
Fix PR review reminders for unknown mergeability

### DIFF
--- a/github.py
+++ b/github.py
@@ -190,6 +190,12 @@ def has_failing_required_checks(pr):
     return rollup.get("state") != "SUCCESS"
 
 
+def has_known_merge_conflicts(pr):
+    """Return True only when GitHub has confirmed the PR cannot merge cleanly."""
+
+    return pr.get("mergeable") == "CONFLICTING"
+
+
 def _parse_github_timestamp(value: str | None) -> datetime | None:
     if not value:
         return None
@@ -322,8 +328,7 @@ def get_prs_waiting_for_review_by_reviewer():
         additions = pr.get("additions")
         if additions is None or additions >= 200:
             continue
-        # only consider pull requests that are mergeable
-        if pr.get("mergeable") != "MERGEABLE":
+        if has_known_merge_conflicts(pr):
             continue
         if not pr["reviewRequests"]["nodes"]:
             continue

--- a/jobs.py
+++ b/jobs.py
@@ -868,7 +868,7 @@ def configure_scheduled_jobs() -> None:
     schedule.every().day.at("12:00").do(post_priority_bugs)
     schedule.every().friday.at("20:00").do(post_leaderboard)
     # schedule.every().thursday.at("19:00").do(post_weekly_changelog)
-    schedule.every().day.at("14:00").do(post_stale)
+    schedule.every().day.at("10:00", "America/New_York").do(post_stale)
     schedule.every().day.at("14:00", "America/New_York").do(post_overdue_projects)
     schedule.every().friday.at("12:00").do(post_upcoming_projects)
     schedule.every().monday.at("12:00").do(post_friday_deadlines)

--- a/tests/test_gql_client_requests.py
+++ b/tests/test_gql_client_requests.py
@@ -101,6 +101,70 @@ class GraphQLClientRequestTests(unittest.TestCase):
         self.assertEqual(waiting["darrylyip"], [pr])
         self.assertEqual(waiting["vitlelis"], [pr])
 
+    def test_waiting_for_review_allows_unknown_mergeability(self):
+        class FixedDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                base = datetime(2026, 3, 25, 14, 0, 0)
+                if tz is None:
+                    return base
+                return base.replace(tzinfo=tz)
+
+        pr = {
+            "number": 6050,
+            "additions": 1,
+            "mergeable": "UNKNOWN",
+            "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "darrylyip"}}]},
+            "reviews": {"nodes": []},
+            "timelineItems": {
+                "nodes": [
+                    {
+                        "createdAt": "2026-03-24T13:51:12Z",
+                        "requestedReviewer": {"login": "darrylyip"},
+                    },
+                ]
+            },
+            "statusCheckRollup": {"state": "SUCCESS"},
+        }
+
+        with patch.object(github, "_get_all_prs", return_value=[pr]):
+            with patch.object(github, "datetime", FixedDateTime):
+                waiting = github.get_prs_waiting_for_review_by_reviewer()
+
+        self.assertEqual(waiting["darrylyip"], [pr])
+
+    def test_waiting_for_review_skips_known_merge_conflicts(self):
+        class FixedDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                base = datetime(2026, 3, 25, 14, 0, 0)
+                if tz is None:
+                    return base
+                return base.replace(tzinfo=tz)
+
+        pr = {
+            "number": 6050,
+            "additions": 1,
+            "mergeable": "CONFLICTING",
+            "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "darrylyip"}}]},
+            "reviews": {"nodes": []},
+            "timelineItems": {
+                "nodes": [
+                    {
+                        "createdAt": "2026-03-24T13:51:12Z",
+                        "requestedReviewer": {"login": "darrylyip"},
+                    },
+                ]
+            },
+            "statusCheckRollup": {"state": "SUCCESS"},
+        }
+
+        with patch.object(github, "_get_all_prs", return_value=[pr]):
+            with patch.object(github, "datetime", FixedDateTime):
+                waiting = github.get_prs_waiting_for_review_by_reviewer()
+
+        self.assertEqual(waiting, {})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -184,8 +184,8 @@ class ConfigureScheduledJobsTest(unittest.TestCase):
             {
                 "interval": None,
                 "unit": "day",
-                "at_time": "14:00",
-                "timezone": None,
+                "at_time": "10:00",
+                "timezone": "America/New_York",
                 "func": jobs_module.post_stale,
             },
             recorded_jobs,


### PR DESCRIPTION
## Summary
- include PRs with GitHub `mergeable: UNKNOWN` in stale review reminders
- continue skipping PRs with confirmed merge conflicts
- make the stale review reminder schedule explicit at 10 AM Eastern

## Proof
- `ruff check github.py jobs.py tests/test_gql_client_requests.py tests/test_jobs.py`
- `python -m unittest discover -s tests -p 'test_*.py'`