### PR TITLE
[codex] Fix stale PR and Linear open issue filters

### DIFF
--- a/github.py
+++ b/github.py
@@ -247,12 +247,6 @@ def get_active_change_request_reviewers(pr):
     return active_reviewers
 
 
-def has_active_change_request(pr):
-    """Return True when GitHub says the PR is blocked by requested changes."""
-
-    return bool(get_active_change_request_reviewers(pr))
-
-
 def _get_all_prs(pr_states: List[str]) -> List[Dict[str, Any]]:
     """Fetch PRs for all tracked repositories concurrently."""
     repo_ids = get_repo_ids()

--- a/github.py
+++ b/github.py
@@ -207,12 +207,12 @@ def _parse_github_timestamp(value: str | None) -> datetime | None:
         return None
 
 
-def has_active_change_request(pr):
-    """Return True when GitHub says the PR is blocked by requested changes."""
+def get_active_change_request_reviewers(pr):
+    """Return reviewers with currently active requested-changes reviews."""
 
     review_decision = pr.get("reviewDecision")
-    if review_decision:
-        return review_decision == "CHANGES_REQUESTED"
+    if review_decision and review_decision != "CHANGES_REQUESTED":
+        return set()
 
     review_request_times_by_reviewer: dict[str, list[datetime]] = {}
     for review_request in pr.get("timelineItems", {}).get("nodes", []):
@@ -222,20 +222,35 @@ def has_active_change_request(pr):
         if reviewer and requested_at is not None:
             review_request_times_by_reviewer.setdefault(reviewer, []).append(requested_at)
 
+    has_change_request_review = False
+    active_reviewers = set()
     for review in pr.get("reviews", {}).get("nodes", []):
         if review.get("state") != "CHANGES_REQUESTED":
             continue
+        has_change_request_review = True
         reviewer = (review.get("author") or {}).get("login")
         submitted_at = _parse_github_timestamp(review.get("submittedAt"))
         if not reviewer or submitted_at is None:
-            return True
+            continue
         latest_review_request_at = max(
             review_request_times_by_reviewer.get(reviewer, []),
             default=None,
         )
         if latest_review_request_at is None or submitted_at >= latest_review_request_at:
-            return True
-    return False
+            active_reviewers.add(reviewer)
+    if review_decision == "CHANGES_REQUESTED" and not has_change_request_review:
+        return {
+            (req.get("requestedReviewer") or {}).get("login")
+            for req in pr.get("reviewRequests", {}).get("nodes", [])
+            if (req.get("requestedReviewer") or {}).get("login")
+        }
+    return active_reviewers
+
+
+def has_active_change_request(pr):
+    """Return True when GitHub says the PR is blocked by requested changes."""
+
+    return bool(get_active_change_request_reviewers(pr))
 
 
 def _get_all_prs(pr_states: List[str]) -> List[Dict[str, Any]]:
@@ -350,9 +365,9 @@ def merged_prs_by_reviewer(days: int = 30) -> Dict[str, List[Dict[str, Any]]]:
 def get_prs_waiting_for_review_by_reviewer():
     """Return PRs waiting on review, grouped by reviewer.
 
-    Includes pull requests with an open review request that was made more
-    than 24 hours ago, even if the PR has previously been reviewed. Only
-    includes PRs with fewer than 200 lines added.
+    Includes pull requests with an open review request or active requested-changes
+    reviewer that has been waiting more than 24 hours, even if the PR has
+    previously been reviewed. Only includes PRs with fewer than 200 lines added.
     """
     all_prs = _get_all_prs(["OPEN"])
     stuck_prs = {}
@@ -363,11 +378,8 @@ def get_prs_waiting_for_review_by_reviewer():
             continue
         if has_known_merge_conflicts(pr):
             continue
-        if has_active_change_request(pr):
-            continue
-        if not pr["reviewRequests"]["nodes"]:
-            continue
-        if any(r.get("state") == "APPROVED" for r in pr["reviews"]["nodes"]):
+        active_change_request_reviewers = get_active_change_request_reviewers(pr)
+        if not pr["reviewRequests"]["nodes"] and not active_change_request_reviewers:
             continue
         if has_failing_required_checks(pr):
             # waiting on author to fix checks
@@ -383,7 +395,12 @@ def get_prs_waiting_for_review_by_reviewer():
                 open_review_requests = [
                     req["requestedReviewer"]["login"] for req in pr["reviewRequests"]["nodes"]
                 ]
-                if reviewer not in open_review_requests:
+                if (
+                    active_change_request_reviewers
+                    and reviewer not in active_change_request_reviewers
+                ):
+                    continue
+                if not active_change_request_reviewers and reviewer not in open_review_requests:
                     continue
                 if reviewer not in stuck_prs:
                     stuck_prs[reviewer] = []

--- a/github.py
+++ b/github.py
@@ -374,7 +374,9 @@ def get_prs_waiting_for_review_by_reviewer():
             continue
         active_change_request_reviewers = get_active_change_request_reviewers(pr)
         open_review_requests = {
-            req["requestedReviewer"]["login"] for req in pr["reviewRequests"]["nodes"]
+            reviewer
+            for req in pr["reviewRequests"]["nodes"]
+            if (reviewer := (req.get("requestedReviewer") or {}).get("login"))
         }
         if not open_review_requests:
             continue

--- a/github.py
+++ b/github.py
@@ -378,27 +378,28 @@ def get_prs_waiting_for_review_by_reviewer():
         if has_failing_required_checks(pr):
             # waiting on author to fix checks
             continue
-        for review in pr["timelineItems"]["nodes"]:
-            requested_at = _parse_github_timestamp(review.get("createdAt"))
-            if (
-                review["requestedReviewer"]
-                and requested_at is not None
-                and requested_at < threshold
-            ):
-                reviewer = review["requestedReviewer"]["login"]
-                open_review_requests = [
-                    req["requestedReviewer"]["login"] for req in pr["reviewRequests"]["nodes"]
-                ]
-                if (
-                    active_change_request_reviewers
-                    and reviewer not in active_change_request_reviewers
-                ):
-                    continue
-                if not active_change_request_reviewers and reviewer not in open_review_requests:
-                    continue
-                if reviewer not in stuck_prs:
-                    stuck_prs[reviewer] = []
-                stuck_prs[reviewer].append(pr)
+        latest_review_request_times_by_reviewer: dict[str, datetime] = {}
+        for review_request in pr["timelineItems"]["nodes"]:
+            requested_reviewer = review_request.get("requestedReviewer") or {}
+            reviewer = requested_reviewer.get("login")
+            requested_at = _parse_github_timestamp(review_request.get("createdAt"))
+            if not reviewer or requested_at is None:
+                continue
+            latest_request_at = latest_review_request_times_by_reviewer.get(reviewer)
+            if latest_request_at is None or requested_at > latest_request_at:
+                latest_review_request_times_by_reviewer[reviewer] = requested_at
+
+        open_review_requests = {
+            req["requestedReviewer"]["login"] for req in pr["reviewRequests"]["nodes"]
+        }
+        reviewers = active_change_request_reviewers or open_review_requests
+        for reviewer in reviewers:
+            requested_at = latest_review_request_times_by_reviewer.get(reviewer)
+            if requested_at is None or requested_at >= threshold:
+                continue
+            if reviewer not in stuck_prs:
+                stuck_prs[reviewer] = []
+            stuck_prs[reviewer].append(pr)
     return stuck_prs
 
 

--- a/github.py
+++ b/github.py
@@ -378,6 +378,11 @@ def get_prs_waiting_for_review_by_reviewer():
         if has_failing_required_checks(pr):
             # waiting on author to fix checks
             continue
+        open_review_requests = {
+            req["requestedReviewer"]["login"] for req in pr["reviewRequests"]["nodes"]
+        }
+        if not open_review_requests:
+            continue
         latest_review_request_times_by_reviewer: dict[str, datetime] = {}
         for review_request in pr["timelineItems"]["nodes"]:
             requested_reviewer = review_request.get("requestedReviewer") or {}
@@ -389,10 +394,10 @@ def get_prs_waiting_for_review_by_reviewer():
             if latest_request_at is None or requested_at > latest_request_at:
                 latest_review_request_times_by_reviewer[reviewer] = requested_at
 
-        open_review_requests = {
-            req["requestedReviewer"]["login"] for req in pr["reviewRequests"]["nodes"]
-        }
-        reviewers = active_change_request_reviewers or open_review_requests
+        if active_change_request_reviewers:
+            reviewers = active_change_request_reviewers & open_review_requests
+        else:
+            reviewers = open_review_requests
         for reviewer in reviewers:
             requested_at = latest_review_request_times_by_reviewer.get(reviewer)
             if requested_at is None or requested_at >= threshold:

--- a/github.py
+++ b/github.py
@@ -373,15 +373,13 @@ def get_prs_waiting_for_review_by_reviewer():
         if has_known_merge_conflicts(pr):
             continue
         active_change_request_reviewers = get_active_change_request_reviewers(pr)
-        if not pr["reviewRequests"]["nodes"] and not active_change_request_reviewers:
-            continue
-        if has_failing_required_checks(pr):
-            # waiting on author to fix checks
-            continue
         open_review_requests = {
             req["requestedReviewer"]["login"] for req in pr["reviewRequests"]["nodes"]
         }
         if not open_review_requests:
+            continue
+        if has_failing_required_checks(pr):
+            # waiting on author to fix checks
             continue
         latest_review_request_times_by_reviewer: dict[str, datetime] = {}
         for review_request in pr["timelineItems"]["nodes"]:

--- a/linear/issues.py
+++ b/linear/issues.py
@@ -20,7 +20,7 @@ def get_open_issues(priority, label):
               team: { key: { eq: $team_key } }
               labels: { name: { eq: $label } }
               priority: { lte: $priority, gte: 1 }
-              state: { type: { nin: ["completed", "canceled"] } }
+              state: { type: { in: ["triage", "backlog", "unstarted", "started"] } }
               project: { null: true }
             }
             orderBy: createdAt
@@ -488,7 +488,7 @@ def get_open_issues_for_person(login: str):
             filter: {
               team: { key: { eq: $team_key } }
               assignee: { displayName: { eq: $login } }
-              state: { type: { nin: ["completed", "canceled"] } }
+              state: { type: { in: ["triage", "backlog", "unstarted", "started"] } }
             }
             orderBy: updatedAt
           ) {

--- a/tests/test_gql_client_requests.py
+++ b/tests/test_gql_client_requests.py
@@ -280,7 +280,7 @@ class GraphQLClientRequestTests(unittest.TestCase):
         self.assertEqual(waiting["michael"], [pr])
         self.assertEqual(waiting["dylan-manchester"], [pr])
 
-    def test_waiting_for_review_allows_rerequested_reviewer_after_changes_requested(self):
+    def test_waiting_for_review_skips_change_request_without_open_review_request(self):
         class FixedDateTime(datetime):
             @classmethod
             def now(cls, tz=None):
@@ -294,7 +294,7 @@ class GraphQLClientRequestTests(unittest.TestCase):
             "additions": 55,
             "mergeable": "MERGEABLE",
             "reviewDecision": "CHANGES_REQUESTED",
-            "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "dylan-manchester"}}]},
+            "reviewRequests": {"nodes": []},
             "reviews": {
                 "nodes": [
                     {
@@ -323,7 +323,7 @@ class GraphQLClientRequestTests(unittest.TestCase):
             with patch.object(github, "datetime", FixedDateTime):
                 waiting = github.get_prs_waiting_for_review_by_reviewer()
 
-        self.assertEqual(waiting["dylan-manchester"], [pr])
+        self.assertEqual(waiting, {})
 
     def test_waiting_for_review_uses_latest_review_request_time(self):
         class FixedDateTime(datetime):

--- a/tests/test_gql_client_requests.py
+++ b/tests/test_gql_client_requests.py
@@ -310,10 +310,6 @@ class GraphQLClientRequestTests(unittest.TestCase):
                         "createdAt": "2026-03-24T13:51:12Z",
                         "requestedReviewer": {"login": "dylan-manchester"},
                     },
-                    {
-                        "createdAt": "2026-03-24T13:12:12Z",
-                        "requestedReviewer": {"login": "dylan-manchester"},
-                    },
                 ]
             },
             "statusCheckRollup": {"state": "SUCCESS"},

--- a/tests/test_gql_client_requests.py
+++ b/tests/test_gql_client_requests.py
@@ -178,7 +178,6 @@ class GraphQLClientRequestTests(unittest.TestCase):
                 return base.replace(tzinfo=tz)
 
         pr = {
-            "number": 6293,
             "additions": 55,
             "mergeable": "MERGEABLE",
             "reviewDecision": "CHANGES_REQUESTED",
@@ -186,6 +185,7 @@ class GraphQLClientRequestTests(unittest.TestCase):
                 "nodes": [
                     {"requestedReviewer": {"login": "dylan-manchester"}},
                     {"requestedReviewer": {"login": "michael"}},
+                    {"requestedReviewer": {}},
                 ]
             },
             "reviews": {
@@ -234,7 +234,6 @@ class GraphQLClientRequestTests(unittest.TestCase):
                 return base.replace(tzinfo=tz)
 
         pr = {
-            "number": 6293,
             "additions": 55,
             "mergeable": "MERGEABLE",
             "reviewDecision": "REVIEW_REQUIRED",
@@ -290,7 +289,6 @@ class GraphQLClientRequestTests(unittest.TestCase):
                 return base.replace(tzinfo=tz)
 
         pr = {
-            "number": 6293,
             "additions": 55,
             "mergeable": "MERGEABLE",
             "reviewDecision": "CHANGES_REQUESTED",
@@ -331,7 +329,6 @@ class GraphQLClientRequestTests(unittest.TestCase):
                 return base.replace(tzinfo=tz)
 
         pr = {
-            "number": 6293,
             "additions": 55,
             "mergeable": "MERGEABLE",
             "reviewDecision": "REVIEW_REQUIRED",
@@ -368,7 +365,6 @@ class GraphQLClientRequestTests(unittest.TestCase):
                 return base.replace(tzinfo=tz)
 
         pr = {
-            "number": 6293,
             "additions": 55,
             "mergeable": "MERGEABLE",
             "reviewDecision": None,
@@ -409,7 +405,6 @@ class GraphQLClientRequestTests(unittest.TestCase):
                 return base.replace(tzinfo=tz)
 
         pr = {
-            "number": 6293,
             "additions": 55,
             "mergeable": "MERGEABLE",
             "reviewDecision": None,
@@ -450,7 +445,6 @@ class GraphQLClientRequestTests(unittest.TestCase):
                 return base.replace(tzinfo=tz)
 
         pr = {
-            "number": 6293,
             "additions": 55,
             "mergeable": "MERGEABLE",
             "reviewDecision": None,

--- a/tests/test_gql_client_requests.py
+++ b/tests/test_gql_client_requests.py
@@ -168,7 +168,119 @@ class GraphQLClientRequestTests(unittest.TestCase):
 
         self.assertEqual(waiting, {})
 
-    def test_waiting_for_review_skips_active_change_requests(self):
+    def test_waiting_for_review_only_notifies_active_change_request_reviewer(self):
+        class FixedDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                base = datetime(2026, 3, 25, 14, 0, 0)
+                if tz is None:
+                    return base
+                return base.replace(tzinfo=tz)
+
+        pr = {
+            "number": 6293,
+            "additions": 55,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "CHANGES_REQUESTED",
+            "reviewRequests": {
+                "nodes": [
+                    {"requestedReviewer": {"login": "dylan-manchester"}},
+                    {"requestedReviewer": {"login": "michael"}},
+                ]
+            },
+            "reviews": {
+                "nodes": [
+                    {
+                        "author": {"login": "michael"},
+                        "state": "APPROVED",
+                        "submittedAt": "2026-03-24T13:51:30Z",
+                    },
+                    {
+                        "author": {"login": "dylan-manchester"},
+                        "state": "CHANGES_REQUESTED",
+                        "submittedAt": "2026-03-24T13:52:12Z",
+                    },
+                ]
+            },
+            "timelineItems": {
+                "nodes": [
+                    {
+                        "createdAt": "2026-03-24T13:51:12Z",
+                        "requestedReviewer": {"login": "dylan-manchester"},
+                    },
+                    {
+                        "createdAt": "2026-03-24T13:51:13Z",
+                        "requestedReviewer": {"login": "michael"},
+                    },
+                ]
+            },
+            "statusCheckRollup": {"state": "SUCCESS"},
+        }
+
+        with patch.object(github, "_get_all_prs", return_value=[pr]):
+            with patch.object(github, "datetime", FixedDateTime):
+                waiting = github.get_prs_waiting_for_review_by_reviewer()
+
+        self.assertEqual(waiting["dylan-manchester"], [pr])
+        self.assertNotIn("michael", waiting)
+
+    def test_waiting_for_review_allows_cleared_change_requests(self):
+        class FixedDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                base = datetime(2026, 3, 25, 14, 0, 0)
+                if tz is None:
+                    return base
+                return base.replace(tzinfo=tz)
+
+        pr = {
+            "number": 6293,
+            "additions": 55,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "reviewRequests": {
+                "nodes": [
+                    {"requestedReviewer": {"login": "michael"}},
+                    {"requestedReviewer": {"login": "dylan-manchester"}},
+                ]
+            },
+            "reviews": {
+                "nodes": [
+                    {
+                        "author": {"login": "michael"},
+                        "state": "APPROVED",
+                        "submittedAt": "2026-03-24T13:50:12Z",
+                    },
+                    {
+                        "author": {"login": "dylan-manchester"},
+                        "state": "CHANGES_REQUESTED",
+                        "submittedAt": "2026-03-24T13:52:12Z",
+                    },
+                ]
+            },
+            "timelineItems": {
+                "nodes": [
+                    {
+                        "createdAt": "2026-03-24T13:51:12Z",
+                        "requestedReviewer": {"login": "michael"},
+                    },
+                    {
+                        "createdAt": "2026-03-24T13:51:13Z",
+                        "requestedReviewer": {"login": "dylan-manchester"},
+                    },
+                ]
+            },
+            "statusCheckRollup": {"state": "SUCCESS"},
+        }
+
+        with patch.object(github, "_get_all_prs", return_value=[pr]):
+            with patch.object(github, "datetime", FixedDateTime):
+                waiting = github.get_prs_waiting_for_review_by_reviewer()
+
+        self.assertEqual(waiting["michael"], [pr])
+        self.assertEqual(waiting["dylan-manchester"], [pr])
+
+    def test_waiting_for_review_allows_rerequested_reviewer_after_changes_requested(self):
         class FixedDateTime(datetime):
             @classmethod
             def now(cls, tz=None):
@@ -198,46 +310,9 @@ class GraphQLClientRequestTests(unittest.TestCase):
                         "createdAt": "2026-03-24T13:51:12Z",
                         "requestedReviewer": {"login": "dylan-manchester"},
                     },
-                ]
-            },
-            "statusCheckRollup": {"state": "SUCCESS"},
-        }
-
-        with patch.object(github, "_get_all_prs", return_value=[pr]):
-            with patch.object(github, "datetime", FixedDateTime):
-                waiting = github.get_prs_waiting_for_review_by_reviewer()
-
-        self.assertEqual(waiting, {})
-
-    def test_waiting_for_review_allows_cleared_change_requests(self):
-        class FixedDateTime(datetime):
-            @classmethod
-            def now(cls, tz=None):
-                base = datetime(2026, 3, 25, 14, 0, 0)
-                if tz is None:
-                    return base
-                return base.replace(tzinfo=tz)
-
-        pr = {
-            "number": 6293,
-            "additions": 55,
-            "mergeable": "MERGEABLE",
-            "reviewDecision": "REVIEW_REQUIRED",
-            "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "michael"}}]},
-            "reviews": {
-                "nodes": [
                     {
-                        "author": {"login": "dylan-manchester"},
-                        "state": "CHANGES_REQUESTED",
-                        "submittedAt": "2026-03-24T13:52:12Z",
-                    }
-                ]
-            },
-            "timelineItems": {
-                "nodes": [
-                    {
-                        "createdAt": "2026-03-24T13:51:12Z",
-                        "requestedReviewer": {"login": "michael"},
+                        "createdAt": "2026-03-24T14:12:12Z",
+                        "requestedReviewer": {"login": "dylan-manchester"},
                     },
                 ]
             },
@@ -248,7 +323,7 @@ class GraphQLClientRequestTests(unittest.TestCase):
             with patch.object(github, "datetime", FixedDateTime):
                 waiting = github.get_prs_waiting_for_review_by_reviewer()
 
-        self.assertEqual(waiting["michael"], [pr])
+        self.assertEqual(waiting["dylan-manchester"], [pr])
 
     def test_waiting_for_review_falls_back_to_current_review_nodes_for_missing_decision(self):
         class FixedDateTime(datetime):
@@ -289,7 +364,7 @@ class GraphQLClientRequestTests(unittest.TestCase):
             with patch.object(github, "datetime", FixedDateTime):
                 waiting = github.get_prs_waiting_for_review_by_reviewer()
 
-        self.assertEqual(waiting, {})
+        self.assertEqual(waiting["dylan-manchester"], [pr])
 
     def test_waiting_for_review_ignores_historical_review_nodes_for_missing_decision(self):
         class FixedDateTime(datetime):

--- a/tests/test_gql_client_requests.py
+++ b/tests/test_gql_client_requests.py
@@ -311,7 +311,7 @@ class GraphQLClientRequestTests(unittest.TestCase):
                         "requestedReviewer": {"login": "dylan-manchester"},
                     },
                     {
-                        "createdAt": "2026-03-24T14:12:12Z",
+                        "createdAt": "2026-03-24T13:12:12Z",
                         "requestedReviewer": {"login": "dylan-manchester"},
                     },
                 ]
@@ -324,6 +324,43 @@ class GraphQLClientRequestTests(unittest.TestCase):
                 waiting = github.get_prs_waiting_for_review_by_reviewer()
 
         self.assertEqual(waiting["dylan-manchester"], [pr])
+
+    def test_waiting_for_review_uses_latest_review_request_time(self):
+        class FixedDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                base = datetime(2026, 3, 25, 14, 0, 0)
+                if tz is None:
+                    return base
+                return base.replace(tzinfo=tz)
+
+        pr = {
+            "number": 6293,
+            "additions": 55,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "dylan-manchester"}}]},
+            "reviews": {"nodes": []},
+            "timelineItems": {
+                "nodes": [
+                    {
+                        "createdAt": "2026-03-23T13:51:12Z",
+                        "requestedReviewer": {"login": "dylan-manchester"},
+                    },
+                    {
+                        "createdAt": "2026-03-25T13:00:00Z",
+                        "requestedReviewer": {"login": "dylan-manchester"},
+                    },
+                ]
+            },
+            "statusCheckRollup": {"state": "SUCCESS"},
+        }
+
+        with patch.object(github, "_get_all_prs", return_value=[pr]):
+            with patch.object(github, "datetime", FixedDateTime):
+                waiting = github.get_prs_waiting_for_review_by_reviewer()
+
+        self.assertEqual(waiting, {})
 
     def test_waiting_for_review_falls_back_to_current_review_nodes_for_missing_decision(self):
         class FixedDateTime(datetime):

--- a/tests/test_linear_issue_state_filters.py
+++ b/tests/test_linear_issue_state_filters.py
@@ -49,6 +49,22 @@ _install_import_shims()
 from linear import issues as issues_module  # noqa: E402
 
 
+def _query_text(query) -> str:
+    request = getattr(query, "request", None)
+    if request is not None:
+        return request
+    document = getattr(query, "document", None)
+    if document is not None:
+        from graphql import print_ast
+
+        return print_ast(document)
+    return query
+
+
+def _compact_query_text(query) -> str:
+    return "".join(_query_text(query).split())
+
+
 class FixedDateTime(datetime):
     @classmethod
     def utcnow(cls):
@@ -83,10 +99,13 @@ class LinearIssueStateFiltersTest(unittest.TestCase):
                     with patch.object(issues_module, "datetime", FixedDateTime):
                         issues = issues_module.get_open_issues(2, "Bug")
 
-        query_text = execute_calls[0][0]
-        self.assertIn('state: { type: { nin: ["completed", "canceled"] } }', query_text)
+        query_text = _compact_query_text(execute_calls[0][0])
+        self.assertIn(
+            'state:{type:{in:["triage","backlog","unstarted","started"]}}',
+            query_text,
+        )
         self.assertNotIn(
-            'state: { name: { nin: ["Done", "Canceled", "Duplicate"] } }',
+            'state:{name:{nin:["Done","Canceled","Duplicate"]}}',
             query_text,
         )
         self.assertIn("slaMediumRiskAt", query_text)
@@ -119,9 +138,9 @@ class LinearIssueStateFiltersTest(unittest.TestCase):
             with patch.object(issues_module, "get_linear_team_key", return_value="APO"):
                 issues_module.get_completed_issues_summary(2, "Bug", 30)
 
-        query_text = execute_calls[0][0]
-        self.assertIn('state: { type: { in: ["completed"] } }', query_text)
-        self.assertNotIn('state: { name: { in: ["Done"] } }', query_text)
+        query_text = _compact_query_text(execute_calls[0][0])
+        self.assertIn('state:{type:{in:["completed"]}}', query_text)
+        self.assertNotIn('state:{name:{in:["Done"]}}', query_text)
         self.assertEqual(execute_calls[0][1]["days"], "-P30D")
 
     def test_get_open_issues_for_person_uses_state_type_for_open_filter(self):
@@ -151,10 +170,13 @@ class LinearIssueStateFiltersTest(unittest.TestCase):
                     with patch.object(issues_module, "datetime", FixedDateTime):
                         issues = issues_module.get_open_issues_for_person("michael.neeley")
 
-        query_text = execute_calls[0][0]
-        self.assertIn('state: { type: { nin: ["completed", "canceled"] } }', query_text)
+        query_text = _compact_query_text(execute_calls[0][0])
+        self.assertIn(
+            'state:{type:{in:["triage","backlog","unstarted","started"]}}',
+            query_text,
+        )
         self.assertNotIn(
-            'state: { name: { nin: ["Done", "Canceled", "Duplicate"] } }',
+            'state:{name:{nin:["Done","Canceled","Duplicate"]}}',
             query_text,
         )
         self.assertEqual(issues[0]["platform"], "Mobile")
@@ -210,9 +232,9 @@ class LinearIssueStateFiltersTest(unittest.TestCase):
                             )
 
         self.assertEqual(len(execute_calls), 2)
-        query_text = execute_calls[0][0]
-        self.assertIn('state: { type: { in: ["completed"] } }', query_text)
-        self.assertNotIn('state: { name: { in: ["Done"] } }', query_text)
+        query_text = _compact_query_text(execute_calls[0][0])
+        self.assertIn('state:{type:{in:["completed"]}}', query_text)
+        self.assertNotIn('state:{name:{in:["Done"]}}', query_text)
         self.assertEqual(execute_calls[0][1]["cursor"], None)
         self.assertEqual(execute_calls[1][1]["cursor"], "cursor-1")
         self.assertEqual(issues[0]["platform"], "iOS")


### PR DESCRIPTION
## Issue
- The stale PR checker skipped PRs whenever GitHub's aggregate review decision was `CHANGES_REQUESTED`, even when the requested-changes reviewer was still the person who needed a reminder or had been re-requested after follow-up commits.
- A Linear issue closed as Duplicate could still appear in open priority bug notifications because open queries excluded a few terminal state types instead of selecting Linear's open state types.

## Solution
- Make stale PR reminders reviewer-specific for active requested-changes reviews: notify only the active change-requesting reviewer while that state is active, and fall back to all open review requests once the change request is cleared.
- Require a current open review request before sending a stale-review reminder, and use the latest request timestamp when calculating stale age.
- Query open Linear work with the comprehensive open state type allow-list: `triage`, `backlog`, `unstarted`, and `started`.

## To Test
- `source .venv-ci/bin/activate && python -m unittest discover -s tests -p 'test_*.py'`
- `source .venv-ci/bin/activate && ruff check .`
- `source .venv-ci/bin/activate && ruff format --check .`
- `source .venv-ci/bin/activate && vulture . --config pyproject.toml`
- `source .venv-ci/bin/activate && mypy .`

## Proof
![Runtime proof](https://raw.githubusercontent.com/ApollosProject/bug-board/codex/proof-assets/pr-338/proof/pr-338-runtime-proof.png)

- Runtime proof ran `jobs.post_stale()` against a local Slack-compatible webhook and showed only the active change-requesting reviewer notified.
- Runtime proof also exercised `github.get_prs_waiting_for_review_by_reviewer()` and live `linear.issues.get_open_issues(2, "Bug")`, confirming APO-8787 is absent from open priority bugs.
- Full test suite passed: 90 tests.
- Ruff, format check, vulture, and mypy passed locally.
- GitHub CI is green for ruff, mypy, unit-tests, vulture, and gunicorn-smoke.
