### PR TITLE
[codex] Dampen Airflow heartbeat flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ On each worker refresh, the app:
 - Evaluates the Airflow REST API and inspects each active DAG's latest run state
 - Refreshes the Redis-backed fleet-health cache when Redis is configured
 - Sends the base heartbeat URL when fleet health is healthy
-- Sends the heartbeat URL with `/fail` appended when fleet health is unhealthy or unknown
+- Sends the heartbeat URL with `/fail` appended when fleet health is degraded
+- Suppresses one-off `unknown` evaluations and only sends `/fail` after 3 consecutive unknowns
 
 The health calculation:
 

--- a/jobs.py
+++ b/jobs.py
@@ -44,6 +44,7 @@ MAX_DIFF_CHARS = 12000
 MAX_DIFF_FILES = 20
 FLEET_HEALTH_REFRESH_DEFAULT_SECONDS = 60
 AIRFLOW_FLEET_HEARTBEAT_TIMEOUT_SECONDS = 10
+AIRFLOW_FLEET_UNKNOWN_HEARTBEAT_FAILURE_THRESHOLD = 3
 INACTIVE_PROJECT_STATUS_NAMES = {
     "completed",
     "incomplete",
@@ -51,6 +52,7 @@ INACTIVE_PROJECT_STATUS_NAMES = {
     "cancelled",
     "released",
 }
+_airflow_fleet_unknown_heartbeat_failures = 0
 
 
 def _read_positive_int_env(name: str, default: int) -> int:
@@ -125,8 +127,26 @@ def report_airflow_fleet_health_heartbeat(payload: dict, status: int) -> None:
     if not heartbeat_url:
         return
 
+    global _airflow_fleet_unknown_heartbeat_failures
+
     is_healthy = status < 400 and payload.get("status") == "healthy"
-    url = heartbeat_url if is_healthy else _append_url_path(heartbeat_url, "fail")
+    should_report_failure = not is_healthy
+    if payload.get("status") == "unknown":
+        _airflow_fleet_unknown_heartbeat_failures += 1
+        should_report_failure = (
+            _airflow_fleet_unknown_heartbeat_failures
+            >= AIRFLOW_FLEET_UNKNOWN_HEARTBEAT_FAILURE_THRESHOLD
+        )
+        if not should_report_failure:
+            logging.warning(
+                "Suppressing transient airflow fleet unknown heartbeat failure (%s/%s)",
+                _airflow_fleet_unknown_heartbeat_failures,
+                AIRFLOW_FLEET_UNKNOWN_HEARTBEAT_FAILURE_THRESHOLD,
+            )
+    else:
+        _airflow_fleet_unknown_heartbeat_failures = 0
+
+    url = heartbeat_url if not should_report_failure else _append_url_path(heartbeat_url, "fail")
 
     try:
         response = requests.get(url, timeout=AIRFLOW_FLEET_HEARTBEAT_TIMEOUT_SECONDS)

--- a/tests/test_failing_dags.py
+++ b/tests/test_failing_dags.py
@@ -69,6 +69,10 @@ def _install_import_shims() -> None:
     aiohttp_module.AIOHTTPTransport = DummyAIOHTTPTransport
     sys.modules.setdefault("gql.transport.aiohttp", aiohttp_module)
 
+    openai_module = cast(Any, types.ModuleType("openai_client"))
+    openai_module.get_chat_function_call = lambda *args, **kwargs: {}
+    sys.modules.setdefault("openai_client", openai_module)
+
 
 _install_import_shims()
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -13,6 +13,7 @@ def _install_import_shims() -> None:
 
     requests_module = cast(Any, types.ModuleType("requests"))
     requests_module.post = lambda *args, **kwargs: None
+    requests_module.get = lambda *args, **kwargs: None
     sys.modules.setdefault("requests", requests_module)
 
     schedule_module = cast(Any, types.ModuleType("schedule"))
@@ -216,6 +217,77 @@ class RunDebugJobsTest(unittest.TestCase):
         leaderboard.assert_called_once_with()
         stale.assert_called_once_with()
         project_updates.assert_called_once_with()
+
+
+class AirflowFleetHeartbeatTest(unittest.TestCase):
+    def setUp(self):
+        jobs_module._airflow_fleet_unknown_heartbeat_failures = 0
+
+    def test_reports_success_for_healthy_payload(self):
+        with patch.dict(
+            jobs_module.os.environ,
+            {"AIRFLOW_FLEET_HEARTBEAT_URL": "https://uptime.betterstack.com/heartbeat/token"},
+            clear=False,
+        ):
+            with patch.object(jobs_module.requests, "get") as get_mock:
+                get_mock.return_value.status_code = 200
+                jobs_module.report_airflow_fleet_health_heartbeat({"status": "healthy"}, 200)
+
+        get_mock.assert_called_once_with(
+            "https://uptime.betterstack.com/heartbeat/token",
+            timeout=jobs_module.AIRFLOW_FLEET_HEARTBEAT_TIMEOUT_SECONDS,
+        )
+
+    def test_reports_failure_immediately_for_degraded_payload(self):
+        with patch.dict(
+            jobs_module.os.environ,
+            {"AIRFLOW_FLEET_HEARTBEAT_URL": "https://uptime.betterstack.com/heartbeat/token/"},
+            clear=False,
+        ):
+            with patch.object(jobs_module.requests, "get") as get_mock:
+                get_mock.return_value.status_code = 200
+                jobs_module.report_airflow_fleet_health_heartbeat({"status": "degraded"}, 503)
+
+        get_mock.assert_called_once_with(
+            "https://uptime.betterstack.com/heartbeat/token/fail",
+            timeout=jobs_module.AIRFLOW_FLEET_HEARTBEAT_TIMEOUT_SECONDS,
+        )
+
+    def test_suppresses_transient_unknown_payloads_until_threshold(self):
+        with patch.dict(
+            jobs_module.os.environ,
+            {"AIRFLOW_FLEET_HEARTBEAT_URL": "https://uptime.betterstack.com/heartbeat/token"},
+            clear=False,
+        ):
+            with patch.object(jobs_module.requests, "get") as get_mock:
+                get_mock.return_value.status_code = 200
+
+                jobs_module.report_airflow_fleet_health_heartbeat({"status": "unknown"}, 503)
+                jobs_module.report_airflow_fleet_health_heartbeat({"status": "unknown"}, 503)
+                jobs_module.report_airflow_fleet_health_heartbeat({"status": "unknown"}, 503)
+
+        self.assertEqual(
+            [call.args[0] for call in get_mock.call_args_list],
+            [
+                "https://uptime.betterstack.com/heartbeat/token",
+                "https://uptime.betterstack.com/heartbeat/token",
+                "https://uptime.betterstack.com/heartbeat/token/fail",
+            ],
+        )
+
+    def test_healthy_payload_resets_unknown_failure_count(self):
+        jobs_module._airflow_fleet_unknown_heartbeat_failures = 2
+
+        with patch.dict(
+            jobs_module.os.environ,
+            {"AIRFLOW_FLEET_HEARTBEAT_URL": "https://uptime.betterstack.com/heartbeat/token"},
+            clear=False,
+        ):
+            with patch.object(jobs_module.requests, "get") as get_mock:
+                get_mock.return_value.status_code = 200
+                jobs_module.report_airflow_fleet_health_heartbeat({"status": "healthy"}, 200)
+
+        self.assertEqual(jobs_module._airflow_fleet_unknown_heartbeat_failures, 0)
 
 
 class FixedDateTime(datetime):


### PR DESCRIPTION
## Summary
- dampen Better Stack heartbeat failures for transient Airflow `unknown` evaluations
- keep real degraded fleet-health payloads reporting `/fail` immediately
- add heartbeat unit coverage and document the new 3-strike unknown behavior

## Root Cause
The worker converts Airflow API evaluation exceptions into `{"status":"unknown"}` with HTTP 503. A single Astronomer `/api/v2/dags` `RemoteDisconnected` then triggered the Better Stack heartbeat `/fail`, which opened and resolved one-minute incidents on the next healthy worker run.

## Proof
- `source .venv-ci/bin/activate && ruff check .`
- `source .venv-ci/bin/activate && mypy .`
- `source .venv-ci/bin/activate && python -m unittest discover -s tests -p 'test_*.py'`
