### PR TITLE
[codex] Add app versions dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ python -m unittest discover -s tests -p 'test_*.py'
 - `AIRFLOW_FLEET_HEALTH_REFRESH_SECONDS` – Optional worker refresh interval for cached fleet health (default: `60`)
 - `AIRFLOW_FLEET_HEALTH_MAX_STALE_SECONDS` – Optional max age accepted by the web endpoint when reading cached data (default: `180`)
 - `AIRFLOW_FLEET_HEALTH_REDIS_TTL_SECONDS` – Optional Redis TTL for cached fleet health record (default: `900`)
+- `BIGQUERY_ANALYTICS_PROJECT_ID` – Optional Google Cloud project that contains the Segment BigQuery export (default: `apollos-project`)
+- `BIGQUERY_ANALYTICS_DATASETS` – Optional comma-separated BigQuery datasets containing Segment export tables (default: `apollos,apollos_tv,apollos_roku`)
+- `BIGQUERY_ANALYTICS_TABLES` – Optional comma-separated Segment tables to inspect for app runtime versions (default: `identifies,screens,app_became_active,app_became_backgrounded,app_became_inactive`)
+- `BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64` – Base64-encoded Google service account JSON for BigQuery access
+- `APP_VERSIONS_LOOKBACK_DAYS` – Optional lookback window for `/app-versions` (default: `30`)
+- `APP_VERSIONS_LIMIT` – Optional maximum app rows rendered by `/app-versions` (default: `1000`)
 
 These can be placed in a `.env` file or exported in your shell.
 
@@ -108,3 +114,23 @@ When Redis caching or the Better Stack heartbeat is enabled, run the worker proc
 (`python jobs.py`) so it refreshes fleet health on the configured interval.
 
 The legacy `GET /airflow-fleet-health` Better Stack monitor endpoint has been removed.
+
+## App versions dashboard
+
+`GET /app-versions` reads the Segment BigQuery export and shows the latest observed Apollos
+version signal per church/app/platform. It uses the analytics metadata sent by the mobile and TV
+apps, including the exported `apollos_version`, `app_version`, `app_update_id`, `bundle_id`,
+`application_name`, `church`, and `apollos_platform` fields. Roku Segment exports currently do
+not expose `apollos_version`, so Roku rows use the exported `context_library_version` and are
+labelled as analytics library versions.
+
+The page first inspects `INFORMATION_SCHEMA.COLUMNS` for the configured Segment tables and only
+queries tables that expose a supported version signal, so Segment lifecycle-only app-store
+`version` fields are not mistaken for Apollos runtime versions. Runtime rows are marked outdated
+when their latest observed runtime is behind the latest runtime observed for the same platform in
+the lookback window.
+
+To make the dashboard query live data locally, in production, or in review apps, set
+`BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64`. The value should be a base64-encoded Google service
+account JSON with BigQuery read access to `apollos-project`. Application Default Credentials are
+not used by this dashboard.

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from flask import Flask, abort, jsonify, render_template, request
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from airflow_fleet_health import AirflowFleetHealthError, evaluate_fleet_health
+from app_versions import get_app_versions_context
 from config import load_config
 from constants import ENGINEERING_TEAM_SLUG, PRIORITY_TO_SCORE
 from fleet_health_cache import (
@@ -363,6 +364,11 @@ def failing_dags_dashboard():
         threshold_ratio=payload.get("threshold_ratio"),
         total_active_dags=payload.get("active_dags_total"),
     )
+
+
+@app.route("/app-versions")
+def app_versions_dashboard():
+    return render_template("app_versions.html", **get_app_versions_context())
 
 
 def record_breakdown(

--- a/app_versions.py
+++ b/app_versions.py
@@ -1,0 +1,584 @@
+import base64
+import binascii
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from packaging.version import InvalidVersion, Version
+
+DEFAULT_BIGQUERY_ANALYTICS_PROJECT_ID = "apollos-project"
+DEFAULT_BIGQUERY_ANALYTICS_DATASETS = ("apollos", "apollos_tv", "apollos_roku")
+DEFAULT_SEGMENT_TABLES = (
+    "identifies",
+    "screens",
+    "app_became_active",
+    "app_became_backgrounded",
+    "app_became_inactive",
+)
+DEFAULT_APP_VERSIONS_LOOKBACK_DAYS = 30
+DEFAULT_APP_VERSIONS_LIMIT = 1000
+
+TIMESTAMP_COLUMN_CANDIDATES = (
+    "timestamp",
+    "received_at",
+    "sent_at",
+    "original_timestamp",
+    "loaded_at",
+)
+
+FIELD_CANDIDATES = {
+    "church": ("church", "group_id", "groupId"),
+    "apollos_platform": ("apollos_platform", "apollosPlatform", "apollosplatform"),
+    "apollos_version": ("apollos_version", "apollosVersion"),
+    "app_version": ("app_version", "appVersion"),
+    "app_update_id": ("app_update_id", "appUpdateId"),
+    "bundle_id": ("bundle_id", "bundleId"),
+    "application_name": ("application_name", "applicationName"),
+    "user_id": ("user_id", "userId"),
+    "anonymous_id": ("anonymous_id", "anonymousId"),
+}
+
+ROKU_ANALYTICS_VERSION_CANDIDATES = ("context_library_version",)
+
+
+@dataclass(frozen=True)
+class AppVersionsConfig:
+    project_id: str
+    datasets: tuple[str, ...]
+    tables: tuple[str, ...]
+    lookback_days: int
+    limit: int
+
+
+class AppVersionsError(RuntimeError):
+    pass
+
+
+def get_app_versions_context() -> dict[str, Any]:
+    config = _get_app_versions_config()
+    try:
+        rows, discovered_tables = fetch_app_versions(config)
+    except AppVersionsError as exc:
+        logging.warning("App versions query skipped: %s", exc)
+        return {
+            "status": "unavailable",
+            "status_label": "Unavailable",
+            "error_message": str(exc),
+            "rows": [],
+            "lookback_days": config.lookback_days,
+            "configured_tables": config.tables,
+            "configured_datasets": config.datasets,
+        }
+    except Exception:
+        logging.exception("App versions query failed")
+        return {
+            "status": "unavailable",
+            "status_label": "Unavailable",
+            "error_message": "Unable to query BigQuery analytics data.",
+            "rows": [],
+            "lookback_days": config.lookback_days,
+            "configured_tables": config.tables,
+            "configured_datasets": config.datasets,
+        }
+
+    return {
+        "status": "ready",
+        "status_label": "Ready",
+        "rows": rows,
+        "platform_tabs": build_platform_tabs(rows),
+        "lookback_days": config.lookback_days,
+        "configured_tables": discovered_tables,
+        "configured_datasets": config.datasets,
+    }
+
+
+def fetch_app_versions(config: AppVersionsConfig) -> tuple[list[dict[str, Any]], tuple[str, ...]]:
+    client = _build_bigquery_client(config.project_id)
+    schema_by_table = _fetch_segment_schema(client, config)
+    query, query_config = _build_app_versions_query(config, schema_by_table)
+    results = client.query(query, job_config=query_config).result()
+    rows = [_row_to_dict(row) for row in results]
+    discovered_tables = tuple(
+        f"{dataset}.{table_name}" for dataset, table_name in schema_by_table.keys()
+    )
+    return _annotate_version_status(rows), discovered_tables
+
+
+def _build_bigquery_client(project_id: str):
+    try:
+        from google.cloud import bigquery
+    except ImportError as exc:
+        raise AppVersionsError(
+            "Install google-cloud-bigquery before enabling the app versions page."
+        ) from exc
+    return bigquery.Client(project=project_id, credentials=_build_bigquery_credentials())
+
+
+def _build_bigquery_credentials() -> Any:
+    encoded_json = os.getenv("BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64", "").strip()
+    if not encoded_json:
+        raise AppVersionsError(
+            "Set BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64 to enable the app versions page."
+        )
+    try:
+        raw_json = base64.b64decode(encoded_json).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError) as exc:
+        raise AppVersionsError("Invalid BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64 value.") from exc
+
+    try:
+        service_account_info = json.loads(raw_json)
+    except json.JSONDecodeError as exc:
+        raise AppVersionsError("Invalid BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64 value.") from exc
+
+    try:
+        from google.oauth2 import service_account
+    except ImportError as exc:
+        raise AppVersionsError(
+            "Install google-auth before using BigQuery service account credentials."
+        ) from exc
+
+    return service_account.Credentials.from_service_account_info(
+        service_account_info,
+        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+    )
+
+
+def _fetch_segment_schema(
+    client: Any,
+    config: AppVersionsConfig,
+) -> dict[tuple[str, str], dict[str, str]]:
+    selects = []
+    for dataset in config.datasets:
+        schema_table = (
+            f"`{_escape_identifier(config.project_id)}."
+            f"{_escape_identifier(dataset)}.INFORMATION_SCHEMA.COLUMNS`"
+        )
+        selects.append(
+            f"""
+            SELECT
+              '{_escape_string_literal(dataset)}' AS dataset_name,
+              table_name,
+              column_name
+            FROM {schema_table}
+            WHERE table_name IN UNNEST(@table_names)
+            """
+        )
+    query = " UNION ALL ".join(selects)
+    query_config = _query_job_config(
+        [
+            _array_query_parameter("table_names", "STRING", list(config.tables)),
+        ]
+    )
+    rows = client.query(query, job_config=query_config).result()
+    schema_by_table: dict[tuple[str, str], dict[str, str]] = {}
+    for row in rows:
+        data = _row_to_dict(row)
+        dataset_name = data.get("dataset_name")
+        table_name = data.get("table_name")
+        column_name = data.get("column_name")
+        if (
+            isinstance(dataset_name, str)
+            and isinstance(table_name, str)
+            and isinstance(column_name, str)
+        ):
+            schema_by_table.setdefault((dataset_name, table_name), {})[column_name.lower()] = (
+                column_name
+            )
+
+    usable_schema = {
+        table_key: columns
+        for table_key, columns in schema_by_table.items()
+        if _choose_column(columns, TIMESTAMP_COLUMN_CANDIDATES)
+        and _choose_version_column(table_key[0], columns)[0]
+    }
+    if not usable_schema:
+        raise AppVersionsError(
+            "No configured Segment tables expose both a timestamp and supported version column."
+        )
+    return usable_schema
+
+
+def _build_app_versions_query(
+    config: AppVersionsConfig,
+    schema_by_table: dict[tuple[str, str], dict[str, str]],
+) -> tuple[str, Any]:
+    selects = []
+    for (dataset, table_name), columns in schema_by_table.items():
+        timestamp_column = _choose_column(columns, TIMESTAMP_COLUMN_CANDIDATES)
+        version_column, version_source = _choose_version_column(dataset, columns)
+        if not timestamp_column or not version_column:
+            continue
+        select_fields = [
+            f"CAST(`{timestamp_column}` AS TIMESTAMP) AS seen_at",
+            f"NULLIF(CAST(`{version_column}` AS STRING), '') AS apollos_version",
+            *[
+                _string_select_expression(columns, field_name, candidates)
+                for field_name, candidates in FIELD_CANDIDATES.items()
+                if field_name != "apollos_version"
+            ],
+            f"'{_escape_string_literal(table_name)}' AS source_table",
+            f"'{_escape_string_literal(version_source)}' AS version_source",
+        ]
+        table_ref = (
+            f"`{_escape_identifier(config.project_id)}."
+            f"{_escape_identifier(dataset)}."
+            f"{_escape_identifier(table_name)}`"
+        )
+        selects.append(
+            f"""
+            SELECT
+              {", ".join(select_fields)},
+              '{_escape_string_literal(dataset)}' AS source_dataset
+            FROM {table_ref}
+            WHERE `{timestamp_column}` >= TIMESTAMP_SUB(
+              CURRENT_TIMESTAMP(),
+              INTERVAL @lookback_days DAY
+            )
+              AND `{version_column}` IS NOT NULL
+              AND CAST(`{version_column}` AS STRING) != ''
+            """
+        )
+
+    if not selects:
+        raise AppVersionsError("No configured Segment tables can be queried for app versions.")
+
+    query = f"""
+        WITH version_events AS (
+          {" UNION ALL ".join(selects)}
+        ),
+        normalized_events AS (
+          SELECT
+            seen_at,
+            COALESCE(NULLIF(church, ''), 'Unknown church') AS church,
+            COALESCE(
+              NULLIF(apollos_platform, ''),
+              IF(source_dataset = 'apollos_roku', 'roku', NULL),
+              'unknown'
+            ) AS apollos_platform,
+            COALESCE(
+              NULLIF(application_name, ''),
+              IF(source_dataset = 'apollos_roku', 'Roku', NULL),
+              'Unknown app'
+            ) AS application_name,
+            COALESCE(
+              NULLIF(bundle_id, ''),
+              IF(source_dataset = 'apollos_roku', 'roku', NULL),
+              'unknown'
+            ) AS bundle_id,
+            apollos_version,
+            app_version,
+            app_update_id,
+            source_dataset,
+            source_table,
+            version_source,
+            user_id,
+            anonymous_id
+          FROM version_events
+          WHERE apollos_version IS NOT NULL AND apollos_version != ''
+        ),
+        latest_by_app AS (
+          SELECT
+            church,
+            apollos_platform,
+            application_name,
+            bundle_id,
+            ARRAY_AGG(
+              STRUCT(
+                apollos_version,
+                app_version,
+                app_update_id,
+                source_dataset,
+                source_table,
+                version_source,
+                seen_at
+              )
+              ORDER BY seen_at DESC
+              LIMIT 1
+            )[OFFSET(0)] AS latest,
+            COUNT(*) AS event_count,
+            COUNT(DISTINCT COALESCE(user_id, anonymous_id)) AS user_count
+          FROM normalized_events
+          GROUP BY church, apollos_platform, application_name, bundle_id
+        )
+        SELECT
+          church,
+          apollos_platform,
+          application_name,
+          bundle_id,
+          latest.apollos_version AS apollos_version,
+          latest.app_version AS app_version,
+          latest.app_update_id AS app_update_id,
+          latest.source_dataset AS source_dataset,
+          latest.source_table AS source_table,
+          latest.version_source AS version_source,
+          latest.seen_at AS latest_seen_at,
+          event_count,
+          user_count
+        FROM latest_by_app
+        ORDER BY latest_seen_at DESC
+        LIMIT @limit
+    """
+    query_config = _query_job_config(
+        [
+            _scalar_query_parameter("lookback_days", "INT64", config.lookback_days),
+            _scalar_query_parameter("limit", "INT64", config.limit),
+        ]
+    )
+    return query, query_config
+
+
+def _string_select_expression(
+    columns: dict[str, str],
+    field_name: str,
+    candidates: tuple[str, ...],
+) -> str:
+    column = _choose_column(columns, candidates)
+    if not column:
+        return f"CAST(NULL AS STRING) AS {field_name}"
+    return f"NULLIF(CAST(`{column}` AS STRING), '') AS {field_name}"
+
+
+def _annotate_version_status(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    latest_by_platform: dict[str, str] = {}
+    for row in rows:
+        platform = _string_value(row.get("apollos_platform")) or "unknown"
+        version_source = _string_value(row.get("version_source")) or "runtime"
+        if platform == "unknown" or version_source != "runtime":
+            continue
+        version = _string_value(row.get("apollos_version"))
+        if not version:
+            continue
+        current_latest = latest_by_platform.get(platform)
+        if current_latest is None or compare_versions(version, current_latest) > 0:
+            latest_by_platform[platform] = version
+
+    annotated = []
+    for row in rows:
+        updated = dict(row)
+        platform = _string_value(row.get("apollos_platform")) or "unknown"
+        version_source = _string_value(row.get("version_source")) or "runtime"
+        version = _string_value(row.get("apollos_version"))
+        latest_version = latest_by_platform.get(platform) or version
+        updated["latest_apollos_version"] = latest_version
+        is_outdated = False
+        if platform != "unknown" and version_source == "runtime" and version and latest_version:
+            is_outdated = compare_versions(version, latest_version) < 0
+        updated["is_outdated"] = is_outdated
+        updated["version_source_label"] = format_version_source_label(version_source)
+        updated["version_status_label"] = (
+            "Observed" if version_source != "runtime" else "Outdated" if is_outdated else "Current"
+        )
+        updated["version_status_class"] = (
+            "observed"
+            if version_source != "runtime"
+            else ("outdated" if is_outdated else "current")
+        )
+        updated["latest_seen_display"] = format_timestamp(row.get("latest_seen_at"))
+        annotated.append(updated)
+    annotated.sort(
+        key=lambda row: (
+            not row.get("is_outdated"),
+            str(row.get("apollos_platform") or ""),
+            str(row.get("church") or ""),
+            str(row.get("application_name") or ""),
+        )
+    )
+    return annotated
+
+
+def build_platform_tabs(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    tabs = [
+        {
+            "key": "all",
+            "label": "All",
+            "rows": rows,
+            "row_count": len(rows),
+            "outdated_count": sum(1 for row in rows if row.get("is_outdated")),
+        }
+    ]
+
+    rows_by_platform: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        platform = _string_value(row.get("apollos_platform")) or "unknown"
+        rows_by_platform.setdefault(platform, []).append(row)
+
+    for platform, platform_rows in sorted(
+        rows_by_platform.items(),
+        key=lambda item: (
+            1 if item[0] == "unknown" else 0,
+            item[0],
+        ),
+    ):
+        tabs.append(
+            {
+                "key": platform,
+                "label": format_platform_label(platform),
+                "rows": platform_rows,
+                "row_count": len(platform_rows),
+                "outdated_count": sum(1 for row in platform_rows if row.get("is_outdated")),
+            }
+        )
+    return tabs
+
+
+def format_platform_label(platform: str) -> str:
+    labels = {
+        "amazon": "Amazon",
+        "android": "Android",
+        "androidtv": "AndroidTV",
+        "ios": "iOS",
+        "roku": "Roku",
+        "tvos": "tvOS",
+        "unknown": "Unknown",
+    }
+    return labels.get(platform, platform.replace("_", " ").title())
+
+
+def format_version_source_label(version_source: str) -> str:
+    labels = {
+        "analytics_library": "Analytics library",
+        "runtime": "Runtime",
+    }
+    return labels.get(version_source, version_source.replace("_", " ").title())
+
+
+def compare_versions(left: str, right: str) -> int:
+    left_key = _version_key(left)
+    right_key = _version_key(right)
+    if left_key == right_key:
+        return 0
+    return 1 if left_key > right_key else -1
+
+
+def _version_key(value: str) -> tuple[Any, ...]:
+    normalized = value.strip().removeprefix("v")
+    try:
+        return (2, Version(normalized))
+    except InvalidVersion:
+        pass
+
+    parts: list[tuple[int, Any]] = []
+    for token in re.findall(r"\d+|[A-Za-z]+", normalized):
+        if token.isdigit():
+            parts.append((1, int(token)))
+        else:
+            parts.append((0, token.lower()))
+    return (1, tuple(parts), normalized.lower())
+
+
+def format_timestamp(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone().strftime("%Y-%m-%d %I:%M %p %Z")
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _get_app_versions_config() -> AppVersionsConfig:
+    return AppVersionsConfig(
+        project_id=os.getenv(
+            "BIGQUERY_ANALYTICS_PROJECT_ID",
+            DEFAULT_BIGQUERY_ANALYTICS_PROJECT_ID,
+        ).strip(),
+        datasets=_get_configured_datasets(),
+        tables=_get_configured_tables(),
+        lookback_days=_get_positive_int_env(
+            "APP_VERSIONS_LOOKBACK_DAYS",
+            DEFAULT_APP_VERSIONS_LOOKBACK_DAYS,
+        ),
+        limit=_get_positive_int_env("APP_VERSIONS_LIMIT", DEFAULT_APP_VERSIONS_LIMIT),
+    )
+
+
+def _get_configured_tables() -> tuple[str, ...]:
+    value = os.getenv("BIGQUERY_ANALYTICS_TABLES", "")
+    if not value.strip():
+        return DEFAULT_SEGMENT_TABLES
+    tables = tuple(table.strip() for table in value.split(",") if table.strip())
+    return tables or DEFAULT_SEGMENT_TABLES
+
+
+def _get_configured_datasets() -> tuple[str, ...]:
+    value = (
+        os.getenv("BIGQUERY_ANALYTICS_DATASETS", "").strip()
+        or os.getenv("BIGQUERY_ANALYTICS_DATASET", "").strip()
+    )
+    if not value:
+        return DEFAULT_BIGQUERY_ANALYTICS_DATASETS
+    datasets = tuple(dataset.strip() for dataset in value.split(",") if dataset.strip())
+    return datasets or DEFAULT_BIGQUERY_ANALYTICS_DATASETS
+
+
+def _get_positive_int_env(name: str, default: int) -> int:
+    try:
+        value = int(os.getenv(name, ""))
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _choose_column(columns: dict[str, str], candidates: tuple[str, ...]) -> str | None:
+    for candidate in candidates:
+        column = columns.get(candidate.lower())
+        if column:
+            return column
+    return None
+
+
+def _choose_version_column(dataset: str, columns: dict[str, str]) -> tuple[str | None, str]:
+    runtime_column = _choose_column(columns, FIELD_CANDIDATES["apollos_version"])
+    if runtime_column:
+        return runtime_column, "runtime"
+    if dataset == "apollos_roku":
+        analytics_column = _choose_column(columns, ROKU_ANALYTICS_VERSION_CANDIDATES)
+        if analytics_column:
+            return analytics_column, "analytics_library"
+    return None, ""
+
+
+def _row_to_dict(row: Any) -> dict[str, Any]:
+    if isinstance(row, dict):
+        return dict(row)
+    if hasattr(row, "items"):
+        return dict(row.items())
+    if hasattr(row, "keys"):
+        return {key: row[key] for key in row.keys()}
+    return dict(row)
+
+
+def _query_job_config(query_parameters: list[Any]) -> Any:
+    from google.cloud import bigquery
+
+    return bigquery.QueryJobConfig(query_parameters=query_parameters)
+
+
+def _scalar_query_parameter(name: str, field_type: str, value: Any) -> Any:
+    from google.cloud import bigquery
+
+    return bigquery.ScalarQueryParameter(name, field_type, value)
+
+
+def _array_query_parameter(name: str, field_type: str, values: list[Any]) -> Any:
+    from google.cloud import bigquery
+
+    return bigquery.ArrayQueryParameter(name, field_type, values)
+
+
+def _escape_identifier(value: str) -> str:
+    if "`" in value:
+        raise AppVersionsError("BigQuery identifiers cannot contain backticks.")
+    return value
+
+
+def _escape_string_literal(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def _string_value(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ click==8.3.3
 Flask==3.1.3
 frozenlist==1.8.0
 gql==4.0.0
+google-cloud-bigquery==3.38.0
 graphql-core==3.2.8
 gunicorn==25.3.0
 h11==0.16.0

--- a/templates/app_versions.html
+++ b/templates/app_versions.html
@@ -1,0 +1,263 @@
+{% extends "base.html" %}
+
+{% block title %}App Versions{% endblock %}
+
+{% block extra_head %}
+<style>
+  .version-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .version-status {
+    display: inline-flex;
+    padding: 0.22rem 0.65rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .version-status--ready {
+    background: rgba(46, 125, 50, 0.15);
+    color: #1b5e20;
+  }
+
+  .version-status--setup-required {
+    background: #f3d8a8;
+    color: #613700;
+    border: 1px solid #d2a054;
+  }
+
+  .version-status--unavailable,
+  .version-status--outdated {
+    background: rgba(183, 28, 28, 0.12);
+    color: #8e0000;
+  }
+
+  .version-status--current {
+    background: rgba(46, 125, 50, 0.15);
+    color: #1b5e20;
+  }
+
+  .version-status--observed {
+    background: rgba(84, 110, 122, 0.15);
+    color: #37474f;
+  }
+
+  .version-table th,
+  .version-table td {
+    white-space: nowrap;
+    vertical-align: top;
+  }
+
+  .version-table td:first-child,
+  .version-table td:nth-child(2) {
+    white-space: normal;
+  }
+
+  .version-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    border-bottom: 1px solid var(--pico-muted-border-color);
+    padding-bottom: 0.7rem;
+  }
+
+  .version-tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    width: auto;
+    margin: 0;
+    padding: 0.4rem 0.75rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--pico-color);
+    font-size: 0.9rem;
+    line-height: 1.2;
+  }
+
+  .version-tab[aria-selected="true"] {
+    border-color: var(--pico-primary);
+    background: rgba(1, 114, 173, 0.12);
+    color: var(--pico-primary);
+    font-weight: 700;
+  }
+
+  .version-tab-count {
+    color: var(--pico-muted-color);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .version-tab-alert {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.35rem;
+    height: 1.35rem;
+    padding: 0 0.35rem;
+    border-radius: 999px;
+    background: rgba(183, 28, 28, 0.12);
+    color: #8e0000;
+    font-size: 0.75rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .version-tab-panel[hidden] {
+    display: none;
+  }
+
+  .version-muted {
+    color: var(--pico-muted-color);
+    font-size: 0.9rem;
+  }
+
+  .version-empty p:last-child,
+  .version-setup p:last-child {
+    margin-bottom: 0;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<section class="version-header">
+  <div>
+    <h1>App Versions</h1>
+    <p>
+      Latest app version signals observed in Segment analytics over the last
+      {{ lookback_days }} days.
+    </p>
+  </div>
+  <span class="version-status version-status--{{ status }}">{{ status_label }}</span>
+</section>
+
+{% if status == "unavailable" %}
+  <article class="version-empty">
+    <h2>App version data is unavailable</h2>
+    <p>{{ error_message }}</p>
+    <p class="version-muted">
+      Datasets checked: {{ configured_datasets|join(", ") }}. Tables configured:
+      {{ configured_tables|join(", ") }}.
+    </p>
+  </article>
+{% elif rows %}
+  <article>
+    <div class="version-tabs" role="tablist" aria-label="Platforms">
+      {% for tab in platform_tabs %}
+        <button
+          class="version-tab"
+          id="version-tab-{{ tab.key }}"
+          type="button"
+          role="tab"
+          aria-selected="{{ 'true' if loop.first else 'false' }}"
+          aria-controls="version-panel-{{ tab.key }}"
+          data-version-tab="{{ tab.key }}"
+        >
+          {{ tab.label }}
+          <span class="version-tab-count">{{ tab.row_count }}</span>
+          {% if tab.outdated_count %}
+            <span class="version-tab-alert">{{ tab.outdated_count }}</span>
+          {% endif %}
+        </button>
+      {% endfor %}
+    </div>
+
+    {% for tab in platform_tabs %}
+      <section
+        class="version-tab-panel"
+        id="version-panel-{{ tab.key }}"
+        role="tabpanel"
+        aria-labelledby="version-tab-{{ tab.key }}"
+        {% if not loop.first %}hidden{% endif %}
+      >
+        <div class="overflow-auto">
+          <table class="version-table">
+            <thead>
+              <tr>
+                <th>Church</th>
+                <th>App</th>
+                <th>Platform</th>
+                <th>Version</th>
+                <th>Latest Version</th>
+                <th>Status</th>
+                <th>Seen</th>
+                <th>Users</th>
+                <th>Events</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in tab.rows %}
+                <tr>
+                  <td>
+                    <strong>{{ row.church }}</strong><br />
+                    <span class="version-muted">{{ row.bundle_id }}</span>
+                  </td>
+                  <td>
+                    {{ row.application_name }}<br />
+                    <span class="version-muted">App {{ row.app_version or "unknown" }}</span>
+                  </td>
+                  <td>{{ row.apollos_platform }}</td>
+                  <td>
+                    <code>{{ row.apollos_version }}</code><br />
+                    <span class="version-muted">{{ row.version_source_label or "Runtime" }}</span>
+                  </td>
+                  <td><code>{{ row.latest_apollos_version }}</code></td>
+                  <td>
+                    <span class="version-status version-status--{{ row.version_status_class or ('outdated' if row.is_outdated else 'current') }}">
+                      {{ row.version_status_label or ("Outdated" if row.is_outdated else "Current") }}
+                    </span>
+                  </td>
+                  <td>{{ row.latest_seen_display or "unknown" }}</td>
+                  <td>{{ row.user_count }}</td>
+                  <td>{{ row.event_count }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    {% endfor %}
+    <p class="version-muted">
+      Tables checked: {{ configured_tables|join(", ") }}. Runtime rows are marked outdated
+      when their latest observed runtime is behind the latest runtime observed for the same
+      platform. Roku currently reports its analytics library version, not an Apollos runtime.
+    </p>
+  </article>
+{% else %}
+  <article class="version-empty">
+    <h2>No app versions found</h2>
+    <p>
+      No configured Segment table reported <code>apollos_version</code> during the selected
+      lookback window.
+    </p>
+    <p class="version-muted">
+      Datasets checked: {{ configured_datasets|join(", ") }}. Tables checked:
+      {{ configured_tables|join(", ") }}.
+    </p>
+  </article>
+{% endif %}
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+  for (const tab of document.querySelectorAll('[data-version-tab]')) {
+    tab.addEventListener('click', () => {
+      const selectedKey = tab.dataset.versionTab;
+      for (const candidate of document.querySelectorAll('[data-version-tab]')) {
+        candidate.setAttribute('aria-selected', String(candidate === tab));
+      }
+      for (const panel of document.querySelectorAll('.version-tab-panel')) {
+        panel.hidden = panel.id !== `version-panel-${selectedKey}`;
+      }
+    });
+  }
+</script>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,6 +23,7 @@
         </ul>
         <ul>
           <li><a href="{{ url_for('team') }}">Engineering Teams</a></li>
+          <li><a href="{{ url_for('app_versions_dashboard') }}">App Versions</a></li>
         </ul>
         {% block header_nav %}{% endblock %}
       </nav>
@@ -35,6 +36,9 @@
           <ul>
             <li>
               <a href="{{ url_for('failing_dags_dashboard') }}">Failing DAGs</a>
+            </li>
+            <li>
+              <a href="{{ url_for('app_versions_dashboard') }}">App Versions</a>
             </li>
             <li>
               <a href="https://differential-ka.sentry.io/issues" target="_blank" rel="noopener noreferrer">Sentry Issues</a>

--- a/tests/test_app_versions.py
+++ b/tests/test_app_versions.py
@@ -1,0 +1,345 @@
+import base64
+import sys
+import types
+import unittest
+from datetime import datetime, timezone
+from typing import Any, cast
+from unittest.mock import patch
+
+
+def _install_import_shims() -> None:
+    dotenv_module = cast(Any, types.ModuleType("dotenv"))
+    dotenv_module.load_dotenv = lambda *args, **kwargs: None
+    sys.modules.setdefault("dotenv", dotenv_module)
+
+    requests_module = cast(Any, types.ModuleType("requests"))
+    requests_module.RequestException = Exception
+    requests_module.HTTPError = Exception
+
+    class DummySession:
+        def __init__(self):
+            self.headers = {}
+
+    requests_module.Session = DummySession
+    requests_module.get = lambda *args, **kwargs: None
+    sys.modules.setdefault("requests", requests_module)
+
+    gql_module = cast(Any, types.ModuleType("gql"))
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            self.requests = []
+
+        def execute(self, request, **kwargs):
+            self.requests.append(request)
+            return {}
+
+    class DummyGraphQLRequest:
+        def __init__(self, request, *, variable_values=None, operation_name=None):
+            self.request = request
+            self.variable_values = variable_values
+            self.operation_name = operation_name
+
+    gql_module.Client = DummyClient
+    gql_module.GraphQLRequest = DummyGraphQLRequest
+    gql_module.gql = lambda query: query
+    sys.modules.setdefault("gql", gql_module)
+    sys.modules.setdefault("gql.transport", types.ModuleType("gql.transport"))
+
+    aiohttp_module = cast(Any, types.ModuleType("gql.transport.aiohttp"))
+    aiohttp_module.AIOHTTPTransport = lambda *args, **kwargs: None
+    sys.modules.setdefault("gql.transport.aiohttp", aiohttp_module)
+
+
+_install_import_shims()
+
+import app as app_module  # noqa: E402
+import app_versions  # noqa: E402
+
+
+class AppVersionsContextTest(unittest.TestCase):
+    def test_default_config_targets_apollos_bigquery_datasets(self):
+        with patch.dict(app_versions.os.environ, {}, clear=False):
+            for env_name in (
+                "BIGQUERY_ANALYTICS_PROJECT_ID",
+                "BIGQUERY_ANALYTICS_DATASET",
+                "BIGQUERY_ANALYTICS_DATASETS",
+                "BIGQUERY_ANALYTICS_TABLES",
+            ):
+                app_versions.os.environ.pop(env_name, None)
+
+            config = app_versions._get_app_versions_config()
+
+        self.assertEqual(config.project_id, "apollos-project")
+        self.assertEqual(config.datasets, ("apollos", "apollos_tv", "apollos_roku"))
+        self.assertIn("app_became_active", config.tables)
+        self.assertIn("identifies", config.tables)
+        self.assertEqual(config.limit, 1000)
+
+    def test_builds_bigquery_credentials_from_base64_service_account_json(self):
+        credentials = object()
+        service_account_json = base64.b64encode(
+            b'{"client_email":"bigquery-reader@example.com","token_uri":"https://oauth2.googleapis.com/token"}'
+        ).decode("ascii")
+
+        with patch.dict(
+            app_versions.os.environ,
+            {"BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64": service_account_json},
+            clear=False,
+        ):
+            with patch(
+                "google.oauth2.service_account.Credentials.from_service_account_info",
+                return_value=credentials,
+            ) as build_credentials:
+                result = app_versions._build_bigquery_credentials()
+
+        self.assertIs(result, credentials)
+        args, kwargs = build_credentials.call_args
+        self.assertEqual(args[0]["client_email"], "bigquery-reader@example.com")
+        self.assertEqual(kwargs["scopes"], ["https://www.googleapis.com/auth/cloud-platform"])
+
+    def test_bigquery_credentials_require_service_account_json(self):
+        with patch.dict(
+            app_versions.os.environ,
+            {
+                "BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64": "",
+            },
+            clear=False,
+        ):
+            with self.assertRaisesRegex(
+                app_versions.AppVersionsError,
+                "Set BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64",
+            ):
+                app_versions._build_bigquery_credentials()
+
+    def test_annotates_outdated_apps_by_platform_latest_runtime(self):
+        rows = [
+            {
+                "church": "one-church",
+                "apollos_platform": "ios",
+                "application_name": "One Church",
+                "bundle_id": "com.one",
+                "apollos_version": "97",
+                "version_source": "runtime",
+                "latest_seen_at": datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc),
+            },
+            {
+                "church": "two-church",
+                "apollos_platform": "ios",
+                "application_name": "Two Church",
+                "bundle_id": "com.two",
+                "apollos_version": "101",
+                "version_source": "runtime",
+                "latest_seen_at": datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
+            },
+            {
+                "church": "tv-church",
+                "apollos_platform": "tvos",
+                "application_name": "TV Church",
+                "bundle_id": "com.tv",
+                "apollos_version": "1.0.0",
+                "version_source": "runtime",
+                "latest_seen_at": datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
+            },
+            {
+                "church": "unknown-platform",
+                "apollos_platform": "unknown",
+                "application_name": "Unknown Platform",
+                "bundle_id": "com.unknown",
+                "apollos_version": "8.2.13",
+                "version_source": "runtime",
+                "latest_seen_at": datetime(2026, 5, 4, 12, 0, tzinfo=timezone.utc),
+            },
+            {
+                "church": "roku-church",
+                "apollos_platform": "roku",
+                "application_name": "Roku",
+                "bundle_id": "roku",
+                "apollos_version": "2.0.0",
+                "version_source": "analytics_library",
+                "latest_seen_at": datetime(2026, 5, 4, 12, 0, tzinfo=timezone.utc),
+            },
+        ]
+
+        annotated = app_versions._annotate_version_status(rows)
+
+        one_church = next(row for row in annotated if row["church"] == "one-church")
+        two_church = next(row for row in annotated if row["church"] == "two-church")
+        tv_church = next(row for row in annotated if row["church"] == "tv-church")
+        unknown_platform = next(row for row in annotated if row["church"] == "unknown-platform")
+        roku_church = next(row for row in annotated if row["church"] == "roku-church")
+        self.assertTrue(one_church["is_outdated"])
+        self.assertEqual(one_church["latest_apollos_version"], "101")
+        self.assertEqual(one_church["version_source_label"], "Runtime")
+        self.assertFalse(two_church["is_outdated"])
+        self.assertFalse(tv_church["is_outdated"])
+        self.assertFalse(unknown_platform["is_outdated"])
+        self.assertEqual(unknown_platform["latest_apollos_version"], "8.2.13")
+        self.assertFalse(roku_church["is_outdated"])
+        self.assertEqual(roku_church["version_source_label"], "Analytics library")
+        self.assertEqual(roku_church["version_status_label"], "Observed")
+        self.assertEqual(annotated[0]["church"], "one-church")
+
+    def test_builds_platform_tabs_with_outdated_counts(self):
+        rows = [
+            {"apollos_platform": "ios", "is_outdated": True},
+            {"apollos_platform": "ios", "is_outdated": False},
+            {"apollos_platform": "android", "is_outdated": False},
+            {"apollos_platform": "androidtv", "is_outdated": False},
+            {"apollos_platform": "unknown", "is_outdated": False},
+        ]
+
+        tabs = app_versions.build_platform_tabs(rows)
+
+        self.assertEqual(
+            [tab["key"] for tab in tabs],
+            ["all", "android", "androidtv", "ios", "unknown"],
+        )
+        self.assertEqual(tabs[0]["row_count"], 5)
+        self.assertEqual(tabs[0]["outdated_count"], 1)
+        ios_tab = next(tab for tab in tabs if tab["key"] == "ios")
+        self.assertEqual(ios_tab["label"], "iOS")
+        self.assertEqual(ios_tab["row_count"], 2)
+        self.assertEqual(ios_tab["outdated_count"], 1)
+        androidtv_tab = next(tab for tab in tabs if tab["key"] == "androidtv")
+        self.assertEqual(androidtv_tab["label"], "AndroidTV")
+
+    def test_builds_query_from_discovered_segment_columns(self):
+        config = app_versions.AppVersionsConfig(
+            project_id="analytics-project",
+            datasets=("apollos", "apollos_tv"),
+            tables=("tracks", "identifies"),
+            lookback_days=14,
+            limit=50,
+        )
+        schema = {
+            ("apollos", "tracks"): {
+                "timestamp": "timestamp",
+                "church": "church",
+                "apollos_version": "apollos_version",
+                "app_version": "app_version",
+                "bundle_id": "bundle_id",
+                "application_name": "application_name",
+                "apollos_platform": "apollos_platform",
+            },
+            ("apollos_tv", "identifies"): {
+                "received_at": "received_at",
+                "groupid": "groupId",
+                "apollosversion": "apollosVersion",
+                "appversion": "appVersion",
+            },
+            ("apollos_roku", "identifies"): {
+                "timestamp": "timestamp",
+                "church": "church",
+                "apollosplatform": "apollosplatform",
+                "context_library_version": "context_library_version",
+            },
+        }
+
+        with patch.object(app_versions, "_query_job_config", side_effect=lambda params: params):
+            with patch.object(
+                app_versions,
+                "_scalar_query_parameter",
+                side_effect=lambda name, field_type, value: (name, field_type, value),
+            ):
+                query, query_config = app_versions._build_app_versions_query(config, schema)
+
+        self.assertIn("`analytics-project.apollos.tracks`", query)
+        self.assertIn("`analytics-project.apollos_tv.identifies`", query)
+        self.assertIn("`analytics-project.apollos_roku.identifies`", query)
+        self.assertIn("NULLIF(CAST(`apollos_version` AS STRING), '') AS apollos_version", query)
+        self.assertIn("NULLIF(CAST(`apollosVersion` AS STRING), '') AS apollos_version", query)
+        self.assertIn(
+            "NULLIF(CAST(`context_library_version` AS STRING), '') AS apollos_version",
+            query,
+        )
+        self.assertIn("NULLIF(CAST(`groupId` AS STRING), '') AS church", query)
+        self.assertIn("'analytics_library' AS version_source", query)
+        self.assertIn("TIMESTAMP_SUB(", query)
+        self.assertIn("INTERVAL @lookback_days DAY", query)
+        self.assertEqual(
+            query_config,
+            [("lookback_days", "INT64", 14), ("limit", "INT64", 50)],
+        )
+
+
+class AppVersionsRouteTest(unittest.TestCase):
+    def setUp(self):
+        self.client = app_module.app.test_client()
+
+    def test_app_versions_route_honors_forwarded_prefix_for_links(self):
+        context = {
+            "status": "unavailable",
+            "status_label": "Unavailable",
+            "error_message": "Unable to query BigQuery analytics data.",
+            "rows": [],
+            "platform_tabs": [],
+            "lookback_days": 30,
+            "configured_datasets": ("apollos", "apollos_tv"),
+            "configured_tables": ("identifies", "screens", "app_became_active"),
+        }
+
+        with patch.object(app_module, "get_app_versions_context", return_value=context):
+            response = self.client.get("/app-versions", headers={"X-Forwarded-Prefix": "/grid"})
+
+        body = response.get_data(as_text=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("App Versions", body)
+        self.assertIn("App version data is unavailable", body)
+        self.assertIn('href="/grid/app-versions"', body)
+        self.assertIn('href="/grid/team"', body)
+
+    def test_app_versions_route_renders_platform_tabs(self):
+        rows = [
+            {
+                "church": "one-church",
+                "bundle_id": "com.one",
+                "application_name": "One Church",
+                "app_version": "1.0.0",
+                "apollos_platform": "ios",
+                "apollos_version": "97",
+                "latest_apollos_version": "101",
+                "is_outdated": True,
+                "latest_seen_display": "2026-05-12 10:00 AM EDT",
+                "user_count": 5,
+                "event_count": 10,
+            },
+            {
+                "church": "two-church",
+                "bundle_id": "com.two",
+                "application_name": "Two Church",
+                "app_version": "1.0.0",
+                "apollos_platform": "android",
+                "apollos_version": "97",
+                "latest_apollos_version": "97",
+                "is_outdated": False,
+                "latest_seen_display": "2026-05-12 10:00 AM EDT",
+                "user_count": 7,
+                "event_count": 12,
+            },
+        ]
+        context = {
+            "status": "ready",
+            "status_label": "Ready",
+            "rows": rows,
+            "platform_tabs": app_versions.build_platform_tabs(rows),
+            "lookback_days": 30,
+            "configured_datasets": ("apollos", "apollos_tv"),
+            "configured_tables": ("apollos.identifies", "apollos_tv.identifies"),
+        }
+
+        with patch.object(app_module, "get_app_versions_context", return_value=context):
+            response = self.client.get("/app-versions")
+
+        body = response.get_data(as_text=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('role="tablist"', body)
+        self.assertIn('data-version-tab="ios"', body)
+        self.assertIn('data-version-tab="android"', body)
+        self.assertIn('id="version-panel-ios"', body)
+        self.assertIn("One Church", body)
+        self.assertIn("Two Church", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `/app-versions`, a Flask dashboard for latest observed app version signals from Segment BigQuery exports.
- Adds platform tabs for Amazon, Android, AndroidTV, iOS, Roku, tvOS, and Unknown.
- Requires BigQuery auth from `BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64`; no ADC fallback is used.
- Documents BigQuery config and adds unit coverage for query generation, tabs, route rendering, and service-account auth parsing.

## Production / review app setup

No credentials are committed in this PR.

For Heroku production and review apps, set `BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64` to a base64-encoded Google service-account JSON with BigQuery read access to `apollos-project` datasets `apollos`, `apollos_tv`, and `apollos_roku`.

Heroku review-app settings for the `bug-board` pipeline are enabled for autodeploy, autodestroy, and wait for CI. Non-secret BigQuery defaults are configured in pipeline review-app config vars via the Heroku Platform API, so `app.json` is not needed for this repo.

`BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64` is now configured for local `.env`, Heroku production (`apollos-bug-board`), this PR review app, Heroku review-app pipeline config vars, and GitHub Actions.

Review app: https://bug-board-codex-app-ver-l7hlki.herokuapp.com/app-versions

## Validation

- `ruff format .`
- `ruff check .`
- `mypy .`
- `python -m unittest discover -s tests -p 'test_*.py'`
- Local BigQuery validation with the service-account base64 env returned `status=ready` and platform tabs: All 366, AndroidTV 22, Roku 11.
- Heroku review app `/app-versions` returned Ready state with `data-version-tab="androidtv"` and `data-version-tab="roku"`.
- GitHub checks are green: CI (`ruff`, `vulture`, `mypy`, `unit-tests`, `gunicorn-smoke`) and CodeQL.
