### PR TITLE
[codex] Add header menu for local pages

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -8,3 +8,40 @@ footer ol {
 footer li {
   list-style: none;
 }
+
+.site-menu {
+  position: relative;
+}
+
+.site-menu summary[role="button"] {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  min-height: 2.25rem;
+  padding: 0.45rem 0.55rem;
+  width: 2.25rem;
+}
+
+.site-menu summary[role="button"]::after {
+  display: none;
+}
+
+.site-menu > ul {
+  left: auto;
+  right: 0;
+}
+
+.hamburger-icon {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.22rem;
+  width: 1rem;
+}
+
+.hamburger-icon span {
+  background: currentColor;
+  border-radius: 999px;
+  display: block;
+  height: 0.12rem;
+  width: 100%;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,8 +22,22 @@
           <li><a href="{{ url_for('index') }}">Bug Board</a></li>
         </ul>
         <ul>
-          <li><a href="{{ url_for('team') }}">Engineering Teams</a></li>
-          <li><a href="{{ url_for('apps_dashboard') }}">Apps</a></li>
+          <li>
+            <details class="dropdown site-menu">
+              <summary role="button" class="outline" aria-label="Open local pages menu">
+                <span class="hamburger-icon" aria-hidden="true">
+                  <span></span>
+                  <span></span>
+                  <span></span>
+                </span>
+              </summary>
+              <ul>
+                <li><a href="{{ url_for('apps_dashboard') }}">Apps</a></li>
+                <li><a href="{{ url_for('team') }}">Teams</a></li>
+                <li><a href="{{ url_for('failing_dags_dashboard') }}">Failing DAGs</a></li>
+              </ul>
+            </details>
+          </li>
         </ul>
         {% block header_nav %}{% endblock %}
       </nav>
@@ -34,12 +48,6 @@
         <div>
           <h6>SRE</h6>
           <ul>
-            <li>
-              <a href="{{ url_for('failing_dags_dashboard') }}">Failing DAGs</a>
-            </li>
-            <li>
-              <a href="{{ url_for('apps_dashboard') }}">Apps</a>
-            </li>
             <li>
               <a href="https://differential-ka.sentry.io/issues" target="_blank" rel="noopener noreferrer">Sentry Issues</a>
             </li>

--- a/templates/partials/team_content.html
+++ b/templates/partials/team_content.html
@@ -1,4 +1,4 @@
-<h2>Engineering Teams</h2>
+<h2>Teams</h2>
 <h2>Current Focus</h2>
 {% if developers %}
 <h4>Projects</h4>

--- a/templates/team.html
+++ b/templates/team.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Engineering Teams{% endblock %}
+{% block title %}Teams{% endblock %}
 
 {% block extra_head %}
 <style>

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest.mock import patch
+
+import app as app_module
+
+
+class NavigationTest(unittest.TestCase):
+    def setUp(self):
+        self.client = app_module.app.test_client()
+
+    def test_local_pages_render_in_header_menu_not_footer(self):
+        response = self.client.get("/team")
+
+        body = response.get_data(as_text=True)
+        self.assertEqual(response.status_code, 200)
+
+        header = body.split("</header>", 1)[0]
+        footer = body.split("<footer", 1)[1]
+
+        self.assertIn('class="dropdown site-menu"', header)
+        self.assertIn('aria-label="Open local pages menu"', header)
+        self.assertIn('href="/apps"', header)
+        self.assertIn(">Teams</a>", header)
+        self.assertIn('href="/failing-dags"', header)
+
+        self.assertNotIn('href="/apps"', footer)
+        self.assertNotIn('href="/team"', footer)
+        self.assertNotIn('href="/failing-dags"', footer)
+
+    def test_team_labels_use_short_name(self):
+        context = {
+            "developers": [],
+            "developer_projects": {},
+            "cycle_projects_by_initiative": {},
+            "completed_cycle_projects": [],
+            "on_call_support": [],
+            "support_issues": {},
+        }
+
+        response = self.client.get("/team")
+        self.assertIn("<title>Teams</title>", response.get_data(as_text=True))
+
+        with patch.object(app_module, "_build_team_context", return_value=context):
+            partial_response = self.client.get("/partials/team/content")
+
+        partial_body = partial_response.get_data(as_text=True)
+        self.assertEqual(partial_response.status_code, 200)
+        self.assertIn("<h2>Teams</h2>", partial_body)
+        self.assertNotIn("Engineering Teams", partial_body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Move local dashboard links into a header hamburger menu: Apps, Teams, and Failing DAGs.
- Rename Engineering Teams to Teams in the header/page labels.
- Remove local dashboard links from the footer while preserving external/resource footer links.
- Add navigation regression tests for header-only local pages and the Teams label.

## Validation
- `source venv/bin/activate && ruff check .`
- `source venv/bin/activate && OPENAI_API_KEY=dummy python -m unittest discover -s tests -p 'test_*.py'`
- Rendered `/team` locally via gunicorn on `127.0.0.1:8001`; confirmed the header dropdown and footer link placement in the response HTML.