### PR TITLE
Consolidate project notification jobs into unified daily digest

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -616,7 +616,6 @@ def post_project_updates():
     people_config = load_config().get("people", {})
     now = datetime.now(timezone.utc)
     today = now.date()
-    canceled_statuses = {"canceled", "cancelled"}
 
     overdue = []
     ending_soon = []
@@ -641,8 +640,7 @@ def post_project_updates():
             elif days_left is not None and 0 <= days_left <= 3:
                 ending_soon.append({"name": name, "target_dt": target_dt, "line": line})
 
-        status_name = ((project.get("status") or {}).get("name") or "").strip().lower()
-        if status_name in canceled_statuses:
+        if inactive:
             continue
         start_dt = parse_iso_date(project.get("startDate"))
         if start_dt:

--- a/jobs.py
+++ b/jobs.py
@@ -657,14 +657,10 @@ def post_project_updates():
     sections = []
     if overdue:
         ordered = sorted(overdue, key=lambda item: (item["target_dt"], item["name"].lower()))
-        sections.append(
-            "*Overdue Projects*\n\n" + "\n".join(item["line"] for item in ordered)
-        )
+        sections.append("*Overdue Projects*\n\n" + "\n".join(item["line"] for item in ordered))
     if ending_soon:
         ordered = sorted(ending_soon, key=lambda item: (item["target_dt"], item["name"].lower()))
-        sections.append(
-            "*Projects Ending Soon*\n\n" + "\n".join(item["line"] for item in ordered)
-        )
+        sections.append("*Projects Ending Soon*\n\n" + "\n".join(item["line"] for item in ordered))
     if starting_soon:
         ordered = sorted(starting_soon, key=lambda item: (item["start_dt"], item["name"].lower()))
         sections.append(

--- a/jobs.py
+++ b/jobs.py
@@ -610,117 +610,71 @@ def post_inactive_engineers():
 
 
 @with_retries
-def post_upcoming_projects():
-    """Notify leads about projects starting on Monday."""
-    projects = get_projects()
-    people_config = load_config().get("people", {})
-    upcoming = []
-    today = datetime.now(timezone.utc).date()
-    canceled_statuses = {"canceled", "cancelled"}
-    for project in projects:
-        if not _is_engineering_lead_project(project, people_config):
-            continue
-        start = project.get("startDate")
-        if not start:
-            continue
-        status_name = (project.get("status") or {}).get("name")
-        if status_name and status_name.lower() in canceled_statuses:
-            continue
-        try:
-            start_dt = datetime.fromisoformat(start).date()
-        except ValueError:
-            continue
-        days_until = (start_dt - today).days
-        if start_dt.weekday() == 0 and 0 <= days_until <= 5:
-            lead = (project.get("lead") or {}).get("displayName")
-            if not lead:
-                continue
-            lead_md = get_slack_markdown_by_linear_username(lead)
-            upcoming.append(f"- <{project['url']}|{project['name']}> - Lead: {lead_md}")
-    if upcoming:
-        markdown = "*Projects Starting Monday*\n\n" + "\n".join(upcoming)
-        post_to_slack(markdown)
-
-
-@with_retries
-def post_overdue_projects():
-    """Notify Slack about active projects whose target date has passed."""
+def post_project_updates():
+    """Daily digest of overdue, ending-soon, and starting-soon projects."""
     projects = get_projects()
     people_config = load_config().get("people", {})
     now = datetime.now(timezone.utc)
+    today = now.date()
+    canceled_statuses = {"canceled", "cancelled"}
+
     overdue = []
+    ending_soon = []
+    starting_soon = []
 
     for project in projects:
-        if _is_inactive_project(project):
-            continue
         if not _is_engineering_lead_project(project, people_config):
             continue
 
-        target_dt = parse_iso_date(project.get("targetDate"))
-        _days_left, target_status_text = format_project_target_status(
-            target_dt,
-            now=now,
-        )
-        if not target_dt or not target_status_text or not target_status_text.endswith("overdue"):
-            continue
-
+        name = project.get("name") or "Untitled Project"
+        url = project.get("url")
         lead = (project.get("lead") or {}).get("displayName")
         lead_md = get_slack_markdown_by_linear_username(lead) if lead else "No Lead"
-        overdue.append(
-            {
-                "name": project.get("name") or "Untitled Project",
-                "target_dt": target_dt,
-                "line": (
-                    f"- <{project['url']}|{project['name']}> - "
-                    f"{target_status_text} - Lead: {lead_md}"
-                ),
-            }
+        inactive = _is_inactive_project(project)
+
+        target_dt = parse_iso_date(project.get("targetDate"))
+        days_left, target_status_text = format_project_target_status(target_dt, now=now)
+        if not inactive and target_dt and target_status_text:
+            line = f"- <{url}|{name}> - {target_status_text} - Lead: {lead_md}"
+            if target_status_text.endswith("overdue"):
+                overdue.append({"name": name, "target_dt": target_dt, "line": line})
+            elif days_left is not None and 0 <= days_left <= 3:
+                ending_soon.append({"name": name, "target_dt": target_dt, "line": line})
+
+        status_name = ((project.get("status") or {}).get("name") or "").strip().lower()
+        if status_name in canceled_statuses:
+            continue
+        start_dt = parse_iso_date(project.get("startDate"))
+        if start_dt:
+            days_until_start = (start_dt - today).days
+            if 0 <= days_until_start <= 3:
+                starting_soon.append(
+                    {
+                        "name": name,
+                        "start_dt": start_dt,
+                        "line": f"- <{url}|{name}> - Lead: {lead_md}",
+                    }
+                )
+
+    sections = []
+    if overdue:
+        ordered = sorted(overdue, key=lambda item: (item["target_dt"], item["name"].lower()))
+        sections.append(
+            "*Overdue Projects*\n\n" + "\n".join(item["line"] for item in ordered)
+        )
+    if ending_soon:
+        ordered = sorted(ending_soon, key=lambda item: (item["target_dt"], item["name"].lower()))
+        sections.append(
+            "*Projects Ending Soon*\n\n" + "\n".join(item["line"] for item in ordered)
+        )
+    if starting_soon:
+        ordered = sorted(starting_soon, key=lambda item: (item["start_dt"], item["name"].lower()))
+        sections.append(
+            "*Projects Starting Soon*\n\n" + "\n".join(item["line"] for item in ordered)
         )
 
-    if overdue:
-        ordered_lines = [
-            item["line"]
-            for item in sorted(
-                overdue,
-                key=lambda item: (item["target_dt"], item["name"].lower()),
-            )
-        ]
-        markdown = "*Overdue Projects*\n\n" + "\n".join(ordered_lines)
-        post_to_slack(markdown)
-
-
-@with_retries
-def post_friday_deadlines():
-    """Notify leads about projects ending on Friday."""
-    projects = get_projects()
-    people_config = load_config().get("people", {})
-    projects = [
-        project for project in projects if _is_engineering_lead_project(project, people_config)
-    ]
-
-    upcoming = []
-    today = datetime.now(timezone.utc).date()
-    inactive_statuses = {"Completed", "Incomplete", "Canceled"}
-
-    for project in projects:
-        target = project.get("targetDate")
-        if not target:
-            continue
-        status_name = (project.get("status") or {}).get("name")
-        if status_name in inactive_statuses:
-            continue
-        try:
-            target_dt = datetime.fromisoformat(target).date()
-        except ValueError:
-            continue
-        days_until = (target_dt - today).days
-        if target_dt.weekday() == 4 and 0 <= days_until <= 5:
-            lead = (project.get("lead") or {}).get("displayName")
-            lead_md = get_slack_markdown_by_linear_username(lead) if lead else "No Lead"
-            upcoming.append(f"- <{project['url']}|{project['name']}> - Lead: {lead_md}")
-    if upcoming:
-        markdown = "*Projects Due Friday*\n\n" + "\n".join(upcoming)
-        post_to_slack(markdown)
+    if sections:
+        post_to_slack("\n\n".join(sections))
 
 
 @with_retries
@@ -844,9 +798,7 @@ def run_debug_jobs() -> None:
     post_leaderboard()
     # post_weekly_changelog()
     post_stale()
-    post_overdue_projects()
-    post_upcoming_projects()
-    post_friday_deadlines()
+    post_project_updates()
 
 
 def configure_scheduled_jobs() -> None:
@@ -869,9 +821,7 @@ def configure_scheduled_jobs() -> None:
     schedule.every().friday.at("20:00").do(post_leaderboard)
     # schedule.every().thursday.at("19:00").do(post_weekly_changelog)
     schedule.every().day.at("14:00").do(post_stale)
-    schedule.every().day.at("14:00", "America/New_York").do(post_overdue_projects)
-    schedule.every().friday.at("12:00").do(post_upcoming_projects)
-    schedule.every().monday.at("12:00").do(post_friday_deadlines)
+    schedule.every().day.at("14:00", "America/New_York").do(post_project_updates)
 
 
 def main() -> None:

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -643,6 +643,22 @@ class PostProjectUpdatesTest(unittest.TestCase):
                 "status": {"name": "Canceled"},
                 "lead": {"displayName": "Alex"},
             },
+            # Completed starting project should be skipped
+            {
+                "name": "Completed Start",
+                "url": "https://linear.app/project/completed-start",
+                "startDate": "2026-03-17",
+                "status": {"name": "Completed"},
+                "lead": {"displayName": "Alex"},
+            },
+            # Released starting project should be skipped
+            {
+                "name": "Released Start",
+                "url": "https://linear.app/project/released-start",
+                "startDate": "2026-03-17",
+                "status": {"name": "Released"},
+                "lead": {"displayName": "Alex"},
+            },
             # Non-engineering lead should be skipped
             {
                 "name": "Product Overdue",
@@ -704,6 +720,8 @@ class PostProjectUpdatesTest(unittest.TestCase):
         self.assertNotIn("Ending Far", message)
         self.assertNotIn("Starting Far", message)
         self.assertNotIn("Canceled Start", message)
+        self.assertNotIn("Completed Start", message)
+        self.assertNotIn("Released Start", message)
         self.assertNotIn("Product Overdue", message)
         self.assertNotIn("Completed Late", message)
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -208,9 +208,7 @@ class RunDebugJobsTest(unittest.TestCase):
             with patch.object(jobs_module, "post_priority_bugs"):
                 with patch.object(jobs_module, "post_leaderboard") as leaderboard:
                     with patch.object(jobs_module, "post_stale") as stale:
-                        with patch.object(
-                            jobs_module, "post_project_updates"
-                        ) as project_updates:
+                        with patch.object(jobs_module, "post_project_updates") as project_updates:
                             jobs_module.run_debug_jobs()
 
         leaderboard.assert_called_once_with()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -196,50 +196,26 @@ class ConfigureScheduledJobsTest(unittest.TestCase):
                 "unit": "day",
                 "at_time": "14:00",
                 "timezone": "America/New_York",
-                "func": jobs_module.post_overdue_projects,
-            },
-            recorded_jobs,
-        )
-        self.assertIn(
-            {
-                "interval": None,
-                "unit": "friday",
-                "at_time": "12:00",
-                "timezone": None,
-                "func": jobs_module.post_upcoming_projects,
-            },
-            recorded_jobs,
-        )
-        self.assertIn(
-            {
-                "interval": None,
-                "unit": "monday",
-                "at_time": "12:00",
-                "timezone": None,
-                "func": jobs_module.post_friday_deadlines,
+                "func": jobs_module.post_project_updates,
             },
             recorded_jobs,
         )
 
 
 class RunDebugJobsTest(unittest.TestCase):
-    def test_runs_leaderboard_overdue_projects_upcoming_projects_and_friday_deadlines(self):
+    def test_runs_leaderboard_stale_and_project_updates(self):
         with patch.object(jobs_module, "should_use_redis_cache", return_value=False):
             with patch.object(jobs_module, "post_priority_bugs"):
                 with patch.object(jobs_module, "post_leaderboard") as leaderboard:
                     with patch.object(jobs_module, "post_stale") as stale:
-                        with patch.object(jobs_module, "post_overdue_projects") as overdue:
-                            with patch.object(jobs_module, "post_upcoming_projects") as upcoming:
-                                with patch.object(
-                                    jobs_module, "post_friday_deadlines"
-                                ) as friday_deadlines:
-                                    jobs_module.run_debug_jobs()
+                        with patch.object(
+                            jobs_module, "post_project_updates"
+                        ) as project_updates:
+                            jobs_module.run_debug_jobs()
 
         leaderboard.assert_called_once_with()
         stale.assert_called_once_with()
-        overdue.assert_called_once_with()
-        upcoming.assert_called_once_with()
-        friday_deadlines.assert_called_once_with()
+        project_updates.assert_called_once_with()
 
 
 class FixedDateTime(datetime):
@@ -590,10 +566,20 @@ class PostPriorityBugsInvalidWhitelistFallbackTest(unittest.TestCase):
         warning.assert_called_once()
 
 
-class PostOverdueProjectsTest(unittest.TestCase):
-    def test_posts_only_engineering_led_active_projects_with_past_target_dates(self):
+class PostProjectUpdatesTest(unittest.TestCase):
+    def _run(self, projects, config):
         posted = []
+        with patch.object(jobs_module, "load_config", return_value=config):
+            with patch.object(jobs_module, "get_projects", return_value=projects):
+                with patch.object(jobs_module, "post_to_slack", side_effect=posted.append):
+                    with patch.object(jobs_module, "datetime", FixedDateTime):
+                        jobs_module.post_project_updates()
+        return posted
+
+    def test_groups_overdue_ending_soon_and_starting_soon_in_order(self):
+        # FixedDateTime -> 2026-03-15 (Sunday)
         projects = [
+            # Overdue
             {
                 "name": "Late Alpha",
                 "url": "https://linear.app/project/late-alpha",
@@ -601,27 +587,71 @@ class PostOverdueProjectsTest(unittest.TestCase):
                 "status": {"name": "Active"},
                 "lead": {"displayName": "Alex"},
             },
+            # Ending soon (within 3 days)
             {
-                "name": "Late Beta",
-                "url": "https://linear.app/project/late-beta",
-                "targetDate": "2026-03-11",
-                "status": {"name": "Planned"},
-                "lead": {"displayName": "Pat"},
-            },
-            {
-                "name": "Late Gamma",
-                "url": "https://linear.app/project/late-gamma",
-                "targetDate": "2026-03-13",
-                "status": {"name": "Active"},
-                "lead": None,
-            },
-            {
-                "name": "Due Today",
-                "url": "https://linear.app/project/due-today",
-                "targetDate": "2026-03-15",
+                "name": "Ending Tue",
+                "url": "https://linear.app/project/ending-tue",
+                "targetDate": "2026-03-17",
                 "status": {"name": "Active"},
                 "lead": {"displayName": "Alex"},
             },
+            # Ending soon boundary (exactly 3 days out)
+            {
+                "name": "Ending Wed",
+                "url": "https://linear.app/project/ending-wed",
+                "targetDate": "2026-03-18",
+                "status": {"name": "Active"},
+                "lead": {"displayName": "Alex"},
+            },
+            # Outside the 3-day ending window
+            {
+                "name": "Ending Far",
+                "url": "https://linear.app/project/ending-far",
+                "targetDate": "2026-03-19",
+                "status": {"name": "Active"},
+                "lead": {"displayName": "Alex"},
+            },
+            # Starting soon (within 3 days)
+            {
+                "name": "Starting Tue",
+                "url": "https://linear.app/project/starting-tue",
+                "startDate": "2026-03-17",
+                "status": {"name": "Planned"},
+                "lead": {"displayName": "Alex"},
+            },
+            # Starting soon boundary (exactly 3 days out)
+            {
+                "name": "Starting Wed",
+                "url": "https://linear.app/project/starting-wed",
+                "startDate": "2026-03-18",
+                "status": {"name": "Planned"},
+                "lead": {"displayName": "Alex"},
+            },
+            # Outside the 3-day starting window
+            {
+                "name": "Starting Far",
+                "url": "https://linear.app/project/starting-far",
+                "startDate": "2026-03-19",
+                "status": {"name": "Planned"},
+                "lead": {"displayName": "Alex"},
+            },
+            # Canceled starting project should be skipped
+            {
+                "name": "Canceled Start",
+                "url": "https://linear.app/project/canceled-start",
+                "startDate": "2026-03-17",
+                "status": {"name": "Canceled"},
+                "lead": {"displayName": "Alex"},
+            },
+            # Non-engineering lead should be skipped
+            {
+                "name": "Product Overdue",
+                "url": "https://linear.app/project/product-overdue",
+                "targetDate": "2026-03-10",
+                "status": {"name": "Active"},
+                "lead": {"displayName": "Pat"},
+            },
+            # Inactive project - overdue target should be skipped
             {
                 "name": "Completed Late",
                 "url": "https://linear.app/project/completed-late",
@@ -629,13 +659,6 @@ class PostOverdueProjectsTest(unittest.TestCase):
                 "status": {"name": "Completed"},
                 "lead": {"displayName": "Alex"},
             },
-            {
-                "name": "Released Late",
-                "url": "https://linear.app/project/released-late",
-                "targetDate": "2026-03-09",
-                "status": {"name": "Released"},
-                "lead": {"displayName": "Alex"},
-            },
         ]
         config = {
             "people": {
@@ -652,53 +675,46 @@ class PostOverdueProjectsTest(unittest.TestCase):
             }
         }
 
-        with patch.object(jobs_module, "load_config", return_value=config):
-            with patch.object(jobs_module, "get_projects", return_value=projects):
-                with patch.object(jobs_module, "post_to_slack", side_effect=posted.append):
-                    with patch.object(jobs_module, "datetime", FixedDateTime):
-                        jobs_module.post_overdue_projects()
+        posted = self._run(projects, config)
 
         self.assertEqual(len(posted), 1)
-        self.assertIn("*Overdue Projects*", posted[0])
-        self.assertIn("Late Alpha", posted[0])
-        self.assertIn("12h overdue - Lead: <@U1>", posted[0])
-        self.assertNotIn("Late Beta", posted[0])
-        self.assertNotIn("Late Gamma", posted[0])
-        self.assertNotIn("Due Today", posted[0])
-        self.assertNotIn("Completed Late", posted[0])
-        self.assertNotIn("Released Late", posted[0])
+        message = posted[0]
 
+        # All three section headers present
+        self.assertIn("*Overdue Projects*", message)
+        self.assertIn("*Projects Ending Soon*", message)
+        self.assertIn("*Projects Starting Soon*", message)
 
-class PostUpcomingProjectsTest(unittest.TestCase):
-    def test_posts_only_monday_projects_with_engineering_leads(self):
-        posted = []
+        # Sections are ordered Overdue -> Ending Soon -> Starting Soon
+        overdue_idx = message.index("*Overdue Projects*")
+        ending_idx = message.index("*Projects Ending Soon*")
+        starting_idx = message.index("*Projects Starting Soon*")
+        self.assertLess(overdue_idx, ending_idx)
+        self.assertLess(ending_idx, starting_idx)
+
+        # Correct projects present
+        self.assertIn("Late Alpha", message)
+        self.assertIn("Ending Tue", message)
+        self.assertIn("Ending Wed", message)
+        self.assertIn("Starting Tue", message)
+        self.assertIn("Starting Wed", message)
+        self.assertIn("Lead: <@U1>", message)
+
+        # Correct projects filtered out
+        self.assertNotIn("Ending Far", message)
+        self.assertNotIn("Starting Far", message)
+        self.assertNotIn("Canceled Start", message)
+        self.assertNotIn("Product Overdue", message)
+        self.assertNotIn("Completed Late", message)
+
+    def test_skips_post_when_no_projects_match(self):
         projects = [
             {
-                "name": "Monday Engineering",
-                "url": "https://linear.app/project/monday-engineering",
-                "startDate": "2026-03-16",
+                "name": "Far Future",
+                "url": "https://linear.app/project/far-future",
+                "startDate": "2026-04-30",
+                "targetDate": "2026-05-30",
                 "status": {"name": "Planned"},
-                "lead": {"displayName": "Alex"},
-            },
-            {
-                "name": "Monday Product",
-                "url": "https://linear.app/project/monday-product",
-                "startDate": "2026-03-16",
-                "status": {"name": "Planned"},
-                "lead": {"displayName": "Pat"},
-            },
-            {
-                "name": "Monday No Lead",
-                "url": "https://linear.app/project/monday-no-lead",
-                "startDate": "2026-03-16",
-                "status": {"name": "Planned"},
-                "lead": None,
-            },
-            {
-                "name": "Canceled Monday",
-                "url": "https://linear.app/project/canceled-monday",
-                "startDate": "2026-03-16",
-                "status": {"name": "Canceled"},
                 "lead": {"displayName": "Alex"},
             },
         ]
@@ -709,27 +725,11 @@ class PostUpcomingProjectsTest(unittest.TestCase):
                     "slack_id": "U1",
                     "team": "engineering",
                 },
-                "pat": {
-                    "linear_username": "Pat",
-                    "slack_id": "U2",
-                    "team": "product",
-                },
             }
         }
 
-        with patch.object(jobs_module, "load_config", return_value=config):
-            with patch.object(jobs_module, "get_projects", return_value=projects):
-                with patch.object(jobs_module, "post_to_slack", side_effect=posted.append):
-                    with patch.object(jobs_module, "datetime", FixedDateTime):
-                        jobs_module.post_upcoming_projects()
-
-        self.assertEqual(len(posted), 1)
-        self.assertIn("*Projects Starting Monday*", posted[0])
-        self.assertIn("Monday Engineering", posted[0])
-        self.assertIn("Lead: <@U1>", posted[0])
-        self.assertNotIn("Monday Product", posted[0])
-        self.assertNotIn("Monday No Lead", posted[0])
-        self.assertNotIn("Canceled Monday", posted[0])
+        posted = self._run(projects, config)
+        self.assertEqual(posted, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Consolidates three separate project notification functions (`post_overdue_projects`, `post_upcoming_projects`, and `post_friday_deadlines`) into a single unified `post_project_updates` function that runs daily and groups projects by status (overdue, ending soon, starting soon).

## Key Changes
- **Merged three jobs into one**: Replaced three separate scheduled jobs with a single daily digest that covers all project statuses
- **Unified filtering logic**: Consolidated engineering lead validation and project status filtering into a single pass through projects
- **Improved time windows**: Changed from day-of-week specific scheduling (Monday/Friday) to a consistent 3-day window for both ending-soon and starting-soon projects
- **Better organization**: Projects are now grouped into three sections (Overdue, Ending Soon, Starting Soon) within a single Slack message, ordered by date within each section
- **Simplified scheduling**: Reduced from 3 scheduled jobs to 1 daily job at 14:00 ET
- **Updated tests**: Refactored test suite to reflect the new consolidated function with comprehensive test cases for filtering, grouping, and ordering logic

## Implementation Details
- The new function processes all projects in a single loop, categorizing them into three lists based on their target/start dates and status
- Projects are filtered to only include those with engineering leads and active/planned statuses
- Overdue projects are identified using existing `format_project_target_status` helper
- Ending-soon and starting-soon projects use a consistent 3-day window (0-3 days from today)
- Only posts to Slack if at least one project matches the criteria
- Maintains backward compatibility with existing project data structure and Slack markdown formatting

https://claude.ai/code/session_01HpRGk3uYAE5awwcPs7vAD8