### PR TITLE
[codex] Remove apps latest observed section

### DIFF
--- a/app_versions.py
+++ b/app_versions.py
@@ -96,7 +96,6 @@ def get_app_versions_context() -> dict[str, Any]:
         "status_label": "Ready",
         "rows": rows,
         "platform_tabs": build_platform_tabs(rows),
-        "platform_latest_versions": build_platform_latest_versions(rows),
         "lookback_days": config.lookback_days,
         "configured_tables": discovered_tables,
         "configured_datasets": config.datasets,
@@ -633,35 +632,6 @@ def build_platform_tabs(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
             }
         )
     return tabs
-
-
-def build_platform_latest_versions(rows: list[dict[str, Any]]) -> list[dict[str, str]]:
-    versions_by_platform: dict[str, str] = {}
-    for row in rows:
-        platform = _string_value(row.get("apollos_platform")) or "unknown"
-        version = _string_value(row.get("latest_apollos_version")) or _string_value(
-            row.get("apollos_version")
-        )
-        if not version:
-            continue
-        current = versions_by_platform.get(platform)
-        if current is None or compare_versions(version, current) > 0:
-            versions_by_platform[platform] = version
-
-    return [
-        {
-            "key": platform,
-            "label": format_platform_label(platform),
-            "version": version,
-        }
-        for platform, version in sorted(
-            versions_by_platform.items(),
-            key=lambda item: (
-                1 if item[0] == "unknown" else 0,
-                item[0],
-            ),
-        )
-    ]
 
 
 def format_platform_label(platform: str) -> str:

--- a/templates/app_versions.html
+++ b/templates/app_versions.html
@@ -49,34 +49,6 @@
     padding-bottom: 0.7rem;
   }
 
-  .platform-latest {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-    margin-bottom: 1rem;
-  }
-
-  .platform-latest-title {
-    color: var(--pico-muted-color);
-    font-size: 0.9rem;
-    font-weight: 700;
-  }
-
-  .platform-latest-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.35rem 0.6rem;
-    border: 1px solid var(--pico-muted-border-color);
-    border-radius: 999px;
-    font-size: 0.85rem;
-  }
-
-  .platform-latest-chip code {
-    font-size: 0.85em;
-  }
-
   .version-tab {
     display: inline-flex;
     align-items: center;
@@ -153,18 +125,6 @@
   </article>
 {% elif rows %}
   <article>
-    {% if platform_latest_versions %}
-      <div class="platform-latest" aria-label="Latest observed versions by platform">
-        <span class="platform-latest-title">Latest observed</span>
-        {% for platform_version in platform_latest_versions %}
-          <span class="platform-latest-chip">
-            {{ platform_version.label }}
-            <code>{{ platform_version.version }}</code>
-          </span>
-        {% endfor %}
-      </div>
-    {% endif %}
-
     <div class="version-tabs" role="tablist" aria-label="Platforms">
       {% for tab in platform_tabs %}
         <button

--- a/tests/test_app_versions.py
+++ b/tests/test_app_versions.py
@@ -480,25 +480,6 @@ class AppVersionsContextTest(unittest.TestCase):
         androidtv_tab = next(tab for tab in tabs if tab["key"] == "androidtv")
         self.assertEqual(androidtv_tab["label"], "AndroidTV")
 
-    def test_builds_platform_latest_versions(self):
-        rows = [
-            {"apollos_platform": "ios", "latest_apollos_version": "101"},
-            {"apollos_platform": "ios", "latest_apollos_version": "97"},
-            {"apollos_platform": "android", "latest_apollos_version": "98"},
-            {"apollos_platform": "unknown", "apollos_version": "8.2.13"},
-        ]
-
-        latest_versions = app_versions.build_platform_latest_versions(rows)
-
-        self.assertEqual(
-            latest_versions,
-            [
-                {"key": "android", "label": "Android", "version": "98"},
-                {"key": "ios", "label": "iOS", "version": "101"},
-                {"key": "unknown", "label": "Unknown", "version": "8.2.13"},
-            ],
-        )
-
     def test_builds_query_from_discovered_segment_columns(self):
         config = app_versions.AppVersionsConfig(
             project_id="analytics-project",
@@ -658,7 +639,6 @@ class AppVersionsRouteTest(unittest.TestCase):
             "status_label": "Ready",
             "rows": rows,
             "platform_tabs": app_versions.build_platform_tabs(rows),
-            "platform_latest_versions": app_versions.build_platform_latest_versions(rows),
             "lookback_days": 30,
             "configured_datasets": ("apollos", "apollos_tv"),
             "configured_tables": ("apollos.identifies", "apollos_tv.identifies"),
@@ -675,7 +655,7 @@ class AppVersionsRouteTest(unittest.TestCase):
         self.assertIn('data-version-tab="ios"', body)
         self.assertIn('data-version-tab="android"', body)
         self.assertIn('id="version-panel-ios"', body)
-        self.assertIn("Latest observed", body)
+        self.assertNotIn("Latest observed", body)
         self.assertIn("One Church", body)
         self.assertIn("Latest App", body)
         self.assertIn("1.0.1", body)


### PR DESCRIPTION
## Summary
- remove the Latest observed chip section from the Apps page
- stop building the now-unused platform latest versions context
- update the Apps route test to assert the section is absent

## Validation
- source venv/bin/activate && python -m unittest tests.test_app_versions
- source venv/bin/activate && python -m unittest discover -s tests -p 'test_*.py'
- source venv/bin/activate && ruff check .
- source venv/bin/activate && ruff format --check .