### PR TITLE
[codex] Suppress review reminders for change-requested PRs

### DIFF
--- a/github.py
+++ b/github.py
@@ -365,18 +365,6 @@ def get_prs_waiting_for_review_by_reviewer():
     return stuck_prs
 
 
-def get_prs_with_changes_requested_by_reviewer():
-    """Return open PRs with change requests, grouped by the reviewer who requested changes."""
-    all_prs = _get_all_prs(["OPEN"])
-    cr_prs = {}
-    for pr in all_prs:
-        for review in pr.get("reviews", {}).get("nodes", []):
-            if review.get("author") and review.get("state") == "CHANGES_REQUESTED":
-                reviewer = review["author"]["login"]
-                cr_prs.setdefault(reviewer, []).append(pr)
-    return cr_prs
-
-
 def get_pr_diff(owner: str, repo: str, number: int) -> str:
     """Return the diff for a pull request."""
     url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}"

--- a/github.py
+++ b/github.py
@@ -151,6 +151,7 @@ def get_prs(repo_id, pr_states):
                             }
                             number
                             mergeable
+                            reviewDecision
                             statusCheckRollup {
                                 state
                             }
@@ -194,6 +195,12 @@ def has_known_merge_conflicts(pr):
     """Return True only when GitHub has confirmed the PR cannot merge cleanly."""
 
     return pr.get("mergeable") == "CONFLICTING"
+
+
+def has_active_change_request(pr):
+    """Return True when GitHub says the PR is blocked by requested changes."""
+
+    return pr.get("reviewDecision") == "CHANGES_REQUESTED"
 
 
 def _parse_github_timestamp(value: str | None) -> datetime | None:
@@ -329,6 +336,8 @@ def get_prs_waiting_for_review_by_reviewer():
         if additions is None or additions >= 200:
             continue
         if has_known_merge_conflicts(pr):
+            continue
+        if has_active_change_request(pr):
             continue
         if not pr["reviewRequests"]["nodes"]:
             continue

--- a/jobs.py
+++ b/jobs.py
@@ -16,7 +16,6 @@ from fleet_health_cache import refresh_fleet_health_cache, should_use_redis_cach
 from github import (
     get_pr_diff,
     get_prs_waiting_for_review_by_reviewer,
-    get_prs_with_changes_requested_by_reviewer,
     merged_prs_by_author,
     merged_prs_by_reviewer,
 )
@@ -532,7 +531,6 @@ def post_stale():
         if person.get("linear_username")
     }
     prs = get_prs_waiting_for_review_by_reviewer()
-    cr_prs = get_prs_with_changes_requested_by_reviewer()
     stale_issues = get_stale_issues_by_assignee(
         get_open_issues(5, "Bug")
         + get_open_issues(5, "Feature Request")
@@ -547,14 +545,8 @@ def post_stale():
     for reviewer, pr_list in prs.items():
         if reviewer not in people_by_github_username:
             continue
-        keep = []
-        for pr in pr_list:
-            crers = [r for r, pls in cr_prs.items() if pr in pls]
-            if any(r != reviewer for r in crers):
-                continue
-            keep.append(pr)
-        if keep:
-            filtered[reviewer] = keep
+        if pr_list:
+            filtered[reviewer] = pr_list
     prs = filtered
     if prs:
         markdown += "*PRs - Checks Passing, Waiting for Review (+24h, <200 lines added)*\n"

--- a/tests/test_gql_client_requests.py
+++ b/tests/test_gql_client_requests.py
@@ -72,6 +72,7 @@ class GraphQLClientRequestTests(unittest.TestCase):
             "number": 6050,
             "additions": 1,
             "mergeable": "MERGEABLE",
+            "reviewDecision": "REVIEW_REQUIRED",
             "reviewRequests": {
                 "nodes": [
                     {"requestedReviewer": {"login": "darrylyip"}},
@@ -114,6 +115,7 @@ class GraphQLClientRequestTests(unittest.TestCase):
             "number": 6050,
             "additions": 1,
             "mergeable": "UNKNOWN",
+            "reviewDecision": "REVIEW_REQUIRED",
             "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "darrylyip"}}]},
             "reviews": {"nodes": []},
             "timelineItems": {
@@ -146,6 +148,7 @@ class GraphQLClientRequestTests(unittest.TestCase):
             "number": 6050,
             "additions": 1,
             "mergeable": "CONFLICTING",
+            "reviewDecision": "REVIEW_REQUIRED",
             "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "darrylyip"}}]},
             "reviews": {"nodes": []},
             "timelineItems": {
@@ -164,6 +167,76 @@ class GraphQLClientRequestTests(unittest.TestCase):
                 waiting = github.get_prs_waiting_for_review_by_reviewer()
 
         self.assertEqual(waiting, {})
+
+    def test_waiting_for_review_skips_active_change_requests(self):
+        class FixedDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                base = datetime(2026, 3, 25, 14, 0, 0)
+                if tz is None:
+                    return base
+                return base.replace(tzinfo=tz)
+
+        pr = {
+            "number": 6293,
+            "additions": 55,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "CHANGES_REQUESTED",
+            "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "michael"}}]},
+            "reviews": {
+                "nodes": [{"author": {"login": "dylan-manchester"}, "state": "CHANGES_REQUESTED"}]
+            },
+            "timelineItems": {
+                "nodes": [
+                    {
+                        "createdAt": "2026-03-24T13:51:12Z",
+                        "requestedReviewer": {"login": "michael"},
+                    },
+                ]
+            },
+            "statusCheckRollup": {"state": "SUCCESS"},
+        }
+
+        with patch.object(github, "_get_all_prs", return_value=[pr]):
+            with patch.object(github, "datetime", FixedDateTime):
+                waiting = github.get_prs_waiting_for_review_by_reviewer()
+
+        self.assertEqual(waiting, {})
+
+    def test_waiting_for_review_allows_cleared_change_requests(self):
+        class FixedDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                base = datetime(2026, 3, 25, 14, 0, 0)
+                if tz is None:
+                    return base
+                return base.replace(tzinfo=tz)
+
+        pr = {
+            "number": 6293,
+            "additions": 55,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "michael"}}]},
+            "reviews": {
+                "nodes": [{"author": {"login": "dylan-manchester"}, "state": "CHANGES_REQUESTED"}]
+            },
+            "timelineItems": {
+                "nodes": [
+                    {
+                        "createdAt": "2026-03-24T13:51:12Z",
+                        "requestedReviewer": {"login": "michael"},
+                    },
+                ]
+            },
+            "statusCheckRollup": {"state": "SUCCESS"},
+        }
+
+        with patch.object(github, "_get_all_prs", return_value=[pr]):
+            with patch.object(github, "datetime", FixedDateTime):
+                waiting = github.get_prs_waiting_for_review_by_reviewer()
+
+        self.assertEqual(waiting["michael"], [pr])
 
 
 if __name__ == "__main__":

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -44,7 +44,6 @@ def _install_import_shims() -> None:
     github_module = cast(Any, types.ModuleType("github"))
     github_module.get_pr_diff = lambda *args, **kwargs: ""
     github_module.get_prs_waiting_for_review_by_reviewer = lambda *args, **kwargs: {}
-    github_module.get_prs_with_changes_requested_by_reviewer = lambda *args, **kwargs: {}
     github_module.merged_prs_by_author = lambda *args, **kwargs: {}
     github_module.merged_prs_by_reviewer = lambda *args, **kwargs: {}
     sys.modules.setdefault("github", github_module)


### PR DESCRIPTION
## Summary

Suppress PR review reminder notifications when GitHub reports that a PR has active requested changes.

## Why

The stale review notifier could still mention reviewers for a PR that was checks-passing and had open review requests, even while the PR was blocked by someone else's active change request. In that state the author needs to resolve the requested changes before reviewers should be nudged again.

## Changes

- Fetch `reviewDecision` from GitHub for tracked pull requests.
- Exclude PRs with `reviewDecision: CHANGES_REQUESTED` from the waiting-for-review predicate.
- Remove the older Slack-side historical change-request filtering so cleared change requests can become eligible again.
- Add tests for active and cleared change-request behavior.

## Validation

- `.venv-ci/bin/python -m unittest discover -s tests -p 'test_*.py'`
- `.venv-ci/bin/ruff check .`
- `.venv-ci/bin/ruff format --check .`