### PR TITLE
[codex] Add David to bug board config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -92,6 +92,11 @@ people:
     slack_id: U08UMCQ511D
     linear_username: justin.isenhart
     github_username:
+  david:
+    team: unassigned
+    slack_id: U02GM64LC
+    linear_username: david
+    github_username: davidwoody
 
 platforms:
   crossroads:


### PR DESCRIPTION
## Summary
- add David Woody to the people config
- wire Slack, Linear, and GitHub identifiers for dashboard and Slack lookup paths

## Validation
- ruby -e "require 'yaml'; c = YAML.load_file('config.yml'); raise 'missing david' unless c['people']['david']['slack_id'] == 'U02GM64LC' && c['people']['david']['linear_username'] == 'david' && c['people']['david']['github_username'] == 'davidwoody'; puts 'config ok'"
- git diff --check