### PR TITLE
Report Airflow fleet health via Better Stack heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ python -m unittest discover -s tests -p 'test_*.py'
 - `OPENAI_API_KEY` – API key used to generate weekly changelogs
 - `AIRFLOW_API_BASE_URL` – Base URL for Airflow REST API (for example: `https://airflow.example.com`)
 - `AIRFLOW_API_TOKEN` – Bearer token for Airflow API
+- `AIRFLOW_FLEET_HEARTBEAT_URL` – Optional Better Stack heartbeat URL for worker-reported Airflow fleet health
 - `AIRFLOW_FLEET_MONITOR_TOKEN` – Optional token required by `/airflow-fleet-health`
 - `REDIS_URL` – Optional Redis connection string for cached `/airflow-fleet-health` responses
 - `REDIS_SSL_CERT_REQS` – Optional TLS cert verification mode for `rediss://` (`none`, `optional`, `required`; default for `rediss://` is `none` unless `REDIS_URL` already sets `ssl_cert_reqs`)
@@ -69,14 +70,21 @@ python jobs.py
 
 The `Procfile` defines both commands for platforms such as Heroku.
 
-## Airflow fleet outage monitor
+## Airflow fleet outage heartbeat
 
-This app exposes `GET /airflow-fleet-health` for Better Stack to detect broad DAG failures
-without relying on Airflow DAG execution itself.
+The worker can report Airflow fleet health to Better Stack using a heartbeat, which avoids
+Better Stack polling this app as an uptime monitor. Configure a Better Stack heartbeat and set
+`AIRFLOW_FLEET_HEARTBEAT_URL` to its secret URL.
 
-The endpoint:
+On each worker refresh, the app:
 
-- Calls the Airflow REST API and inspects each active DAG's latest run state
+- Evaluates the Airflow REST API and inspects each active DAG's latest run state
+- Refreshes the Redis-backed `/airflow-fleet-health` cache when Redis is configured
+- Sends the base heartbeat URL when fleet health is healthy
+- Sends the heartbeat URL with `/fail` appended when fleet health is unhealthy or unknown
+
+The health calculation:
+
 - Computes failed/evaluated ratio across active DAGs (not time-window based)
 - Returns `503` when failure ratio is `>= 0.10` (with at least 20 DAGs evaluated), otherwise `200`
 - Includes both `top_failed_dags` and the full `failed_dags` list in the JSON payload
@@ -97,10 +105,11 @@ This checker is intentionally not highly configurable. It uses fixed settings:
 - failure threshold ratio: `0.10`
 - minimum evaluated DAGs: `20`
 
-When Redis caching is enabled, run the worker process (`python jobs.py`) so it refreshes
-the cached fleet health value on the configured interval.
+When Redis caching or the Better Stack heartbeat is enabled, run the worker process
+(`python jobs.py`) so it refreshes fleet health on the configured interval.
 
-If `AIRFLOW_FLEET_MONITOR_TOKEN` is set, Better Stack must send either of these on
+`GET /airflow-fleet-health` remains available for the dashboard/cache JSON payload. If
+`AIRFLOW_FLEET_MONITOR_TOKEN` is set, callers must send either of these on
 `GET /airflow-fleet-health`:
 
 - `Authorization: Bearer <token>` header, or

--- a/jobs.py
+++ b/jobs.py
@@ -3,6 +3,7 @@ import os
 import re
 import time
 from datetime import datetime, timezone
+from urllib.parse import urlsplit, urlunsplit
 
 import requests
 import schedule
@@ -43,6 +44,7 @@ RETRY_SLEEP_SECONDS = 5
 MAX_DIFF_CHARS = 12000
 MAX_DIFF_FILES = 20
 FLEET_HEALTH_REFRESH_DEFAULT_SECONDS = 60
+AIRFLOW_FLEET_HEARTBEAT_TIMEOUT_SECONDS = 10
 INACTIVE_PROJECT_STATUS_NAMES = {
     "completed",
     "incomplete",
@@ -106,12 +108,39 @@ def post_to_slack(markdown: str):
 
 def refresh_airflow_fleet_health_cache_job():
     payload, status = refresh_fleet_health_cache()
+    report_airflow_fleet_health_heartbeat(payload, status)
     logging.info(
         "Refreshed airflow fleet health cache (status=%s, http_status=%s, evaluated_dags=%s)",
         payload.get("status"),
         status,
         payload.get("evaluated_dags"),
     )
+
+
+def report_airflow_fleet_health_heartbeat(payload: dict, status: int) -> None:
+    heartbeat_url = os.getenv("AIRFLOW_FLEET_HEARTBEAT_URL", "").strip()
+    if not heartbeat_url:
+        return
+
+    is_healthy = status < 400 and payload.get("status") == "healthy"
+    url = heartbeat_url if is_healthy else _append_url_path(heartbeat_url, "fail")
+
+    try:
+        response = requests.get(url, timeout=AIRFLOW_FLEET_HEARTBEAT_TIMEOUT_SECONDS)
+        if response.status_code >= 400:
+            logging.error(
+                "Airflow fleet Better Stack heartbeat returned %s: %s",
+                response.status_code,
+                response.text,
+            )
+    except requests.RequestException:
+        logging.exception("Failed to report airflow fleet Better Stack heartbeat")
+
+
+def _append_url_path(url: str, segment: str) -> str:
+    parsed = urlsplit(url)
+    path = f"{parsed.path.rstrip('/')}/{segment}"
+    return urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, parsed.fragment))
 
 
 def post_to_manager_slack(markdown: str):

--- a/tests/test_failing_dags.py
+++ b/tests/test_failing_dags.py
@@ -824,11 +824,7 @@ class FailingDagsDashboardTest(unittest.TestCase):
 
         with patch.dict(
             jobs_module.os.environ,
-            {
-                "AIRFLOW_FLEET_HEARTBEAT_URL": (
-                    "https://uptime.betterstack.com/heartbeat/token"
-                )
-            },
+            {"AIRFLOW_FLEET_HEARTBEAT_URL": ("https://uptime.betterstack.com/heartbeat/token")},
             clear=False,
         ):
             with patch.object(jobs_module.requests, "get") as get_mock:
@@ -845,11 +841,7 @@ class FailingDagsDashboardTest(unittest.TestCase):
 
         with patch.dict(
             jobs_module.os.environ,
-            {
-                "AIRFLOW_FLEET_HEARTBEAT_URL": (
-                    "https://uptime.betterstack.com/heartbeat/token/"
-                )
-            },
+            {"AIRFLOW_FLEET_HEARTBEAT_URL": ("https://uptime.betterstack.com/heartbeat/token/")},
             clear=False,
         ):
             with patch.object(jobs_module.requests, "get") as get_mock:

--- a/tests/test_failing_dags.py
+++ b/tests/test_failing_dags.py
@@ -819,6 +819,48 @@ class FailingDagsDashboardTest(unittest.TestCase):
         self.assertEqual(response.get_json(), {"status": "unknown"})
         evaluate_mock.assert_not_called()
 
+    def test_airflow_fleet_heartbeat_reports_success_for_healthy_payload(self):
+        import jobs as jobs_module
+
+        with patch.dict(
+            jobs_module.os.environ,
+            {
+                "AIRFLOW_FLEET_HEARTBEAT_URL": (
+                    "https://uptime.betterstack.com/heartbeat/token"
+                )
+            },
+            clear=False,
+        ):
+            with patch.object(jobs_module.requests, "get") as get_mock:
+                get_mock.return_value.status_code = 200
+                jobs_module.report_airflow_fleet_health_heartbeat({"status": "healthy"}, 200)
+
+        get_mock.assert_called_once_with(
+            "https://uptime.betterstack.com/heartbeat/token",
+            timeout=jobs_module.AIRFLOW_FLEET_HEARTBEAT_TIMEOUT_SECONDS,
+        )
+
+    def test_airflow_fleet_heartbeat_reports_failure_for_unhealthy_payload(self):
+        import jobs as jobs_module
+
+        with patch.dict(
+            jobs_module.os.environ,
+            {
+                "AIRFLOW_FLEET_HEARTBEAT_URL": (
+                    "https://uptime.betterstack.com/heartbeat/token/"
+                )
+            },
+            clear=False,
+        ):
+            with patch.object(jobs_module.requests, "get") as get_mock:
+                get_mock.return_value.status_code = 200
+                jobs_module.report_airflow_fleet_health_heartbeat({"status": "unhealthy"}, 503)
+
+        get_mock.assert_called_once_with(
+            "https://uptime.betterstack.com/heartbeat/token/fail",
+            timeout=jobs_module.AIRFLOW_FLEET_HEARTBEAT_TIMEOUT_SECONDS,
+        )
+
 
 class ProjectStatusClassificationTest(unittest.TestCase):
     def test_released_project_is_inactive_and_completed(self):


### PR DESCRIPTION
## Summary

- report Airflow fleet health to Better Stack through a worker-driven heartbeat
- send the base heartbeat URL for healthy fleet health and `/fail` for unhealthy or unknown fleet health
- document `AIRFLOW_FLEET_HEARTBEAT_URL` and the heartbeat-based alerting flow

## Validation

Not run; not requested.
