### PR TITLE
[codex] fix project update date labels

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -681,6 +681,8 @@ def post_project_updates():
             target_label = (
                 target_status_text
                 if target_status_text.endswith("overdue")
+                else "Today"
+                if days_left == 0
                 else _format_short_weekday(target_dt)
             )
             line = f"- <{url}|{name}> - {target_label} - Lead: {lead_md}"
@@ -694,7 +696,7 @@ def post_project_updates():
         start_dt = parse_iso_date(project.get("startDate"))
         if start_dt:
             days_until_start = (start_dt - today).days
-            if 0 <= days_until_start <= 3:
+            if 1 <= days_until_start <= 3:
                 starting_soon.append(
                     {
                         "name": name,

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -715,6 +715,14 @@ class PostProjectUpdatesTest(unittest.TestCase):
                 "status": {"name": "Active"},
                 "lead": {"displayName": "Alex"},
             },
+            # Ending today should use a relative label.
+            {
+                "name": "Ending Today",
+                "url": "https://linear.app/project/ending-today",
+                "targetDate": "2026-03-15",
+                "status": {"name": "Active"},
+                "lead": {"displayName": "Alex"},
+            },
             # Ending soon (within 3 days)
             {
                 "name": "Ending Tue",
@@ -737,6 +745,14 @@ class PostProjectUpdatesTest(unittest.TestCase):
                 "url": "https://linear.app/project/ending-far",
                 "targetDate": "2026-03-19",
                 "status": {"name": "Active"},
+                "lead": {"displayName": "Alex"},
+            },
+            # Starting today should not be in starting soon.
+            {
+                "name": "Starting Today",
+                "url": "https://linear.app/project/starting-today",
+                "startDate": "2026-03-15",
+                "status": {"name": "Planned"},
                 "lead": {"displayName": "Alex"},
             },
             # Starting soon (within 3 days)
@@ -838,11 +854,16 @@ class PostProjectUpdatesTest(unittest.TestCase):
 
         # Correct projects present
         self.assertIn("Late Alpha", message)
+        self.assertIn("Ending Today", message)
         self.assertIn("Ending Tue", message)
         self.assertIn("Ending Wed", message)
         self.assertIn("Starting Tue", message)
         self.assertIn("Starting Wed", message)
         self.assertIn("Lead: <@U1>", message)
+        self.assertIn(
+            "- <https://linear.app/project/ending-today|Ending Today> - Today - Lead: <@U1>",
+            message,
+        )
         self.assertIn(
             "- <https://linear.app/project/ending-tue|Ending Tue> - Tue - Lead: <@U1>", message
         )
@@ -860,6 +881,7 @@ class PostProjectUpdatesTest(unittest.TestCase):
 
         # Correct projects filtered out
         self.assertNotIn("Ending Far", message)
+        self.assertNotIn("Starting Today", message)
         self.assertNotIn("Starting Far", message)
         self.assertNotIn("Canceled Start", message)
         self.assertNotIn("Completed Start", message)


### PR DESCRIPTION
## Summary

- Render projects ending today as `today` in the Slack project update digest.
- Exclude projects starting today from the `Projects Starting Soon` Slack section.
- Add regression coverage for both cases in the project update unit tests.

## Root Cause

The digest used short weekday labels for every non-overdue project target date, including deadlines that are today. The starting-soon window also included day zero, so projects starting today were still shown as upcoming.

## Validation

- `python -m unittest tests.test_jobs.PostProjectUpdatesTest`
- `ruff check .`
- `python -m unittest discover -s tests -p 'test_*.py'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentation and window logic in the scheduled Slack digest; covered by unit tests with no auth or data changes.
> 
> **Overview**
> Adjusts the daily **Projects Ending Soon** / **Projects Starting Soon** Slack digest in `post_project_updates` so same-day dates read clearly and “starting soon” means upcoming days only.
> 
> Projects whose target date is **today** now show **`Today`** in the line label instead of the short weekday (e.g. Sun). Projects whose **start date is today** are no longer listed under *Projects Starting Soon*; that section only includes starts **1–3 days** out.
> 
> Unit tests in `PostProjectUpdatesTest` cover an ending-today line and assert starting-today projects are omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8c2a3a299f8552d243ff54f3606749a923d8618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->