### PR TITLE
[codex] Fix leaderboard posting

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -833,7 +833,7 @@ def configure_scheduled_jobs() -> None:
 
     schedule.every().friday.at("13:00").do(post_inactive_engineers)
     schedule.every().day.at("12:00").do(post_priority_bugs)
-    schedule.every().friday.at("20:00").do(post_leaderboard)
+    schedule.every().friday.at("16:00", "America/New_York").do(post_leaderboard)
     # schedule.every().thursday.at("19:00").do(post_weekly_changelog)
     schedule.every().day.at("10:00", "America/New_York").do(post_stale)
     schedule.every().day.at("14:00", "America/New_York").do(post_project_updates)

--- a/linear/projects.py
+++ b/linear/projects.py
@@ -9,7 +9,7 @@ def get_completed_project_issue_assignees(project_id: str) -> list[str]:
     """Return sorted unique assignee display names for a project's completed issues."""
     query = gql(
         """
-        query CompletedProjectIssueAssignees($project_id: String!, $after: String) {
+        query CompletedProjectIssueAssignees($project_id: ID!, $after: String) {
           issues(
             first: 50
             after: $after

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -173,8 +173,8 @@ class ConfigureScheduledJobsTest(unittest.TestCase):
             {
                 "interval": None,
                 "unit": "friday",
-                "at_time": "20:00",
-                "timezone": None,
+                "at_time": "16:00",
+                "timezone": "America/New_York",
                 "func": jobs_module.post_leaderboard,
             },
             recorded_jobs,
@@ -204,11 +204,14 @@ class ConfigureScheduledJobsTest(unittest.TestCase):
 class RunDebugJobsTest(unittest.TestCase):
     def test_runs_leaderboard_stale_and_project_updates(self):
         with patch.object(jobs_module, "should_use_redis_cache", return_value=False):
-            with patch.object(jobs_module, "post_priority_bugs"):
-                with patch.object(jobs_module, "post_leaderboard") as leaderboard:
-                    with patch.object(jobs_module, "post_stale") as stale:
-                        with patch.object(jobs_module, "post_project_updates") as project_updates:
-                            jobs_module.run_debug_jobs()
+            with patch.object(jobs_module, "post_inactive_engineers"):
+                with patch.object(jobs_module, "post_priority_bugs"):
+                    with patch.object(jobs_module, "post_leaderboard") as leaderboard:
+                        with patch.object(jobs_module, "post_stale") as stale:
+                            with patch.object(
+                                jobs_module, "post_project_updates"
+                            ) as project_updates:
+                                jobs_module.run_debug_jobs()
 
         leaderboard.assert_called_once_with()
         stale.assert_called_once_with()

--- a/tests/test_linear_projects.py
+++ b/tests/test_linear_projects.py
@@ -106,8 +106,10 @@ class GetCompletedProjectIssueAssigneesTest(unittest.TestCase):
             },
         ]
         calls = []
+        queries = []
 
         def fake_execute(_query, variable_values=None):
+            queries.append(str(_query))
             calls.append(variable_values)
             return responses[len(calls) - 1]
 
@@ -121,6 +123,7 @@ class GetCompletedProjectIssueAssigneesTest(unittest.TestCase):
                 {"project_id": "project-2", "after": "issue-cursor-1"},
             ],
         )
+        self.assertIn("$project_id: ID!", queries[0])
         self.assertEqual(assignees, ["Austin Witherow", "Later Page Contributor"])
 
 


### PR DESCRIPTION
## Summary

Fixes the weekly leaderboard worker path so it can post successfully and run at the intended 4pm Eastern wall-clock time.

## Root cause

The completed-project contributor query declared `$project_id` as `String!`, but Linear's `project.id.eq` filter expects an `ID`. That caused a GraphQL validation error before the worker reached the Slack post.

The leaderboard schedule also used `friday.at("20:00")` without a timezone, unlike the other wall-clock Slack jobs. On UTC workers that resolved to 20:00 UTC instead of the intended Eastern-time schedule.

## Changes

- Change the completed-project contributor query variable to `ID!`.
- Schedule `post_leaderboard` at `16:00` in `America/New_York`.
- Update tests to assert the query type and timezone registration.
- Stub `post_inactive_engineers` in the debug-job test so it stays focused on debug job orchestration.

## Validation

- `.venv-ci/bin/python -m unittest tests.test_jobs tests.test_linear_projects tests.test_leaderboard`
- `.venv-ci/bin/ruff check jobs.py tests/test_jobs.py linear/projects.py tests/test_linear_projects.py`
- `.venv-ci/bin/ruff format --check jobs.py tests/test_jobs.py linear/projects.py tests/test_linear_projects.py`
- Verified under `TZ=UTC` that `16:00 America/New_York` resolves to `20:00 UTC` / `16:00 Eastern`.
