### PR TITLE
Remove legacy Airflow fleet health monitor endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ python -m unittest discover -s tests -p 'test_*.py'
 - `AIRFLOW_API_BASE_URL` – Base URL for Airflow REST API (for example: `https://airflow.example.com`)
 - `AIRFLOW_API_TOKEN` – Bearer token for Airflow API
 - `AIRFLOW_FLEET_HEARTBEAT_URL` – Optional Better Stack heartbeat URL for worker-reported Airflow fleet health
-- `AIRFLOW_FLEET_MONITOR_TOKEN` – Optional token required by `/airflow-fleet-health`
-- `REDIS_URL` – Optional Redis connection string for cached `/airflow-fleet-health` responses
+- `REDIS_URL` – Optional Redis connection string for cached Airflow fleet-health responses
 - `REDIS_SSL_CERT_REQS` – Optional TLS cert verification mode for `rediss://` (`none`, `optional`, `required`; default for `rediss://` is `none` unless `REDIS_URL` already sets `ssl_cert_reqs`)
 - `AIRFLOW_FLEET_HEALTH_REFRESH_SECONDS` – Optional worker refresh interval for cached fleet health (default: `60`)
 - `AIRFLOW_FLEET_HEALTH_MAX_STALE_SECONDS` – Optional max age accepted by the web endpoint when reading cached data (default: `180`)
@@ -79,7 +78,7 @@ Better Stack polling this app as an uptime monitor. Configure a Better Stack hea
 On each worker refresh, the app:
 
 - Evaluates the Airflow REST API and inspects each active DAG's latest run state
-- Refreshes the Redis-backed `/airflow-fleet-health` cache when Redis is configured
+- Refreshes the Redis-backed fleet-health cache when Redis is configured
 - Sends the base heartbeat URL when fleet health is healthy
 - Sends the heartbeat URL with `/fail` appended when fleet health is unhealthy or unknown
 
@@ -108,9 +107,4 @@ This checker is intentionally not highly configurable. It uses fixed settings:
 When Redis caching or the Better Stack heartbeat is enabled, run the worker process
 (`python jobs.py`) so it refreshes fleet health on the configured interval.
 
-`GET /airflow-fleet-health` remains available for the dashboard/cache JSON payload. If
-`AIRFLOW_FLEET_MONITOR_TOKEN` is set, callers must send either of these on
-`GET /airflow-fleet-health`:
-
-- `Authorization: Bearer <token>` header, or
-- `?token=<token>` query param
+The legacy `GET /airflow-fleet-health` Better Stack monitor endpoint has been removed.

--- a/app.py
+++ b/app.py
@@ -319,6 +319,7 @@ def healthz():
     response.headers["Cache-Control"] = "no-store"
     return response, 200
 
+
 @app.route("/failing-dags")
 def failing_dags_dashboard():
     payload, status = _get_airflow_fleet_health_payload(

--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from typing import Any, TypedDict, TypeVar
 from urllib.parse import quote
 
-from flask import Flask, jsonify, render_template, request
+from flask import Flask, abort, jsonify, render_template, request
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from airflow_fleet_health import AirflowFleetHealthError, evaluate_fleet_health

--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from typing import Any, TypedDict, TypeVar
 from urllib.parse import quote
 
-from flask import Flask, abort, jsonify, render_template, request
+from flask import Flask, jsonify, render_template, request
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from airflow_fleet_health import AirflowFleetHealthError, evaluate_fleet_health
@@ -313,34 +313,11 @@ def _format_checked_at(value: Any) -> str | None:
     return checked_at.astimezone().strftime("%Y-%m-%d %I:%M:%S %p %Z")
 
 
-def _require_airflow_fleet_monitor_token() -> None:
-    expected_token = os.getenv("AIRFLOW_FLEET_MONITOR_TOKEN")
-    if not expected_token:
-        return
-
-    bearer_token = request.headers.get("Authorization", "").removeprefix("Bearer ")
-    request_token = request.args.get("token", default="", type=str)
-    if bearer_token != expected_token and request_token != expected_token:
-        abort(401)
-
-
 @app.route("/healthz")
 def healthz():
     response = jsonify({"status": "ok"})
     response.headers["Cache-Control"] = "no-store"
     return response, 200
-
-
-@app.route("/airflow-fleet-health")
-def airflow_fleet_health():
-    _require_airflow_fleet_monitor_token()
-
-    payload, status = _get_airflow_fleet_health_payload(allow_live_eval=False)
-
-    response = jsonify(payload)
-    response.headers["Cache-Control"] = "no-store"
-    return response, status
-
 
 @app.route("/failing-dags")
 def failing_dags_dashboard():

--- a/tests/test_failing_dags.py
+++ b/tests/test_failing_dags.py
@@ -738,86 +738,11 @@ class FailingDagsDashboardTest(unittest.TestCase):
         self.assertNotIn("Failing DAG data is currently unavailable.", body)
         evaluate_mock.assert_not_called()
 
-    def test_health_endpoint_requires_monitor_token_when_configured(self):
-        with patch.dict(app_module.os.environ, {"AIRFLOW_FLEET_MONITOR_TOKEN": "secret"}):
-            response = self.client.get("/airflow-fleet-health")
-
-        self.assertEqual(response.status_code, 401)
-
     def test_healthz_returns_ok_payload(self):
         response = self.client.get("/healthz")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get_json(), {"status": "ok"})
-
-    def test_health_endpoint_skips_live_eval_without_redis(self):
-        with patch.dict(
-            app_module.os.environ,
-            {
-                "AIRFLOW_API_BASE_URL": "https://airflow.example.com",
-                "AIRFLOW_API_TOKEN": "token",
-            },
-            clear=False,
-        ):
-            app_module.os.environ.pop("AIRFLOW_FLEET_MONITOR_TOKEN", None)
-            app_module.os.environ.pop("REDIS_URL", None)
-
-            with patch.object(app_module, "should_use_redis_cache", return_value=False):
-                with patch.object(app_module, "evaluate_fleet_health") as evaluate_mock:
-                    response = self.client.get("/airflow-fleet-health")
-
-        self.assertEqual(response.status_code, 503)
-        self.assertEqual(response.get_json(), {"status": "unknown"})
-        evaluate_mock.assert_not_called()
-
-    def test_health_endpoint_returns_setup_required_payload_without_redis_when_creds_missing(self):
-        with patch.dict(app_module.os.environ, {}, clear=False):
-            for env_name in (
-                "AIRFLOW_API_BASE_URL",
-                "AIRFLOW_API_TOKEN",
-                "AIRFLOW_FLEET_MONITOR_TOKEN",
-                "REDIS_URL",
-            ):
-                app_module.os.environ.pop(env_name, None)
-
-            with patch.object(app_module, "should_use_redis_cache", return_value=False):
-                with patch.object(app_module, "evaluate_fleet_health") as evaluate_mock:
-                    response = self.client.get("/airflow-fleet-health")
-
-        self.assertEqual(response.status_code, 503)
-        self.assertEqual(
-            response.get_json(),
-            {
-                "status": "unknown",
-                "error_type": "missing_airflow_credentials",
-                "missing_airflow_env_vars": [
-                    "AIRFLOW_API_BASE_URL",
-                    "AIRFLOW_API_TOKEN",
-                ],
-            },
-        )
-        evaluate_mock.assert_not_called()
-
-    def test_health_endpoint_skips_live_eval_when_cache_is_unavailable(self):
-        with patch.dict(
-            app_module.os.environ,
-            {
-                "AIRFLOW_API_BASE_URL": "https://airflow.example.com",
-                "AIRFLOW_API_TOKEN": "token",
-                "REDIS_URL": "redis://cache.example.com:6379/0",
-            },
-            clear=False,
-        ):
-            app_module.os.environ.pop("AIRFLOW_FLEET_MONITOR_TOKEN", None)
-
-            with patch.object(app_module, "should_use_redis_cache", return_value=True):
-                with patch.object(app_module, "get_cached_fleet_health", return_value=None):
-                    with patch.object(app_module, "evaluate_fleet_health") as evaluate_mock:
-                        response = self.client.get("/airflow-fleet-health")
-
-        self.assertEqual(response.status_code, 503)
-        self.assertEqual(response.get_json(), {"status": "unknown"})
-        evaluate_mock.assert_not_called()
 
     def test_airflow_fleet_heartbeat_reports_success_for_healthy_payload(self):
         import jobs as jobs_module


### PR DESCRIPTION
## Summary

- remove the legacy `/airflow-fleet-health` Better Stack monitor endpoint
- remove the monitor-token auth helper and docs for `AIRFLOW_FLEET_MONITOR_TOKEN`
- keep the `/failing-dags` dashboard backed by the existing fleet-health cache/evaluation path

## Stack

- #302: Report Airflow fleet health via Better Stack heartbeat
- this PR: remove the legacy Better Stack monitor endpoint

## Validation

Not run; not requested.
