### PR TITLE
[codex] Fix app version runtime selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ python -m unittest discover -s tests -p 'test_*.py'
 - `BIGQUERY_ANALYTICS_DATASETS` – Optional comma-separated BigQuery datasets containing Segment export tables (default: `apollos,apollos_tv,apollos_roku`)
 - `BIGQUERY_ANALYTICS_TABLES` – Optional comma-separated Segment tables to inspect for app runtime versions (default: `identifies,screens,app_became_active,app_became_backgrounded,app_became_inactive`)
 - `BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64` – Base64-encoded Google service account JSON for BigQuery access
-- `APP_VERSIONS_LOOKBACK_DAYS` – Optional lookback window for `/app-versions` (default: `30`)
-- `APP_VERSIONS_LIMIT` – Optional maximum app rows rendered by `/app-versions` (default: `1000`)
+- `APP_VERSIONS_LOOKBACK_DAYS` – Optional lookback window for `/apps` (default: `30`)
+- `APP_VERSIONS_LIMIT` – Optional maximum app rows rendered by `/apps` (default: `1000`)
 
 These can be placed in a `.env` file or exported in your shell.
 
@@ -115,22 +115,30 @@ When Redis caching or the Better Stack heartbeat is enabled, run the worker proc
 
 The legacy `GET /airflow-fleet-health` Better Stack monitor endpoint has been removed.
 
-## App versions dashboard
+## Apps dashboard
 
-`GET /app-versions` reads the Segment BigQuery export and shows the latest observed Apollos
+`GET /apps` reads the Segment BigQuery export and shows the highest observed Apollos
 version signal per church/app/platform. It uses the analytics metadata sent by the mobile and TV
 apps, including the exported `apollos_version`, `app_version`, `app_update_id`, `bundle_id`,
-`application_name`, `church`, and `apollos_platform` fields. Roku Segment exports currently do
-not expose `apollos_version`, so Roku rows use the exported `context_library_version` and are
-labelled as analytics library versions.
+`application_name`, `church`, and `apollos_platform` fields. Public App Store versions are also
+looked up by bundle ID when available so iOS rows can distinguish the observed installed app
+version from the current production App Store version. Roku Segment exports currently do not expose
+`apollos_version`, so Roku rows use the exported `context_library_version` and are labelled as
+analytics library versions.
 
 The page first inspects `INFORMATION_SCHEMA.COLUMNS` for the configured Segment tables and only
 queries tables that expose a supported version signal, so Segment lifecycle-only app-store
 `version` fields are not mistaken for Apollos runtime versions. Runtime rows are marked outdated
-when their latest observed runtime is behind the latest runtime observed for the same platform in
-the lookback window.
+when their highest observed runtime is behind the highest runtime observed for the same platform in
+the lookback window, or when the observed app version is behind an available App Store version. If
+older clients are still active after a release, the dashboard keeps the highest observed runtime for
+the app instead of letting the most recent older-client event hide it. Mobile rows prefer the
+`apollos` Segment dataset, TV rows prefer `apollos_tv`, and Roku rows prefer `apollos_roku` so the
+same app event is not counted twice when Segment exports overlap.
 
 To make the dashboard query live data locally, in production, or in review apps, set
 `BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64`. The value should be a base64-encoded Google service
 account JSON with BigQuery read access to `apollos-project`. Application Default Credentials are
 not used by this dashboard.
+
+The legacy `/app-versions` URL renders the same dashboard for compatibility with existing links.

--- a/app.py
+++ b/app.py
@@ -366,9 +366,14 @@ def failing_dags_dashboard():
     )
 
 
+@app.route("/apps")
+def apps_dashboard():
+    return render_template("app_versions.html", **get_app_versions_context())
+
+
 @app.route("/app-versions")
 def app_versions_dashboard():
-    return render_template("app_versions.html", **get_app_versions_context())
+    return apps_dashboard()
 
 
 def record_breakdown(

--- a/app_versions.py
+++ b/app_versions.py
@@ -4,10 +4,12 @@ import json
 import logging
 import os
 import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
+import requests
 from packaging.version import InvalidVersion, Version
 
 DEFAULT_BIGQUERY_ANALYTICS_PROJECT_ID = "apollos-project"
@@ -21,6 +23,10 @@ DEFAULT_SEGMENT_TABLES = (
 )
 DEFAULT_APP_VERSIONS_LOOKBACK_DAYS = 30
 DEFAULT_APP_VERSIONS_LIMIT = 1000
+APP_STORE_LOOKUP_URL = "https://itunes.apple.com/lookup"
+APP_STORE_LOOKUP_LIMIT = 24
+APP_STORE_LOOKUP_TIMEOUT_SECONDS = 5
+APP_STORE_LOOKUP_WORKERS = 8
 
 TIMESTAMP_COLUMN_CANDIDATES = (
     "timestamp",
@@ -102,10 +108,12 @@ def fetch_app_versions(config: AppVersionsConfig) -> tuple[list[dict[str, Any]],
     query, query_config = _build_app_versions_query(config, schema_by_table)
     results = client.query(query, job_config=query_config).result()
     rows = [_row_to_dict(row) for row in results]
+    latest_rows = _select_latest_observed_versions(rows)
+    latest_rows = _enrich_app_store_versions(latest_rows)
     discovered_tables = tuple(
         f"{dataset}.{table_name}" for dataset, table_name in schema_by_table.keys()
     )
-    return _annotate_version_status(rows), discovered_tables
+    return _annotate_version_status(latest_rows)[: config.limit], discovered_tables
 
 
 def _build_bigquery_client(project_id: str):
@@ -257,6 +265,7 @@ def _build_app_versions_query(
             COALESCE(
               NULLIF(apollos_platform, ''),
               IF(source_dataset = 'apollos_roku', 'roku', NULL),
+              IF(source_dataset = 'apollos_tv', 'tv', NULL),
               'unknown'
             ) AS apollos_platform,
             COALESCE(
@@ -280,53 +289,102 @@ def _build_app_versions_query(
           FROM version_events
           WHERE apollos_version IS NOT NULL AND apollos_version != ''
         ),
-        latest_by_app AS (
+        filtered_events AS (
+          SELECT *
+          FROM normalized_events
+          WHERE
+            source_dataset = 'apollos_roku'
+            OR (
+              source_dataset = 'apollos_tv'
+              AND apollos_platform IN ('amazon', 'androidtv', 'tvos', 'tv')
+            )
+            OR (
+              source_dataset = 'apollos'
+              AND apollos_platform NOT IN ('amazon', 'androidtv', 'tvos', 'tv', 'roku')
+            )
+            OR source_dataset NOT IN ('apollos', 'apollos_tv', 'apollos_roku')
+        ),
+        app_identity_events AS (
           SELECT
-            church,
-            apollos_platform,
-            application_name,
-            bundle_id,
+            *,
+            IF(
+              LOWER(bundle_id) IN ('unknown', 'roku'),
+              CONCAT(church, '|', apollos_platform, '|', LOWER(bundle_id)),
+              CONCAT(apollos_platform, '|', LOWER(bundle_id))
+            ) AS app_identity_key
+          FROM filtered_events
+        ),
+        display_churches AS (
+          SELECT
+            app_identity_key,
             ARRAY_AGG(
-              STRUCT(
-                apollos_version,
-                app_version,
-                app_update_id,
-                source_dataset,
-                source_table,
-                version_source,
-                seen_at
-              )
-              ORDER BY seen_at DESC
+              church
+              ORDER BY IF(church = 'Unknown church', 1, 0), church
               LIMIT 1
-            )[OFFSET(0)] AS latest,
+            )[OFFSET(0)] AS church
+          FROM app_identity_events
+          GROUP BY app_identity_key
+        ),
+        version_observations AS (
+          SELECT
+            events.app_identity_key,
+            display_churches.church,
+            events.apollos_platform,
+            events.application_name,
+            events.bundle_id,
+            events.apollos_version,
+            events.app_version,
+            events.app_update_id,
+            events.source_dataset,
+            events.source_table,
+            events.version_source,
+            MAX(events.seen_at) AS latest_seen_at,
+            COUNT(*) AS version_event_count
+          FROM app_identity_events events
+          JOIN display_churches
+            USING (app_identity_key)
+          GROUP BY
+            events.app_identity_key,
+            display_churches.church,
+            events.apollos_platform,
+            events.application_name,
+            events.bundle_id,
+            events.apollos_version,
+            events.app_version,
+            events.app_update_id,
+            events.source_dataset,
+            events.source_table,
+            events.version_source
+        ),
+        app_totals AS (
+          SELECT
+            app_identity_key,
             COUNT(*) AS event_count,
             COUNT(DISTINCT COALESCE(user_id, anonymous_id)) AS user_count
-          FROM normalized_events
-          GROUP BY church, apollos_platform, application_name, bundle_id
+          FROM app_identity_events
+          GROUP BY app_identity_key
         )
         SELECT
-          church,
-          apollos_platform,
-          application_name,
-          bundle_id,
-          latest.apollos_version AS apollos_version,
-          latest.app_version AS app_version,
-          latest.app_update_id AS app_update_id,
-          latest.source_dataset AS source_dataset,
-          latest.source_table AS source_table,
-          latest.version_source AS version_source,
-          latest.seen_at AS latest_seen_at,
-          event_count,
-          user_count
-        FROM latest_by_app
-        ORDER BY latest_seen_at DESC
-        LIMIT @limit
+          observation.church,
+          observation.apollos_platform,
+          observation.application_name,
+          observation.bundle_id,
+          observation.apollos_version,
+          observation.app_version,
+          observation.app_update_id,
+          observation.source_dataset,
+          observation.source_table,
+          observation.version_source,
+          observation.latest_seen_at,
+          totals.event_count,
+          totals.user_count
+        FROM version_observations observation
+        JOIN app_totals totals
+          USING (app_identity_key)
+        ORDER BY observation.latest_seen_at DESC
     """
     query_config = _query_job_config(
-        [
-            _scalar_query_parameter("lookback_days", "INT64", config.lookback_days),
-            _scalar_query_parameter("limit", "INT64", config.limit),
-        ]
+        [_scalar_query_parameter("lookback_days", "INT64", config.lookback_days)]
     )
     return query, query_config
 
@@ -364,9 +422,25 @@ def _annotate_version_status(rows: list[dict[str, Any]]) -> list[dict[str, Any]]
         version = _string_value(row.get("apollos_version"))
         latest_version = latest_by_platform.get(platform) or version
         updated["latest_apollos_version"] = latest_version
-        is_outdated = False
+        observed_app_version = _string_value(row.get("app_version"))
+        latest_app_version = _string_value(row.get("latest_app_version")) or observed_app_version
+        latest_app_version_source = (
+            _string_value(row.get("latest_app_version_source")) or "observed"
+        )
+        updated["latest_app_version"] = latest_app_version
+        updated["latest_app_version_source"] = latest_app_version_source
+        updated["latest_app_version_source_label"] = format_app_version_source_label(
+            latest_app_version_source
+        )
+        is_runtime_outdated = False
         if platform != "unknown" and version_source == "runtime" and version and latest_version:
-            is_outdated = compare_versions(version, latest_version) < 0
+            is_runtime_outdated = compare_versions(version, latest_version) < 0
+        is_app_version_outdated = False
+        if observed_app_version and latest_app_version:
+            is_app_version_outdated = compare_versions(observed_app_version, latest_app_version) < 0
+        is_outdated = is_runtime_outdated or is_app_version_outdated
+        updated["is_runtime_outdated"] = is_runtime_outdated
+        updated["is_app_version_outdated"] = is_app_version_outdated
         updated["is_outdated"] = is_outdated
         updated["version_source_label"] = format_version_source_label(version_source)
         updated["version_status_label"] = (
@@ -388,6 +462,150 @@ def _annotate_version_status(rows: list[dict[str, Any]]) -> list[dict[str, Any]]
         )
     )
     return annotated
+
+
+def _enrich_app_store_versions(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    bundle_ids = list(
+        dict.fromkeys(
+            bundle_id
+            for row in rows
+            if (bundle_id := _string_value(row.get("bundle_id")))
+            and _should_lookup_app_store_version(row)
+        )
+    )
+    lookup_bundle_ids = bundle_ids[:APP_STORE_LOOKUP_LIMIT]
+    if len(bundle_ids) > APP_STORE_LOOKUP_LIMIT:
+        logging.warning(
+            "Skipping App Store lookup for %s iOS bundle IDs over the %s-bundle limit.",
+            len(bundle_ids) - APP_STORE_LOOKUP_LIMIT,
+            APP_STORE_LOOKUP_LIMIT,
+        )
+    app_store_versions: dict[str, dict[str, Any]] = {}
+    if lookup_bundle_ids:
+        try:
+            app_store_versions = _fetch_app_store_versions(lookup_bundle_ids)
+        except requests.RequestException as exc:
+            logging.warning("App Store version lookup failed: %s", exc)
+        except ValueError as exc:
+            logging.warning("App Store version lookup returned invalid JSON: %s", exc)
+
+    enriched = []
+    for row in rows:
+        updated = dict(row)
+        bundle_id = _string_value(row.get("bundle_id"))
+        store_version = (
+            app_store_versions.get(bundle_id or "")
+            if _should_lookup_app_store_version(row)
+            else None
+        )
+        if store_version and (version := _string_value(store_version.get("version"))):
+            updated["latest_app_version"] = version
+            updated["latest_app_version_source"] = "app_store"
+            updated["latest_app_version_seen_at"] = store_version.get("currentVersionReleaseDate")
+            updated["latest_app_name"] = store_version.get("trackName")
+        else:
+            updated["latest_app_version"] = _string_value(row.get("app_version"))
+            updated["latest_app_version_source"] = "observed"
+        enriched.append(updated)
+    return enriched
+
+
+def _fetch_app_store_versions(bundle_ids: list[str]) -> dict[str, dict[str, Any]]:
+    app_store_versions: dict[str, dict[str, Any]] = {}
+    max_workers = min(APP_STORE_LOOKUP_WORKERS, len(bundle_ids))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_by_bundle_id = {
+            executor.submit(_fetch_app_store_version, bundle_id): bundle_id
+            for bundle_id in bundle_ids
+        }
+        for future in as_completed(future_by_bundle_id):
+            bundle_id = future_by_bundle_id[future]
+            try:
+                result = future.result()
+            except (requests.RequestException, ValueError) as exc:
+                logging.warning("App Store version lookup failed for %s: %s", bundle_id, exc)
+                continue
+            if result:
+                app_store_versions[result["bundleId"]] = result
+    return app_store_versions
+
+
+def _fetch_app_store_version(bundle_id: str) -> dict[str, Any] | None:
+    response = requests.get(
+        APP_STORE_LOOKUP_URL,
+        params={
+            "bundleId": bundle_id,
+            "country": "us",
+        },
+        timeout=APP_STORE_LOOKUP_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    for result in payload.get("results", []):
+        if not isinstance(result, dict):
+            continue
+        fetched_bundle_id = _string_value(result.get("bundleId"))
+        version = _string_value(result.get("version"))
+        if fetched_bundle_id and version:
+            return {**result, "bundleId": fetched_bundle_id}
+    return None
+
+
+def _should_lookup_app_store_version(row: dict[str, Any]) -> bool:
+    platform = (_string_value(row.get("apollos_platform")) or "").lower()
+    bundle_id = _string_value(row.get("bundle_id")) or ""
+    normalized = bundle_id.lower()
+    if platform != "ios":
+        return False
+    return "." in normalized and normalized not in {"unknown", "roku"}
+
+
+def _select_latest_observed_versions(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    latest_by_app: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for row in rows:
+        key = _app_identity_key(row)
+        current = latest_by_app.get(key)
+        if current is None or _is_newer_observed_version(row, current):
+            latest_by_app[key] = row
+    return list(latest_by_app.values())
+
+
+def _app_identity_key(row: dict[str, Any]) -> tuple[str, str, str]:
+    church = _string_value(row.get("church")) or "Unknown church"
+    platform = _string_value(row.get("apollos_platform")) or "unknown"
+    bundle_id = (_string_value(row.get("bundle_id")) or "unknown").lower()
+    if bundle_id in {"unknown", "roku"}:
+        return church, platform, bundle_id
+    return "", platform, bundle_id
+
+
+def _is_newer_observed_version(candidate: dict[str, Any], current: dict[str, Any]) -> bool:
+    candidate_version = _string_value(candidate.get("apollos_version"))
+    current_version = _string_value(current.get("apollos_version"))
+    if candidate_version and current_version:
+        version_compare = compare_versions(candidate_version, current_version)
+        if version_compare != 0:
+            return version_compare > 0
+    elif candidate_version != current_version:
+        return bool(candidate_version)
+
+    candidate_app_version = _string_value(candidate.get("app_version"))
+    current_app_version = _string_value(current.get("app_version"))
+    if candidate_app_version and current_app_version:
+        app_version_compare = compare_versions(candidate_app_version, current_app_version)
+        if app_version_compare != 0:
+            return app_version_compare > 0
+    elif candidate_app_version != current_app_version:
+        return bool(candidate_app_version)
+
+    candidate_church = _string_value(candidate.get("church")) or "Unknown church"
+    current_church = _string_value(current.get("church")) or "Unknown church"
+    if candidate_church != current_church:
+        return current_church == "Unknown church"
+
+    return _timestamp_sort_key(candidate.get("latest_seen_at")) > _timestamp_sort_key(
+        current.get("latest_seen_at")
+    )
 
 
 def build_platform_tabs(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -432,6 +650,7 @@ def format_platform_label(platform: str) -> str:
         "androidtv": "AndroidTV",
         "ios": "iOS",
         "roku": "Roku",
+        "tv": "TV",
         "tvos": "tvOS",
         "unknown": "Unknown",
     }
@@ -442,6 +661,14 @@ def format_version_source_label(version_source: str) -> str:
     labels = {
         "analytics_library": "Analytics library",
         "runtime": "Runtime",
+    }
+    return labels.get(version_source, version_source.replace("_", " ").title())
+
+
+def format_app_version_source_label(version_source: str) -> str:
+    labels = {
+        "app_store": "App Store",
+        "observed": "Observed",
     }
     return labels.get(version_source, version_source.replace("_", " ").title())
 
@@ -478,6 +705,14 @@ def format_timestamp(value: Any) -> str | None:
     if isinstance(value, str):
         return value
     return str(value)
+
+
+def _timestamp_sort_key(value: Any) -> tuple[int, Any]:
+    if isinstance(value, datetime):
+        return (2, value.timestamp())
+    if value is None:
+        return (0, "")
+    return (1, str(value))
 
 
 def _get_app_versions_config() -> AppVersionsConfig:

--- a/templates/app_versions.html
+++ b/templates/app_versions.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}App Versions{% endblock %}
+{% block title %}Apps{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -130,10 +130,10 @@
 {% block content %}
 <section class="version-header">
   <div>
-    <h1>App Versions</h1>
+    <h1>Apps</h1>
     <p>
-      Latest app version signals observed in Segment analytics over the last
-      {{ lookback_days }} days.
+      Observed app and platform version signals from Segment over the last {{ lookback_days }} days,
+      compared with public App Store versions when available.
     </p>
   </div>
   <span class="version-status version-status--{{ status }}">{{ status_label }}</span>
@@ -141,12 +141,8 @@
 
 {% if status == "unavailable" %}
   <article class="version-empty">
-    <h2>App version data is unavailable</h2>
+    <h2>App data is unavailable</h2>
     <p>{{ error_message }}</p>
-    <p class="version-muted">
-      Datasets checked: {{ configured_datasets|join(", ") }}. Tables configured:
-      {{ configured_tables|join(", ") }}.
-    </p>
   </article>
 {% elif rows %}
   <article>
@@ -184,9 +180,10 @@
               <tr>
                 <th>Church</th>
                 <th>App</th>
+                <th>Latest App</th>
                 <th>Platform</th>
-                <th>Version</th>
-                <th>Latest Version</th>
+                <th>Observed Version</th>
+                <th>Latest Observed</th>
                 <th>Status</th>
                 <th>Seen</th>
                 <th>Users</th>
@@ -202,13 +199,16 @@
                   </td>
                   <td>
                     {{ row.application_name }}<br />
-                    <span class="version-muted">App {{ row.app_version or "unknown" }}</span>
+                    <span class="version-muted">Observed {{ row.app_version or "unknown" }}</span>
+                  </td>
+                  <td>
+                    <code>{{ row.latest_app_version or "unknown" }}</code><br />
+                    <span class="version-muted">
+                      {{ row.latest_app_version_source_label or "Observed" }}
+                    </span>
                   </td>
                   <td>{{ row.apollos_platform }}</td>
-                  <td>
-                    <code>{{ row.apollos_version }}</code><br />
-                    <span class="version-muted">{{ row.version_source_label or "Runtime" }}</span>
-                  </td>
+                  <td><code>{{ row.apollos_version }}</code></td>
                   <td><code>{{ row.latest_apollos_version }}</code></td>
                   <td>
                     <span class="version-status version-status--{{ row.version_status_class or ('outdated' if row.is_outdated else 'current') }}">
@@ -225,22 +225,13 @@
         </div>
       </section>
     {% endfor %}
-    <p class="version-muted">
-      Tables checked: {{ configured_tables|join(", ") }}. Runtime rows are marked outdated
-      when their latest observed runtime is behind the latest runtime observed for the same
-      platform. Roku currently reports its analytics library version, not an Apollos runtime.
-    </p>
   </article>
 {% else %}
   <article class="version-empty">
-    <h2>No app versions found</h2>
+    <h2>No apps found</h2>
     <p>
       No configured Segment table reported <code>apollos_version</code> during the selected
       lookback window.
-    </p>
-    <p class="version-muted">
-      Datasets checked: {{ configured_datasets|join(", ") }}. Tables checked:
-      {{ configured_tables|join(", ") }}.
     </p>
   </article>
 {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,7 +23,7 @@
         </ul>
         <ul>
           <li><a href="{{ url_for('team') }}">Engineering Teams</a></li>
-          <li><a href="{{ url_for('app_versions_dashboard') }}">App Versions</a></li>
+          <li><a href="{{ url_for('apps_dashboard') }}">Apps</a></li>
         </ul>
         {% block header_nav %}{% endblock %}
       </nav>
@@ -38,7 +38,7 @@
               <a href="{{ url_for('failing_dags_dashboard') }}">Failing DAGs</a>
             </li>
             <li>
-              <a href="{{ url_for('app_versions_dashboard') }}">App Versions</a>
+              <a href="{{ url_for('apps_dashboard') }}">Apps</a>
             </li>
             <li>
               <a href="https://differential-ka.sentry.io/issues" target="_blank" rel="noopener noreferrer">Sentry Issues</a>

--- a/tests/test_app_versions.py
+++ b/tests/test_app_versions.py
@@ -180,6 +180,284 @@ class AppVersionsContextTest(unittest.TestCase):
         self.assertEqual(roku_church["version_status_label"], "Observed")
         self.assertEqual(annotated[0]["church"], "one-church")
 
+    def test_annotates_outdated_apps_by_app_store_version(self):
+        rows = [
+            {
+                "church": "bayside",
+                "apollos_platform": "ios",
+                "application_name": "Bayside",
+                "bundle_id": "com.subsplashconsulting.Bayside-Church",
+                "apollos_version": "97",
+                "app_version": "5.20.18",
+                "latest_app_version": "5.20.30",
+                "latest_app_version_source": "app_store",
+                "version_source": "runtime",
+                "latest_seen_at": datetime(2026, 5, 12, 12, 0, tzinfo=timezone.utc),
+            },
+            {
+                "church": "red-rocks",
+                "apollos_platform": "ios",
+                "application_name": "Red Rocks",
+                "bundle_id": "com.subsplashconsulting.D4KJF4",
+                "apollos_version": "97",
+                "app_version": "18.2.22",
+                "latest_app_version": "18.2.22",
+                "latest_app_version_source": "app_store",
+                "version_source": "runtime",
+                "latest_seen_at": datetime(2026, 5, 12, 13, 0, tzinfo=timezone.utc),
+            },
+        ]
+
+        annotated = app_versions._annotate_version_status(rows)
+
+        bayside = next(row for row in annotated if row["church"] == "bayside")
+        red_rocks = next(row for row in annotated if row["church"] == "red-rocks")
+        self.assertTrue(bayside["is_outdated"])
+        self.assertFalse(bayside["is_runtime_outdated"])
+        self.assertTrue(bayside["is_app_version_outdated"])
+        self.assertEqual(bayside["latest_app_version_source_label"], "App Store")
+        self.assertFalse(red_rocks["is_outdated"])
+
+    def test_enriches_app_store_versions_by_bundle_id(self):
+        rows = [
+            {
+                "church": "bayside",
+                "apollos_platform": "ios",
+                "application_name": "Bayside",
+                "bundle_id": "com.subsplashconsulting.Bayside-Church",
+                "apollos_version": "67",
+                "app_version": "5.20.18",
+            },
+            {
+                "church": "android",
+                "apollos_platform": "android",
+                "application_name": "Android",
+                "bundle_id": "com.example.android",
+                "apollos_version": "97",
+                "app_version": "1.0.0",
+            },
+        ]
+
+        with patch.object(
+            app_versions,
+            "_fetch_app_store_versions",
+            return_value={
+                "com.subsplashconsulting.Bayside-Church": {
+                    "bundleId": "com.subsplashconsulting.Bayside-Church",
+                    "version": "5.20.30",
+                    "currentVersionReleaseDate": "2026-04-14T16:34:35Z",
+                    "trackName": "Bayside Church",
+                },
+            },
+        ) as fetch_app_store_versions:
+            enriched = app_versions._enrich_app_store_versions(rows)
+
+        fetch_app_store_versions.assert_called_once_with(["com.subsplashconsulting.Bayside-Church"])
+        bayside = next(row for row in enriched if row["church"] == "bayside")
+        android = next(row for row in enriched if row["church"] == "android")
+        self.assertEqual(bayside["latest_app_version"], "5.20.30")
+        self.assertEqual(bayside["latest_app_version_source"], "app_store")
+        self.assertEqual(bayside["latest_app_version_seen_at"], "2026-04-14T16:34:35Z")
+        self.assertEqual(android["latest_app_version"], "1.0.0")
+        self.assertEqual(android["latest_app_version_source"], "observed")
+
+    def test_limits_app_store_lookup_count(self):
+        rows = [
+            {
+                "church": f"church-{index}",
+                "apollos_platform": "ios",
+                "application_name": f"App {index}",
+                "bundle_id": f"com.example.{index}",
+                "apollos_version": "67",
+                "app_version": "1.0.0",
+            }
+            for index in range(app_versions.APP_STORE_LOOKUP_LIMIT + 1)
+        ]
+
+        with patch.object(
+            app_versions,
+            "_fetch_app_store_versions",
+            return_value={},
+        ) as fetch_app_store_versions:
+            app_versions._enrich_app_store_versions(rows)
+
+        lookup_bundle_ids = fetch_app_store_versions.call_args.args[0]
+        self.assertEqual(len(lookup_bundle_ids), app_versions.APP_STORE_LOOKUP_LIMIT)
+        self.assertNotIn(
+            f"com.example.{app_versions.APP_STORE_LOOKUP_LIMIT}",
+            lookup_bundle_ids,
+        )
+
+    def test_fetches_each_app_store_bundle_id_individually(self):
+        class Response:
+            def __init__(self, payload: dict[str, Any]):
+                self.payload = payload
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict[str, Any]:
+                return self.payload
+
+        responses = [
+            Response(
+                {
+                    "results": [
+                        {
+                            "bundleId": "com.example.one",
+                            "version": "1.2.3",
+                        },
+                    ],
+                }
+            ),
+            Response(
+                {
+                    "results": [
+                        {
+                            "bundleId": "com.example.two",
+                            "version": "2.3.4",
+                        },
+                    ],
+                }
+            ),
+        ]
+
+        with patch.object(
+            app_versions.requests,
+            "get",
+            side_effect=responses,
+        ) as get:
+            versions = app_versions._fetch_app_store_versions(
+                ["com.example.one", "com.example.two"]
+            )
+
+        self.assertEqual(versions["com.example.one"]["version"], "1.2.3")
+        self.assertEqual(versions["com.example.two"]["version"], "2.3.4")
+        self.assertEqual(get.call_count, 2)
+        self.assertCountEqual(
+            [call.kwargs["params"] for call in get.call_args_list],
+            [
+                {"bundleId": "com.example.one", "country": "us"},
+                {"bundleId": "com.example.two", "country": "us"},
+            ],
+        )
+
+    def test_selects_highest_observed_version_instead_of_most_recent_event(self):
+        rows = [
+            {
+                "church": "grow_church",
+                "apollos_platform": "android",
+                "application_name": "Grow Church",
+                "bundle_id": "com.apollos.growchurch",
+                "apollos_version": "67",
+                "app_version": "1.0.13",
+                "version_source": "runtime",
+                "latest_seen_at": datetime(2026, 5, 12, 12, 0, tzinfo=timezone.utc),
+                "event_count": 30,
+                "user_count": 10,
+            },
+            {
+                "church": "grow_church",
+                "apollos_platform": "android",
+                "application_name": "Grow Church",
+                "bundle_id": "com.apollos.growchurch",
+                "apollos_version": "97",
+                "app_version": "1.0.31",
+                "version_source": "runtime",
+                "latest_seen_at": datetime(2026, 5, 10, 12, 0, tzinfo=timezone.utc),
+                "event_count": 30,
+                "user_count": 10,
+            },
+            {
+                "church": "other_church",
+                "apollos_platform": "android",
+                "application_name": "Other Church",
+                "bundle_id": "com.apollos.other",
+                "apollos_version": "96",
+                "app_version": "2.0.0",
+                "version_source": "runtime",
+                "latest_seen_at": datetime(2026, 5, 12, 11, 0, tzinfo=timezone.utc),
+                "event_count": 12,
+                "user_count": 7,
+            },
+        ]
+
+        selected = app_versions._select_latest_observed_versions(rows)
+
+        grow_church = next(row for row in selected if row["church"] == "grow_church")
+        self.assertEqual(len(selected), 2)
+        self.assertEqual(grow_church["apollos_version"], "97")
+        self.assertEqual(grow_church["app_version"], "1.0.31")
+
+    def test_app_identity_uses_bundle_when_application_name_changes(self):
+        rows = [
+            {
+                "church": "red_rocks_church",
+                "apollos_platform": "ios",
+                "application_name": "Red Rocks Church ",
+                "bundle_id": "com.subsplashconsulting.D4KJF4",
+                "apollos_version": "65",
+                "app_version": "18.2.2",
+                "version_source": "runtime",
+                "latest_seen_at": datetime(2026, 5, 12, 7, 45, tzinfo=timezone.utc),
+                "event_count": 1996,
+                "user_count": 580,
+            },
+            {
+                "church": "red_rocks_church",
+                "apollos_platform": "ios",
+                "application_name": "Red Rocks",
+                "bundle_id": "com.subsplashconsulting.D4KJF4",
+                "apollos_version": "97",
+                "app_version": "18.2.22",
+                "version_source": "runtime",
+                "latest_seen_at": datetime(2026, 5, 12, 9, 41, tzinfo=timezone.utc),
+                "event_count": 46805,
+                "user_count": 3134,
+            },
+        ]
+
+        selected = app_versions._select_latest_observed_versions(rows)
+
+        self.assertEqual(len(selected), 1)
+        self.assertEqual(selected[0]["application_name"], "Red Rocks")
+        self.assertEqual(selected[0]["apollos_version"], "97")
+        self.assertEqual(selected[0]["app_version"], "18.2.22")
+
+    def test_app_identity_uses_bundle_when_church_is_missing(self):
+        rows = [
+            {
+                "church": "Unknown church",
+                "apollos_platform": "androidtv",
+                "application_name": "Apollos Preview",
+                "bundle_id": "com.apollos.apollospreview",
+                "apollos_version": "1.0.0",
+                "app_version": "1.0.20",
+                "version_source": "runtime",
+                "latest_seen_at": datetime(2026, 5, 12, 9, 41, tzinfo=timezone.utc),
+                "event_count": 579,
+                "user_count": 29,
+            },
+            {
+                "church": "apollos_preview",
+                "apollos_platform": "androidtv",
+                "application_name": "Apollos Preview",
+                "bundle_id": "com.apollos.apollospreview",
+                "apollos_version": "1.0.0",
+                "app_version": "1.0.20",
+                "version_source": "runtime",
+                "latest_seen_at": datetime(2026, 5, 12, 9, 41, tzinfo=timezone.utc),
+                "event_count": 113,
+                "user_count": 28,
+            },
+        ]
+
+        selected = app_versions._select_latest_observed_versions(rows)
+
+        self.assertEqual(len(selected), 1)
+        self.assertEqual(selected[0]["church"], "apollos_preview")
+        self.assertEqual(selected[0]["bundle_id"], "com.apollos.apollospreview")
+
     def test_builds_platform_tabs_with_outdated_counts(self):
         rows = [
             {"apollos_platform": "ios", "is_outdated": True},
@@ -257,9 +535,24 @@ class AppVersionsContextTest(unittest.TestCase):
         self.assertIn("'analytics_library' AS version_source", query)
         self.assertIn("TIMESTAMP_SUB(", query)
         self.assertIn("INTERVAL @lookback_days DAY", query)
+        self.assertIn("filtered_events AS", query)
+        self.assertIn("source_dataset = 'apollos_tv'", query)
+        self.assertIn("IF(source_dataset = 'apollos_tv', 'tv', NULL)", query)
+        self.assertIn("apollos_platform IN ('amazon', 'androidtv', 'tvos', 'tv')", query)
+        self.assertIn(
+            "apollos_platform NOT IN ('amazon', 'androidtv', 'tvos', 'tv', 'roku')",
+            query,
+        )
+        self.assertIn("app_identity_events AS", query)
+        self.assertIn("display_churches AS", query)
+        self.assertIn("version_observations AS", query)
+        self.assertIn("app_totals AS", query)
+        self.assertIn("MAX(events.seen_at) AS latest_seen_at", query)
+        self.assertIn("GROUP BY app_identity_key", query)
+        self.assertIn("USING (app_identity_key)", query)
         self.assertEqual(
             query_config,
-            [("lookback_days", "INT64", 14), ("limit", "INT64", 50)],
+            [("lookback_days", "INT64", 14)],
         )
 
 
@@ -267,7 +560,7 @@ class AppVersionsRouteTest(unittest.TestCase):
     def setUp(self):
         self.client = app_module.app.test_client()
 
-    def test_app_versions_route_honors_forwarded_prefix_for_links(self):
+    def test_apps_route_honors_forwarded_prefix_for_links(self):
         context = {
             "status": "unavailable",
             "status_label": "Unavailable",
@@ -280,22 +573,45 @@ class AppVersionsRouteTest(unittest.TestCase):
         }
 
         with patch.object(app_module, "get_app_versions_context", return_value=context):
-            response = self.client.get("/app-versions", headers={"X-Forwarded-Prefix": "/grid"})
+            response = self.client.get("/apps", headers={"X-Forwarded-Prefix": "/grid"})
 
         body = response.get_data(as_text=True)
         self.assertEqual(response.status_code, 200)
-        self.assertIn("App Versions", body)
-        self.assertIn("App version data is unavailable", body)
-        self.assertIn('href="/grid/app-versions"', body)
+        self.assertIn("<h1>Apps</h1>", body)
+        self.assertIn("App data is unavailable", body)
+        self.assertIn('href="/grid/apps"', body)
         self.assertIn('href="/grid/team"', body)
 
-    def test_app_versions_route_renders_platform_tabs(self):
+    def test_legacy_app_versions_route_renders_apps_dashboard(self):
+        with patch.object(
+            app_module,
+            "get_app_versions_context",
+            return_value={
+                "status": "ready",
+                "status_label": "Ready",
+                "rows": [],
+                "platform_tabs": [],
+                "lookback_days": 30,
+                "configured_datasets": ("apollos",),
+                "configured_tables": ("apollos.identifies",),
+            },
+        ):
+            response = self.client.get("/app-versions")
+
+        body = response.get_data(as_text=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("<h1>Apps</h1>", body)
+        self.assertIn("No apps found", body)
+
+    def test_apps_route_renders_platform_tabs(self):
         rows = [
             {
                 "church": "one-church",
                 "bundle_id": "com.one",
                 "application_name": "One Church",
                 "app_version": "1.0.0",
+                "latest_app_version": "1.0.1",
+                "latest_app_version_source_label": "App Store",
                 "apollos_platform": "ios",
                 "apollos_version": "97",
                 "latest_apollos_version": "101",
@@ -309,6 +625,8 @@ class AppVersionsRouteTest(unittest.TestCase):
                 "bundle_id": "com.two",
                 "application_name": "Two Church",
                 "app_version": "1.0.0",
+                "latest_app_version": "1.0.0",
+                "latest_app_version_source_label": "Observed",
                 "apollos_platform": "android",
                 "apollos_version": "97",
                 "latest_apollos_version": "97",
@@ -329,15 +647,19 @@ class AppVersionsRouteTest(unittest.TestCase):
         }
 
         with patch.object(app_module, "get_app_versions_context", return_value=context):
-            response = self.client.get("/app-versions")
+            response = self.client.get("/apps")
 
         body = response.get_data(as_text=True)
         self.assertEqual(response.status_code, 200)
+        self.assertIn("<title>Apps</title>", body)
         self.assertIn('role="tablist"', body)
         self.assertIn('data-version-tab="ios"', body)
         self.assertIn('data-version-tab="android"', body)
         self.assertIn('id="version-panel-ios"', body)
         self.assertIn("One Church", body)
+        self.assertIn("Latest App", body)
+        self.assertIn("1.0.1", body)
+        self.assertIn("App Store", body)
         self.assertIn("Two Church", body)
 
 


### PR DESCRIPTION
## Summary

Fixes the app versions dashboard so stale client events do not hide newer releases that have already been observed in Segment analytics.

## Root Cause

The dashboard query previously selected the latest event timestamp per app identity. That made a later event from an older installed app win over an earlier event from a newer release. In production BigQuery, Grow Church Android showed runtime `67` / app `1.0.13` at `2026-05-12 08:28 AM EDT`, even though runtime `97` / app `1.0.31` had already been observed at `2026-05-12 05:48 AM EDT`.

Red Rocks exposed a second identity issue: current telemetry uses application name `Red Rocks`, while older telemetry used `Red Rocks Church ` for the same bundle. Grouping by application name split one app into separate rows, leaving the older runtime `65` / app `18.2.2` visible as outdated even though runtime `97` / app `18.2.22` was current.

## Changes

- Select the highest observed runtime/app version per church/platform/bundle before status annotation.
- Aggregate event/user totals by stable bundle identity instead of application display name.
- Use source-neutral table headers (`Observed Version` / `Latest Observed`) and remove the repeated per-row runtime source subtitle.
- Document the highest-observed runtime semantics.
- Add regression coverage for the Grow Church stale-event case and the Red Rocks app-name-change case.

## Validation

- `python -m unittest tests.test_app_versions`
- `ruff check app_versions.py tests/test_app_versions.py`
- `ruff format --check app_versions.py tests/test_app_versions.py`
- `mypy app_versions.py`
- `python -m unittest discover -s tests -p 'test_*.py'`
- Queried production BigQuery via the Heroku `BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64` config and verified patched output reports Grow Church Android and Red Rocks Android/iOS as runtime `97`, status `Current`.
- Reloaded local dashboard at `http://127.0.0.1:8000/app-versions` and verified Grow Church Android is runtime `97` / app `1.0.31`, Red Rocks Android/iOS are runtime `97` / app `18.2.22`, and Android no longer has an outdated alert.
- Verified Bayside against Apple lookup and local dashboard: App Store reports `5.20.30` for `com.subsplashconsulting.Bayside-Church`; local dashboard now shows Bayside iOS as observed app `5.20.18`, latest app `5.20.30` from App Store, runtime `67`, latest runtime `97`, and keeps non-iOS App Store lookup out of Android/Amazon/tvOS counts.
- Investigated the Apollos Preview AndroidTV duplicate row: the same bundle was split between `Unknown church` and `apollos_preview`, and TV events overlapped between `apollos` and `apollos_tv`. The query now prefers platform-specific Segment datasets and collapses real bundle IDs by platform+bundle, verified locally as one `com.apollos.apollospreview` AndroidTV row.
- Reclassified the dashboard as `Apps`: the canonical local route is now `/apps`, nav/footer/page title/H1 use `Apps`, and legacy `/app-versions` still renders the same dashboard for existing links.
- Removed the dashboard table-check inventory notes from Apps; /apps renders without Tables checked, Tables configured, or Datasets checked text.
- Reloaded local dashboard at `http://127.0.0.1:8000/apps` and verified it renders `Observed Version` / `Latest Observed` with no repeated `Runtime` subtitles or old runtime headers.
- Addressed Codex review feedback: App Store lookup now fetches each iOS bundle individually, with regression coverage for multiple bundles.
- Addressed follow-up Codex review feedback: bounded/concurrent App Store lookups and preserved TV analytics rows without platform metadata.
- Reduced the App Store lookup cap to 24 so the bounded concurrent lookup phase stays below the default sync worker timeout even when Apple is slow.
- Addressed final Codex TV overlap feedback: generic apollos tv rows are excluded so apollos_tv remains the TV source of truth.