### PR TITLE
[codex] Fall back to review nodes for change-requested PRs

### DIFF
--- a/github.py
+++ b/github.py
@@ -123,6 +123,7 @@ def get_prs(repo_id, pr_states):
                                         login
                                     }
                                     state
+                                    submittedAt
                                 }
                             }
                             timelineItems(
@@ -197,12 +198,6 @@ def has_known_merge_conflicts(pr):
     return pr.get("mergeable") == "CONFLICTING"
 
 
-def has_active_change_request(pr):
-    """Return True when GitHub says the PR is blocked by requested changes."""
-
-    return pr.get("reviewDecision") == "CHANGES_REQUESTED"
-
-
 def _parse_github_timestamp(value: str | None) -> datetime | None:
     if not value:
         return None
@@ -210,6 +205,37 @@ def _parse_github_timestamp(value: str | None) -> datetime | None:
         return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
     except ValueError:
         return None
+
+
+def has_active_change_request(pr):
+    """Return True when GitHub says the PR is blocked by requested changes."""
+
+    review_decision = pr.get("reviewDecision")
+    if review_decision:
+        return review_decision == "CHANGES_REQUESTED"
+
+    review_request_times_by_reviewer: dict[str, list[datetime]] = {}
+    for review_request in pr.get("timelineItems", {}).get("nodes", []):
+        requested_reviewer = review_request.get("requestedReviewer") or {}
+        reviewer = requested_reviewer.get("login")
+        requested_at = _parse_github_timestamp(review_request.get("createdAt"))
+        if reviewer and requested_at is not None:
+            review_request_times_by_reviewer.setdefault(reviewer, []).append(requested_at)
+
+    for review in pr.get("reviews", {}).get("nodes", []):
+        if review.get("state") != "CHANGES_REQUESTED":
+            continue
+        reviewer = (review.get("author") or {}).get("login")
+        submitted_at = _parse_github_timestamp(review.get("submittedAt"))
+        if not reviewer or submitted_at is None:
+            return True
+        latest_review_request_at = max(
+            review_request_times_by_reviewer.get(reviewer, []),
+            default=None,
+        )
+        if latest_review_request_at is None or submitted_at >= latest_review_request_at:
+            return True
+    return False
 
 
 def _get_all_prs(pr_states: List[str]) -> List[Dict[str, Any]]:

--- a/tests/test_gql_client_requests.py
+++ b/tests/test_gql_client_requests.py
@@ -182,15 +182,21 @@ class GraphQLClientRequestTests(unittest.TestCase):
             "additions": 55,
             "mergeable": "MERGEABLE",
             "reviewDecision": "CHANGES_REQUESTED",
-            "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "michael"}}]},
+            "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "dylan-manchester"}}]},
             "reviews": {
-                "nodes": [{"author": {"login": "dylan-manchester"}, "state": "CHANGES_REQUESTED"}]
+                "nodes": [
+                    {
+                        "author": {"login": "dylan-manchester"},
+                        "state": "CHANGES_REQUESTED",
+                        "submittedAt": "2026-03-24T13:52:12Z",
+                    }
+                ]
             },
             "timelineItems": {
                 "nodes": [
                     {
                         "createdAt": "2026-03-24T13:51:12Z",
-                        "requestedReviewer": {"login": "michael"},
+                        "requestedReviewer": {"login": "dylan-manchester"},
                     },
                 ]
             },
@@ -219,7 +225,13 @@ class GraphQLClientRequestTests(unittest.TestCase):
             "reviewDecision": "REVIEW_REQUIRED",
             "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "michael"}}]},
             "reviews": {
-                "nodes": [{"author": {"login": "dylan-manchester"}, "state": "CHANGES_REQUESTED"}]
+                "nodes": [
+                    {
+                        "author": {"login": "dylan-manchester"},
+                        "state": "CHANGES_REQUESTED",
+                        "submittedAt": "2026-03-24T13:52:12Z",
+                    }
+                ]
             },
             "timelineItems": {
                 "nodes": [
@@ -237,6 +249,129 @@ class GraphQLClientRequestTests(unittest.TestCase):
                 waiting = github.get_prs_waiting_for_review_by_reviewer()
 
         self.assertEqual(waiting["michael"], [pr])
+
+    def test_waiting_for_review_falls_back_to_current_review_nodes_for_missing_decision(self):
+        class FixedDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                base = datetime(2026, 3, 25, 14, 0, 0)
+                if tz is None:
+                    return base
+                return base.replace(tzinfo=tz)
+
+        pr = {
+            "number": 6293,
+            "additions": 55,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": None,
+            "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "dylan-manchester"}}]},
+            "reviews": {
+                "nodes": [
+                    {
+                        "author": {"login": "dylan-manchester"},
+                        "state": "CHANGES_REQUESTED",
+                        "submittedAt": "2026-03-24T13:52:12Z",
+                    }
+                ]
+            },
+            "timelineItems": {
+                "nodes": [
+                    {
+                        "createdAt": "2026-03-24T13:51:12Z",
+                        "requestedReviewer": {"login": "dylan-manchester"},
+                    },
+                ]
+            },
+            "statusCheckRollup": {"state": "SUCCESS"},
+        }
+
+        with patch.object(github, "_get_all_prs", return_value=[pr]):
+            with patch.object(github, "datetime", FixedDateTime):
+                waiting = github.get_prs_waiting_for_review_by_reviewer()
+
+        self.assertEqual(waiting, {})
+
+    def test_waiting_for_review_ignores_historical_review_nodes_for_missing_decision(self):
+        class FixedDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                base = datetime(2026, 3, 25, 14, 0, 0)
+                if tz is None:
+                    return base
+                return base.replace(tzinfo=tz)
+
+        pr = {
+            "number": 6293,
+            "additions": 55,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": None,
+            "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "dylan-manchester"}}]},
+            "reviews": {
+                "nodes": [
+                    {
+                        "author": {"login": "dylan-manchester"},
+                        "state": "CHANGES_REQUESTED",
+                        "submittedAt": "2026-03-24T12:51:12Z",
+                    }
+                ]
+            },
+            "timelineItems": {
+                "nodes": [
+                    {
+                        "createdAt": "2026-03-24T13:51:12Z",
+                        "requestedReviewer": {"login": "dylan-manchester"},
+                    },
+                ]
+            },
+            "statusCheckRollup": {"state": "SUCCESS"},
+        }
+
+        with patch.object(github, "_get_all_prs", return_value=[pr]):
+            with patch.object(github, "datetime", FixedDateTime):
+                waiting = github.get_prs_waiting_for_review_by_reviewer()
+
+        self.assertEqual(waiting["dylan-manchester"], [pr])
+
+    def test_waiting_for_review_ignores_unrelated_review_requests_for_missing_decision(self):
+        class FixedDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                base = datetime(2026, 3, 25, 14, 0, 0)
+                if tz is None:
+                    return base
+                return base.replace(tzinfo=tz)
+
+        pr = {
+            "number": 6293,
+            "additions": 55,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": None,
+            "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "michael"}}]},
+            "reviews": {
+                "nodes": [
+                    {
+                        "author": {"login": "dylan-manchester"},
+                        "state": "CHANGES_REQUESTED",
+                        "submittedAt": "2026-03-24T12:51:12Z",
+                    }
+                ]
+            },
+            "timelineItems": {
+                "nodes": [
+                    {
+                        "createdAt": "2026-03-24T13:51:12Z",
+                        "requestedReviewer": {"login": "michael"},
+                    },
+                ]
+            },
+            "statusCheckRollup": {"state": "SUCCESS"},
+        }
+
+        with patch.object(github, "_get_all_prs", return_value=[pr]):
+            with patch.object(github, "datetime", FixedDateTime):
+                waiting = github.get_prs_waiting_for_review_by_reviewer()
+
+        self.assertEqual(waiting, {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add a fallback for active change-request detection when GitHub does not return an aggregate `reviewDecision`.

## Why

PR #319 moved the stale review notifier to GitHub's current `reviewDecision`, which correctly suppresses reminders while a PR is actively changes-requested and allows reminders again once GitHub reports `REVIEW_REQUIRED`. A late review note identified an edge case: repositories without required PR reviews can return `reviewDecision: null` even when `reviews.nodes` contains a `CHANGES_REQUESTED` review.

## Changes

- Keep `reviewDecision` as the authoritative current state when GitHub returns it.
- Fall back to fetched `reviews.nodes` only when `reviewDecision` is missing or null.
- Add a regression test for the null-decision fallback.

## Validation

- `.venv-ci/bin/python -m unittest discover -s tests -p 'test_*.py'`
- `.venv-ci/bin/ruff check .`
- `.venv-ci/bin/ruff format --check .`
- `.venv-ci/bin/vulture . --config pyproject.toml`