### PR TITLE
[codex] Fix header menu overflow

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -26,8 +26,9 @@ footer li {
   display: none;
 }
 
-.site-menu > ul {
+details.dropdown.site-menu > summary + ul {
   left: auto;
+  max-width: calc(100vw - 2rem);
   right: 0;
 }
 

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -27,6 +27,18 @@ class NavigationTest(unittest.TestCase):
         self.assertNotIn('href="/team"', footer)
         self.assertNotIn('href="/failing-dags"', footer)
 
+    def test_header_menu_overrides_pico_left_aligned_dropdown(self):
+        with open("static/styles.css") as styles_file:
+            styles = styles_file.read()
+
+        self.assertIn("details.dropdown.site-menu > summary + ul", styles)
+        site_menu_rule = styles.split("details.dropdown.site-menu > summary + ul", 1)[1]
+        site_menu_rule = site_menu_rule.split("}", 1)[0]
+
+        self.assertIn("left: auto;", site_menu_rule)
+        self.assertIn("right: 0;", site_menu_rule)
+        self.assertIn("max-width: calc(100vw - 2rem);", site_menu_rule)
+
     def test_team_labels_use_short_name(self):
         context = {
             "developers": [],


### PR DESCRIPTION
## Summary

- Strengthen the site-menu dropdown selector so it overrides Pico's default left-aligned dropdown positioning.
- Add a viewport max width to keep the header menu inside the page.
- Add regression coverage for the local-pages menu override.

## Root Cause

The hamburger menu was placed near the right edge of the header, but Pico's default dropdown rule could still apply `left: 0`, causing the menu to expand off the right side of the viewport.

## Validation

- `source venv/bin/activate && ruff check .`
- `source venv/bin/activate && python -m unittest discover -s tests -p 'test_*.py'`
- Playwright rendered check at 1280px and 390px widths confirmed the opened dropdown stayed inside the viewport.