### PR TITLE
[codex] Clean up apps version dashboard

### DIFF
--- a/app_versions.py
+++ b/app_versions.py
@@ -96,6 +96,7 @@ def get_app_versions_context() -> dict[str, Any]:
         "status_label": "Ready",
         "rows": rows,
         "platform_tabs": build_platform_tabs(rows),
+        "platform_latest_versions": build_platform_latest_versions(rows),
         "lookback_days": config.lookback_days,
         "configured_tables": discovered_tables,
         "configured_datasets": config.datasets,
@@ -609,16 +610,7 @@ def _is_newer_observed_version(candidate: dict[str, Any], current: dict[str, Any
 
 
 def build_platform_tabs(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    tabs = [
-        {
-            "key": "all",
-            "label": "All",
-            "rows": rows,
-            "row_count": len(rows),
-            "outdated_count": sum(1 for row in rows if row.get("is_outdated")),
-        }
-    ]
-
+    tabs = []
     rows_by_platform: dict[str, list[dict[str, Any]]] = {}
     for row in rows:
         platform = _string_value(row.get("apollos_platform")) or "unknown"
@@ -641,6 +633,35 @@ def build_platform_tabs(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
             }
         )
     return tabs
+
+
+def build_platform_latest_versions(rows: list[dict[str, Any]]) -> list[dict[str, str]]:
+    versions_by_platform: dict[str, str] = {}
+    for row in rows:
+        platform = _string_value(row.get("apollos_platform")) or "unknown"
+        version = _string_value(row.get("latest_apollos_version")) or _string_value(
+            row.get("apollos_version")
+        )
+        if not version:
+            continue
+        current = versions_by_platform.get(platform)
+        if current is None or compare_versions(version, current) > 0:
+            versions_by_platform[platform] = version
+
+    return [
+        {
+            "key": platform,
+            "label": format_platform_label(platform),
+            "version": version,
+        }
+        for platform, version in sorted(
+            versions_by_platform.items(),
+            key=lambda item: (
+                1 if item[0] == "unknown" else 0,
+                item[0],
+            ),
+        )
+    ]
 
 
 def format_platform_label(platform: str) -> str:

--- a/templates/app_versions.html
+++ b/templates/app_versions.html
@@ -4,14 +4,6 @@
 
 {% block extra_head %}
 <style>
-  .version-header {
-    display: flex;
-    justify-content: space-between;
-    gap: 1rem;
-    align-items: flex-start;
-    flex-wrap: wrap;
-  }
-
   .version-status {
     display: inline-flex;
     padding: 0.22rem 0.65rem;
@@ -22,18 +14,6 @@
     letter-spacing: 0.04em;
   }
 
-  .version-status--ready {
-    background: rgba(46, 125, 50, 0.15);
-    color: #1b5e20;
-  }
-
-  .version-status--setup-required {
-    background: #f3d8a8;
-    color: #613700;
-    border: 1px solid #d2a054;
-  }
-
-  .version-status--unavailable,
   .version-status--outdated {
     background: rgba(183, 28, 28, 0.12);
     color: #8e0000;
@@ -67,6 +47,34 @@
     margin-bottom: 1rem;
     border-bottom: 1px solid var(--pico-muted-border-color);
     padding-bottom: 0.7rem;
+  }
+
+  .platform-latest {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+  }
+
+  .platform-latest-title {
+    color: var(--pico-muted-color);
+    font-size: 0.9rem;
+    font-weight: 700;
+  }
+
+  .platform-latest-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.6rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: 999px;
+    font-size: 0.85rem;
+  }
+
+  .platform-latest-chip code {
+    font-size: 0.85em;
   }
 
   .version-tab {
@@ -136,7 +144,6 @@
       compared with public App Store versions when available.
     </p>
   </div>
-  <span class="version-status version-status--{{ status }}">{{ status_label }}</span>
 </section>
 
 {% if status == "unavailable" %}
@@ -146,6 +153,18 @@
   </article>
 {% elif rows %}
   <article>
+    {% if platform_latest_versions %}
+      <div class="platform-latest" aria-label="Latest observed versions by platform">
+        <span class="platform-latest-title">Latest observed</span>
+        {% for platform_version in platform_latest_versions %}
+          <span class="platform-latest-chip">
+            {{ platform_version.label }}
+            <code>{{ platform_version.version }}</code>
+          </span>
+        {% endfor %}
+      </div>
+    {% endif %}
+
     <div class="version-tabs" role="tablist" aria-label="Platforms">
       {% for tab in platform_tabs %}
         <button
@@ -181,9 +200,7 @@
                 <th>Church</th>
                 <th>App</th>
                 <th>Latest App</th>
-                <th>Platform</th>
                 <th>Observed Version</th>
-                <th>Latest Observed</th>
                 <th>Status</th>
                 <th>Seen</th>
                 <th>Users</th>
@@ -207,9 +224,7 @@
                       {{ row.latest_app_version_source_label or "Observed" }}
                     </span>
                   </td>
-                  <td>{{ row.apollos_platform }}</td>
                   <td><code>{{ row.apollos_version }}</code></td>
-                  <td><code>{{ row.latest_apollos_version }}</code></td>
                   <td>
                     <span class="version-status version-status--{{ row.version_status_class or ('outdated' if row.is_outdated else 'current') }}">
                       {{ row.version_status_label or ("Outdated" if row.is_outdated else "Current") }}

--- a/tests/test_app_versions.py
+++ b/tests/test_app_versions.py
@@ -471,16 +471,33 @@ class AppVersionsContextTest(unittest.TestCase):
 
         self.assertEqual(
             [tab["key"] for tab in tabs],
-            ["all", "android", "androidtv", "ios", "unknown"],
+            ["android", "androidtv", "ios", "unknown"],
         )
-        self.assertEqual(tabs[0]["row_count"], 5)
-        self.assertEqual(tabs[0]["outdated_count"], 1)
         ios_tab = next(tab for tab in tabs if tab["key"] == "ios")
         self.assertEqual(ios_tab["label"], "iOS")
         self.assertEqual(ios_tab["row_count"], 2)
         self.assertEqual(ios_tab["outdated_count"], 1)
         androidtv_tab = next(tab for tab in tabs if tab["key"] == "androidtv")
         self.assertEqual(androidtv_tab["label"], "AndroidTV")
+
+    def test_builds_platform_latest_versions(self):
+        rows = [
+            {"apollos_platform": "ios", "latest_apollos_version": "101"},
+            {"apollos_platform": "ios", "latest_apollos_version": "97"},
+            {"apollos_platform": "android", "latest_apollos_version": "98"},
+            {"apollos_platform": "unknown", "apollos_version": "8.2.13"},
+        ]
+
+        latest_versions = app_versions.build_platform_latest_versions(rows)
+
+        self.assertEqual(
+            latest_versions,
+            [
+                {"key": "android", "label": "Android", "version": "98"},
+                {"key": "ios", "label": "iOS", "version": "101"},
+                {"key": "unknown", "label": "Unknown", "version": "8.2.13"},
+            ],
+        )
 
     def test_builds_query_from_discovered_segment_columns(self):
         config = app_versions.AppVersionsConfig(
@@ -641,6 +658,7 @@ class AppVersionsRouteTest(unittest.TestCase):
             "status_label": "Ready",
             "rows": rows,
             "platform_tabs": app_versions.build_platform_tabs(rows),
+            "platform_latest_versions": app_versions.build_platform_latest_versions(rows),
             "lookback_days": 30,
             "configured_datasets": ("apollos", "apollos_tv"),
             "configured_tables": ("apollos.identifies", "apollos_tv.identifies"),
@@ -653,14 +671,18 @@ class AppVersionsRouteTest(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("<title>Apps</title>", body)
         self.assertIn('role="tablist"', body)
+        self.assertNotIn('data-version-tab="all"', body)
         self.assertIn('data-version-tab="ios"', body)
         self.assertIn('data-version-tab="android"', body)
         self.assertIn('id="version-panel-ios"', body)
+        self.assertIn("Latest observed", body)
         self.assertIn("One Church", body)
         self.assertIn("Latest App", body)
         self.assertIn("1.0.1", body)
         self.assertIn("App Store", body)
         self.assertIn("Two Church", body)
+        self.assertNotIn("<th>Platform</th>", body)
+        self.assertNotIn("<th>Latest Observed</th>", body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove the Apps dashboard All tab and repeated platform/latest observed columns
- add a compact latest-observed version summary by platform above the tabs
- remove the unused ready status pill below the page header

## Validation
- python -m unittest tests.test_app_versions
- python -m unittest discover -s tests -p 'test_*.py'\n- ruff check .\n- ruff format --check .\n- local /apps returned 200 on http://127.0.0.1:8001/apps