### PR TITLE
[codex] Read app source metadata in apps dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ The legacy `GET /airflow-fleet-health` Better Stack monitor endpoint has been re
 `GET /apps` reads the Segment BigQuery export and shows the highest observed Apollos
 version signal per church/app/platform. It uses the analytics metadata sent by the mobile and TV
 apps, including the exported `apollos_version`, `app_version`, `app_update_id`, `bundle_id`,
-`application_name`, `church`, and `apollos_platform` fields. Public App Store versions are also
-looked up by bundle ID when available so iOS rows can distinguish the observed installed app
-version from the current production App Store version. Roku Segment exports currently do not expose
-`apollos_version`, so Roku rows use the exported `context_library_version` and are labelled as
-analytics library versions.
+`application_name`, `church`, `apollos_platform`, `source_revision`, and `source_version` fields.
+Public App Store versions are also looked up by bundle ID when available so iOS rows can distinguish
+the observed installed app version from the current production App Store version. Roku Segment
+exports currently do not expose `apollos_version`, so Roku rows use the exported
+`context_library_version` and are labelled as analytics library versions.
 
 The page first inspects `INFORMATION_SCHEMA.COLUMNS` for the configured Segment tables and only
 queries tables that expose a supported version signal, so Segment lifecycle-only app-store
@@ -135,6 +135,9 @@ older clients are still active after a release, the dashboard keeps the highest 
 the app instead of letting the most recent older-client event hide it. Mobile rows prefer the
 `apollos` Segment dataset, TV rows prefer `apollos_tv`, and Roku rows prefer `apollos_roku` so the
 same app event is not counted twice when Segment exports overlap.
+TV rows show `TBD` until source metadata appears in Segment exports. Once those fields are present,
+TV freshness uses the highest observed `source_version` for each TV platform instead of the static
+Expo runtime version.
 
 To make the dashboard query live data locally, in production, or in review apps, set
 `BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64`. The value should be a base64-encoded Google service

--- a/app_versions.py
+++ b/app_versions.py
@@ -44,11 +44,14 @@ FIELD_CANDIDATES = {
     "app_update_id": ("app_update_id", "appUpdateId"),
     "bundle_id": ("bundle_id", "bundleId"),
     "application_name": ("application_name", "applicationName"),
+    "source_revision": ("source_revision", "sourceRevision"),
+    "source_version": ("source_version", "sourceVersion"),
     "user_id": ("user_id", "userId"),
     "anonymous_id": ("anonymous_id", "anonymousId"),
 }
 
 ROKU_ANALYTICS_VERSION_CANDIDATES = ("context_library_version",)
+TV_PLATFORMS = {"amazon", "androidtv", "roku", "tv", "tvos"}
 
 
 @dataclass(frozen=True)
@@ -281,6 +284,8 @@ def _build_app_versions_query(
             apollos_version,
             app_version,
             app_update_id,
+            source_revision,
+            source_version,
             source_dataset,
             source_table,
             version_source,
@@ -335,6 +340,8 @@ def _build_app_versions_query(
             events.apollos_version,
             events.app_version,
             events.app_update_id,
+            events.source_revision,
+            events.source_version,
             events.source_dataset,
             events.source_table,
             events.version_source,
@@ -352,6 +359,8 @@ def _build_app_versions_query(
             events.apollos_version,
             events.app_version,
             events.app_update_id,
+            events.source_revision,
+            events.source_version,
             events.source_dataset,
             events.source_table,
             events.version_source
@@ -372,6 +381,8 @@ def _build_app_versions_query(
           observation.apollos_version,
           observation.app_version,
           observation.app_update_id,
+          observation.source_revision,
+          observation.source_version,
           observation.source_dataset,
           observation.source_table,
           observation.version_source,
@@ -402,17 +413,25 @@ def _string_select_expression(
 
 def _annotate_version_status(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     latest_by_platform: dict[str, str] = {}
+    latest_source_version_by_platform: dict[str, str] = {}
     for row in rows:
         platform = _string_value(row.get("apollos_platform")) or "unknown"
         version_source = _string_value(row.get("version_source")) or "runtime"
-        if platform == "unknown" or version_source != "runtime":
-            continue
-        version = _string_value(row.get("apollos_version"))
-        if not version:
-            continue
-        current_latest = latest_by_platform.get(platform)
-        if current_latest is None or compare_versions(version, current_latest) > 0:
-            latest_by_platform[platform] = version
+        if platform != "unknown" and version_source == "runtime":
+            version = _string_value(row.get("apollos_version"))
+            if version:
+                current_latest = latest_by_platform.get(platform)
+                if current_latest is None or compare_versions(version, current_latest) > 0:
+                    latest_by_platform[platform] = version
+
+        source_version = _string_value(row.get("source_version"))
+        if platform in TV_PLATFORMS and source_version:
+            current_latest_source = latest_source_version_by_platform.get(platform)
+            if (
+                current_latest_source is None
+                or compare_versions(source_version, current_latest_source) > 0
+            ):
+                latest_source_version_by_platform[platform] = source_version
 
     annotated = []
     for row in rows:
@@ -438,19 +457,35 @@ def _annotate_version_status(rows: list[dict[str, Any]]) -> list[dict[str, Any]]
         is_app_version_outdated = False
         if observed_app_version and latest_app_version:
             is_app_version_outdated = compare_versions(observed_app_version, latest_app_version) < 0
-        is_outdated = is_runtime_outdated or is_app_version_outdated
+        source_version = _string_value(row.get("source_version"))
+        source_revision = _string_value(row.get("source_revision"))
+        latest_source_version = latest_source_version_by_platform.get(platform) or source_version
+        is_source_outdated = False
+        is_source_status_tbd = False
+        if platform in TV_PLATFORMS:
+            is_source_status_tbd = not source_version and not source_revision
+            if source_version and latest_source_version:
+                is_source_outdated = compare_versions(source_version, latest_source_version) < 0
+        is_outdated = is_runtime_outdated or is_app_version_outdated or is_source_outdated
         updated["is_runtime_outdated"] = is_runtime_outdated
         updated["is_app_version_outdated"] = is_app_version_outdated
+        updated["is_source_outdated"] = is_source_outdated
+        updated["is_source_status_tbd"] = is_source_status_tbd
         updated["is_outdated"] = is_outdated
+        updated["latest_source_version"] = latest_source_version
+        updated["source_display"] = format_source_display(source_version, source_revision)
         updated["version_source_label"] = format_version_source_label(version_source)
-        updated["version_status_label"] = (
-            "Observed" if version_source != "runtime" else "Outdated" if is_outdated else "Current"
-        )
-        updated["version_status_class"] = (
-            "observed"
-            if version_source != "runtime"
-            else ("outdated" if is_outdated else "current")
-        )
+        if is_source_status_tbd:
+            version_status_label = "TBD"
+            version_status_class = "observed"
+        elif version_source != "runtime":
+            version_status_label = "Observed"
+            version_status_class = "observed"
+        else:
+            version_status_label = "Outdated" if is_outdated else "Current"
+            version_status_class = "outdated" if is_outdated else "current"
+        updated["version_status_label"] = version_status_label
+        updated["version_status_class"] = version_status_class
         updated["latest_seen_display"] = format_timestamp(row.get("latest_seen_at"))
         annotated.append(updated)
     annotated.sort(
@@ -598,6 +633,15 @@ def _is_newer_observed_version(candidate: dict[str, Any], current: dict[str, Any
     elif candidate_app_version != current_app_version:
         return bool(candidate_app_version)
 
+    candidate_source_version = _string_value(candidate.get("source_version"))
+    current_source_version = _string_value(current.get("source_version"))
+    if candidate_source_version and current_source_version:
+        source_version_compare = compare_versions(candidate_source_version, current_source_version)
+        if source_version_compare != 0:
+            return source_version_compare > 0
+    elif candidate_source_version != current_source_version:
+        return bool(candidate_source_version)
+
     candidate_church = _string_value(candidate.get("church")) or "Unknown church"
     current_church = _string_value(current.get("church")) or "Unknown church"
     if candidate_church != current_church:
@@ -662,6 +706,16 @@ def format_app_version_source_label(version_source: str) -> str:
         "observed": "Observed",
     }
     return labels.get(version_source, version_source.replace("_", " ").title())
+
+
+def format_source_display(source_version: str | None, source_revision: str | None) -> str:
+    if source_version and source_revision:
+        return f"{source_version} ({source_revision[:7]})"
+    if source_version:
+        return source_version
+    if source_revision:
+        return source_revision[:7]
+    return "TBD"
 
 
 def compare_versions(left: str, right: str) -> int:

--- a/templates/app_versions.html
+++ b/templates/app_versions.html
@@ -161,6 +161,7 @@
                 <th>App</th>
                 <th>Latest App</th>
                 <th>Observed Version</th>
+                <th>Source</th>
                 <th>Status</th>
                 <th>Seen</th>
                 <th>Users</th>
@@ -185,6 +186,7 @@
                     </span>
                   </td>
                   <td><code>{{ row.apollos_version }}</code></td>
+                  <td><code>{{ row.source_display or "TBD" }}</code></td>
                   <td>
                     <span class="version-status version-status--{{ row.version_status_class or ('outdated' if row.is_outdated else 'current') }}">
                       {{ row.version_status_label or ("Outdated" if row.is_outdated else "Current") }}

--- a/tests/test_app_versions.py
+++ b/tests/test_app_versions.py
@@ -142,6 +142,30 @@ class AppVersionsContextTest(unittest.TestCase):
                 "latest_seen_at": datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
             },
             {
+                "church": "old-tv-church",
+                "apollos_platform": "tvos",
+                "application_name": "Old TV Church",
+                "bundle_id": "com.oldtv",
+                "apollos_version": "1.0.0",
+                "app_version": "1.0.0",
+                "source_version": "v2026.05.01.00",
+                "source_revision": "abcdef123456",
+                "version_source": "runtime",
+                "latest_seen_at": datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
+            },
+            {
+                "church": "new-tv-church",
+                "apollos_platform": "tvos",
+                "application_name": "New TV Church",
+                "bundle_id": "com.newtv",
+                "apollos_version": "1.0.0",
+                "app_version": "1.0.0",
+                "source_version": "v2026.05.12.00",
+                "source_revision": "123456abcdef",
+                "version_source": "runtime",
+                "latest_seen_at": datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
+            },
+            {
                 "church": "unknown-platform",
                 "apollos_platform": "unknown",
                 "application_name": "Unknown Platform",
@@ -166,6 +190,8 @@ class AppVersionsContextTest(unittest.TestCase):
         one_church = next(row for row in annotated if row["church"] == "one-church")
         two_church = next(row for row in annotated if row["church"] == "two-church")
         tv_church = next(row for row in annotated if row["church"] == "tv-church")
+        old_tv_church = next(row for row in annotated if row["church"] == "old-tv-church")
+        new_tv_church = next(row for row in annotated if row["church"] == "new-tv-church")
         unknown_platform = next(row for row in annotated if row["church"] == "unknown-platform")
         roku_church = next(row for row in annotated if row["church"] == "roku-church")
         self.assertTrue(one_church["is_outdated"])
@@ -173,11 +199,18 @@ class AppVersionsContextTest(unittest.TestCase):
         self.assertEqual(one_church["version_source_label"], "Runtime")
         self.assertFalse(two_church["is_outdated"])
         self.assertFalse(tv_church["is_outdated"])
+        self.assertTrue(tv_church["is_source_status_tbd"])
+        self.assertEqual(tv_church["version_status_label"], "TBD")
+        self.assertEqual(tv_church["source_display"], "TBD")
+        self.assertTrue(old_tv_church["is_outdated"])
+        self.assertTrue(old_tv_church["is_source_outdated"])
+        self.assertEqual(old_tv_church["source_display"], "v2026.05.01.00 (abcdef1)")
+        self.assertFalse(new_tv_church["is_outdated"])
         self.assertFalse(unknown_platform["is_outdated"])
         self.assertEqual(unknown_platform["latest_apollos_version"], "8.2.13")
         self.assertFalse(roku_church["is_outdated"])
         self.assertEqual(roku_church["version_source_label"], "Analytics library")
-        self.assertEqual(roku_church["version_status_label"], "Observed")
+        self.assertEqual(roku_church["version_status_label"], "TBD")
         self.assertEqual(annotated[0]["church"], "one-church")
 
     def test_annotates_outdated_apps_by_app_store_version(self):
@@ -494,6 +527,8 @@ class AppVersionsContextTest(unittest.TestCase):
                 "church": "church",
                 "apollos_version": "apollos_version",
                 "app_version": "app_version",
+                "source_revision": "source_revision",
+                "source_version": "source_version",
                 "bundle_id": "bundle_id",
                 "application_name": "application_name",
                 "apollos_platform": "apollos_platform",
@@ -503,6 +538,8 @@ class AppVersionsContextTest(unittest.TestCase):
                 "groupid": "groupId",
                 "apollosversion": "apollosVersion",
                 "appversion": "appVersion",
+                "sourcerevision": "sourceRevision",
+                "sourceversion": "sourceVersion",
             },
             ("apollos_roku", "identifies"): {
                 "timestamp": "timestamp",
@@ -525,10 +562,13 @@ class AppVersionsContextTest(unittest.TestCase):
         self.assertIn("`analytics-project.apollos_roku.identifies`", query)
         self.assertIn("NULLIF(CAST(`apollos_version` AS STRING), '') AS apollos_version", query)
         self.assertIn("NULLIF(CAST(`apollosVersion` AS STRING), '') AS apollos_version", query)
+        self.assertIn("NULLIF(CAST(`source_revision` AS STRING), '') AS source_revision", query)
+        self.assertIn("NULLIF(CAST(`sourceVersion` AS STRING), '') AS source_version", query)
         self.assertIn(
             "NULLIF(CAST(`context_library_version` AS STRING), '') AS apollos_version",
             query,
         )
+        self.assertIn("CAST(NULL AS STRING) AS source_revision", query)
         self.assertIn("NULLIF(CAST(`groupId` AS STRING), '') AS church", query)
         self.assertIn("'analytics_library' AS version_source", query)
         self.assertIn("TIMESTAMP_SUB(", query)
@@ -613,6 +653,7 @@ class AppVersionsRouteTest(unittest.TestCase):
                 "apollos_platform": "ios",
                 "apollos_version": "97",
                 "latest_apollos_version": "101",
+                "source_display": "v2026.05.12.00 (abc1234)",
                 "is_outdated": True,
                 "latest_seen_display": "2026-05-12 10:00 AM EDT",
                 "user_count": 5,
@@ -628,6 +669,7 @@ class AppVersionsRouteTest(unittest.TestCase):
                 "apollos_platform": "android",
                 "apollos_version": "97",
                 "latest_apollos_version": "97",
+                "source_display": "TBD",
                 "is_outdated": False,
                 "latest_seen_display": "2026-05-12 10:00 AM EDT",
                 "user_count": 7,
@@ -658,8 +700,11 @@ class AppVersionsRouteTest(unittest.TestCase):
         self.assertNotIn("Latest observed", body)
         self.assertIn("One Church", body)
         self.assertIn("Latest App", body)
+        self.assertIn("<th>Source</th>", body)
         self.assertIn("1.0.1", body)
         self.assertIn("App Store", body)
+        self.assertIn("v2026.05.12.00 (abc1234)", body)
+        self.assertIn("<code>TBD</code>", body)
         self.assertIn("Two Church", body)
         self.assertNotIn("<th>Platform</th>", body)
         self.assertNotIn("<th>Latest Observed</th>", body)


### PR DESCRIPTION
## Summary
- add optional sourceRevision/sourceVersion fields to the Segment BigQuery query
- show a Source column with TBD until source metadata appears in exported events
- use observed sourceVersion for TV freshness once those fields are present

## Validation
- source venv/bin/activate && ruff format app_versions.py tests/test_app_versions.py
- source venv/bin/activate && ruff check app_versions.py tests/test_app_versions.py
- source venv/bin/activate && python -m unittest tests.test_app_versions
- source venv/bin/activate && python -m unittest discover -s tests -p 'test_*.py'\n