### PR TITLE
[codex] skip approved PRs in stale review reminders

### DIFF
--- a/github.py
+++ b/github.py
@@ -198,6 +198,12 @@ def has_known_merge_conflicts(pr):
     return pr.get("mergeable") == "CONFLICTING"
 
 
+def has_required_approval(pr):
+    """Return True when GitHub says the PR has satisfied review requirements."""
+
+    return pr.get("reviewDecision") == "APPROVED"
+
+
 def _parse_github_timestamp(value: str | None) -> datetime | None:
     if not value:
         return None
@@ -360,8 +366,9 @@ def get_prs_waiting_for_review_by_reviewer():
     """Return PRs waiting on review, grouped by reviewer.
 
     Includes pull requests with an open review request or active requested-changes
-    reviewer that has been waiting more than 24 hours, even if the PR has
-    previously been reviewed. Only includes PRs with fewer than 200 lines added.
+    reviewer that has been waiting more than 24 hours. Approved PRs are excluded
+    even if GitHub still has leftover review requests. Only includes PRs with
+    fewer than 200 lines added.
     """
     all_prs = _get_all_prs(["OPEN"])
     stuck_prs = {}
@@ -371,6 +378,8 @@ def get_prs_waiting_for_review_by_reviewer():
         if additions is None or additions >= 200:
             continue
         if has_known_merge_conflicts(pr):
+            continue
+        if has_required_approval(pr):
             continue
         active_change_request_reviewers = get_active_change_request_reviewers(pr)
         open_review_requests = {

--- a/tests/test_gql_client_requests.py
+++ b/tests/test_gql_client_requests.py
@@ -168,6 +168,47 @@ class GraphQLClientRequestTests(unittest.TestCase):
 
         self.assertEqual(waiting, {})
 
+    def test_waiting_for_review_skips_approved_prs_with_open_requests(self):
+        class FixedDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                base = datetime(2026, 3, 25, 14, 0, 0)
+                if tz is None:
+                    return base
+                return base.replace(tzinfo=tz)
+
+        pr = {
+            "number": 1479,
+            "additions": 3,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "APPROVED",
+            "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "redreceipt"}}]},
+            "reviews": {
+                "nodes": [
+                    {
+                        "author": {"login": "solideo-gloria"},
+                        "state": "APPROVED",
+                        "submittedAt": "2026-03-24T13:52:12Z",
+                    }
+                ]
+            },
+            "timelineItems": {
+                "nodes": [
+                    {
+                        "createdAt": "2026-03-24T13:51:12Z",
+                        "requestedReviewer": {"login": "redreceipt"},
+                    },
+                ]
+            },
+            "statusCheckRollup": {"state": "SUCCESS"},
+        }
+
+        with patch.object(github, "_get_all_prs", return_value=[pr]):
+            with patch.object(github, "datetime", FixedDateTime):
+                waiting = github.get_prs_waiting_for_review_by_reviewer()
+
+        self.assertEqual(waiting, {})
+
     def test_waiting_for_review_only_notifies_active_change_request_reviewer(self):
         class FixedDateTime(datetime):
             @classmethod


### PR DESCRIPTION
## Summary

This updates the stale review reminder filter so PRs with GitHub's aggregate `reviewDecision` of `APPROVED` are excluded, even when GitHub still has leftover open review requests.

Root cause: the Slack job grouped any open `reviewRequests` as waiting-for-review work after checks passed. That let approved PRs like `ApollosProject/apollos-shovel#1479` appear in the reminder because one requested reviewer was still pending after another reviewer had already approved it.

## To Test

- `source .venv-ci/bin/activate && python -m unittest discover -s tests -p 'test_*.py'`
- `source .venv-ci/bin/activate && ruff check .`
- `source .venv-ci/bin/activate && mypy .`
- `git diff --check`

## Proof

- Full unit suite passed: 95 tests.
- Ruff passed.
- Mypy passed with only existing advisory notes.
- Diff whitespace check passed.
- Live GitHub state for `ApollosProject/apollos-shovel#1479` confirmed the repro shape: `reviewDecision: APPROVED`, successful checks, and an open review request still present.