### PR TITLE
[codex] Disable scheduled leaderboard post

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -864,7 +864,7 @@ def configure_scheduled_jobs() -> None:
 
     schedule.every().friday.at("13:00").do(post_inactive_engineers)
     schedule.every().day.at("12:00").do(post_priority_bugs)
-    schedule.every().friday.at("16:00", "America/New_York").do(post_leaderboard)
+    # schedule.every().friday.at("16:00", "America/New_York").do(post_leaderboard)
     # schedule.every().thursday.at("19:00").do(post_weekly_changelog)
     schedule.every().day.at("10:00", "America/New_York").do(post_stale)
     schedule.every().day.at("14:00", "America/New_York").do(post_project_updates)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -171,7 +171,7 @@ class ConfigureScheduledJobsTest(unittest.TestCase):
             },
             recorded_jobs,
         )
-        self.assertIn(
+        self.assertNotIn(
             {
                 "interval": None,
                 "unit": "friday",


### PR DESCRIPTION
## Summary
- Comment out the scheduled Friday weekly leaderboard Slack post.
- Leave the debug runner path intact so `DEBUG=true` still posts the leaderboard manually.
- Update the existing scheduled-jobs test expectation to match the temporary disabled schedule.

## Validation
- `source venv/bin/activate && python -m unittest discover -s tests -p 'test_*.py'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only comments out one cron-style Slack job and adjusts a test; no auth, data, or leaderboard logic changes.
> 
> **Overview**
> **Temporarily stops** the automated **Friday 4:00 PM (America/New_York) weekly leaderboard** Slack post by commenting out its `schedule` registration in `configure_scheduled_jobs`. Other scheduled jobs are unchanged.
> 
> `post_leaderboard` is still invoked from `run_debug_jobs` when `DEBUG=true`, so manual/debug runs can still send the message. The scheduled-jobs unit test now expects the Friday leaderboard entry **not** to be registered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 897f393d8b73108114532d8e716647d7d70b2275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->