### PR TITLE
Filter duplicate issues from priority bug Slack post

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -262,6 +262,15 @@ def _person_matches_any_unassigned_platform(person: dict, bugs: list[dict]) -> b
     return any(_normalize_platform_name(bug.get("platform")) in allowed_platforms for bug in bugs)
 
 
+def _is_duplicate_issue(issue: dict) -> bool:
+    state_name = ((issue.get("state") or {}).get("name") or "").strip().lower()
+    if state_name == "duplicate":
+        return True
+
+    labels = (issue.get("labels") or {}).get("nodes", [])
+    return any(((label or {}).get("name") or "").strip().lower() == "duplicate" for label in labels)
+
+
 def _get_pr_diffs(issue):
     """Return a list of diffs for PRs linked in the issue attachments."""
 
@@ -318,6 +327,7 @@ def _get_pr_diffs(issue):
 def post_priority_bugs():
     config = load_config()
     open_priority_bugs = get_open_issues(2, "Bug")
+    open_priority_bugs = [bug for bug in open_priority_bugs if not _is_duplicate_issue(bug)]
     unassigned = [bug for bug in open_priority_bugs if bug["assignee"] is None]
     now = datetime.now(timezone.utc)
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -227,6 +227,47 @@ class FixedDateTime(datetime):
 
 
 class PostPriorityBugsTest(unittest.TestCase):
+    def test_excludes_issues_marked_duplicate(self):
+        posted = []
+        bugs = [
+            {
+                "id": "duplicate-bug",
+                "title": "Duplicate bug",
+                "assignee": None,
+                "url": "https://linear.app/issue/duplicate-bug",
+                "platform": "Admin",
+                "daysOpen": 26,
+                "priority": 2,
+                "state": {"name": "Duplicate"},
+                "slaMediumRiskAt": "2026-03-14T08:00:00.000Z",
+                "slaHighRiskAt": "2026-03-15T09:00:00.000Z",
+                "slaBreachesAt": "2026-03-15T11:00:00.000Z",
+            },
+            {
+                "id": "active-bug",
+                "title": "Active bug",
+                "assignee": None,
+                "url": "https://linear.app/issue/active-bug",
+                "platform": "Web",
+                "daysOpen": 2,
+                "priority": 2,
+                "state": {"name": "Todo"},
+                "slaMediumRiskAt": "2026-03-14T08:00:00.000Z",
+                "slaHighRiskAt": "2026-03-16T10:00:00.000Z",
+                "slaBreachesAt": "2026-03-17T12:00:00.000Z",
+            },
+        ]
+
+        with patch.object(jobs_module, "load_config", return_value={"people": {}, "platforms": {}}):
+            with patch.object(jobs_module, "get_open_issues", return_value=bugs):
+                with patch.object(jobs_module, "post_to_slack", side_effect=posted.append):
+                    with patch.object(jobs_module, "datetime", FixedDateTime):
+                        jobs_module.post_priority_bugs()
+
+        self.assertEqual(len(posted), 1)
+        self.assertIn("Active bug", posted[0])
+        self.assertNotIn("Duplicate bug", posted[0])
+
     def test_uses_linear_sla_windows_for_at_risk_and_overdue(self):
         posted = []
         bugs = [


### PR DESCRIPTION
### Motivation
- Duplicate-marked Linear issues were showing up in the priority bug Slack post (e.g., in *Unassigned Priority Bugs*), creating noise in notifications. 

### Description
- Added a helper ` _is_duplicate_issue(issue: dict) -> bool` that treats an issue as duplicate when its Linear state name is `Duplicate` or when any label name equals `duplicate` (case-insensitive). 
- Filtered out duplicate issues early in `post_priority_bugs()` by applying `open_priority_bugs = [bug for bug in open_priority_bugs if not _is_duplicate_issue(bug)]`. 
- Added a regression test `test_excludes_issues_marked_duplicate` in `tests/test_jobs.py` to ensure duplicate-marked issues are omitted while normal issues remain included. 

### Testing
- Ran `python -m unittest tests.test_jobs.PostPriorityBugsTest.test_excludes_issues_marked_duplicate tests.test_jobs.PostPriorityBugsTest.test_uses_linear_sla_windows_for_at_risk_and_overdue` and both tests passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da326bf50832e865e36de3c6f5853)