### PR TITLE
[codex] Add overdue project update digest section

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -2,7 +2,7 @@ import logging
 import os
 import re
 import time
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from urllib.parse import urlsplit, urlunsplit
 
 import requests
@@ -53,6 +53,7 @@ INACTIVE_PROJECT_STATUS_NAMES = {
     "cancelled",
     "released",
 }
+PROJECT_UPDATE_DUE_WEEKDAY = 4
 _airflow_fleet_unknown_heartbeat_failures = 0
 
 
@@ -74,6 +75,10 @@ def _is_inactive_project(project: dict) -> bool:
 
 def _format_short_weekday(project_date: date) -> str:
     return project_date.strftime("%a")
+
+
+def _format_short_month_day(project_date: date) -> str:
+    return f"{project_date.strftime('%b')} {project_date.day}"
 
 
 def _normalize_linear_display_name(name: str) -> str:
@@ -98,6 +103,46 @@ def _is_engineering_lead_project(project: dict, people_config: dict) -> bool:
     normalized = _normalize_linear_display_name(lead)
     slug = name_to_slug.get(normalized) or name_to_slug.get(normalized.split()[0])
     return slug in engineering_slugs
+
+
+def _latest_completed_project_update_due_date(today: date) -> date:
+    days_since_friday = (today.weekday() - PROJECT_UPDATE_DUE_WEEKDAY) % 7
+    if days_since_friday == 0:
+        days_since_friday = 7
+    return today - timedelta(days=days_since_friday)
+
+
+def _requires_weekly_project_update(project: dict) -> bool:
+    if _is_inactive_project(project):
+        return False
+    if parse_iso_date(project.get("targetDate")) is None:
+        return False
+    status_type = ((project.get("status") or {}).get("type") or "").strip().lower()
+    return status_type == "started"
+
+
+def _get_project_last_update_dt(project: dict) -> datetime | None:
+    last_update = project.get("lastUpdate") or {}
+    return parse_linear_dt(last_update.get("createdAt"))
+
+
+def _format_overdue_project_update_detail(
+    project: dict, update_due_date: date
+) -> tuple[date, str] | None:
+    last_update_dt = _get_project_last_update_dt(project)
+    if last_update_dt and last_update_dt.date() >= update_due_date:
+        return None
+
+    last_update_date = last_update_dt.date() if last_update_dt else date.min
+    last_update_text = (
+        f"last update {_format_short_month_day(last_update_date)}"
+        if last_update_dt
+        else "no updates yet"
+    )
+    return (
+        last_update_date,
+        f"Due {_format_short_month_day(update_due_date)}; {last_update_text}",
+    )
 
 
 def post_to_slack(markdown: str):
@@ -660,8 +705,10 @@ def post_project_updates():
     people_config = load_config().get("people", {})
     now = datetime.now(timezone.utc)
     today = now.date()
+    update_due_date = _latest_completed_project_update_due_date(today)
 
     overdue = []
+    overdue_updates = []
     ending_soon = []
     starting_soon = []
 
@@ -674,6 +721,18 @@ def post_project_updates():
         lead = (project.get("lead") or {}).get("displayName")
         lead_md = get_slack_markdown_by_linear_username(lead) if lead else "No Lead"
         inactive = _is_inactive_project(project)
+
+        if _requires_weekly_project_update(project):
+            update_detail = _format_overdue_project_update_detail(project, update_due_date)
+            if update_detail:
+                last_update_date, update_status_text = update_detail
+                overdue_updates.append(
+                    {
+                        "name": name,
+                        "last_update_date": last_update_date,
+                        "line": f"- <{url}|{name}> - {update_status_text} - Lead: {lead_md}",
+                    }
+                )
 
         target_dt = parse_iso_date(project.get("targetDate"))
         days_left, target_status_text = format_project_target_status(target_dt, now=now)
@@ -712,6 +771,14 @@ def post_project_updates():
     if overdue:
         ordered = sorted(overdue, key=lambda item: (item["target_dt"], item["name"].lower()))
         sections.append("*Overdue Projects*\n\n" + "\n".join(item["line"] for item in ordered))
+    if overdue_updates:
+        ordered = sorted(
+            overdue_updates,
+            key=lambda item: (item["last_update_date"], item["name"].lower()),
+        )
+        sections.append(
+            "*Projects With Overdue Updates*\n\n" + "\n".join(item["line"] for item in ordered)
+        )
     if ending_soon:
         ordered = sorted(ending_soon, key=lambda item: (item["target_dt"], item["name"].lower()))
         sections.append("*Projects Ending Soon*\n\n" + "\n".join(item["line"] for item in ordered))

--- a/linear/projects.py
+++ b/linear/projects.py
@@ -83,6 +83,9 @@ def get_projects():
                   completedAt
                   startDate
                   targetDate
+                  lastUpdate {
+                    createdAt
+                  }
                   lead {
                     displayName
                   }

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -354,6 +354,14 @@ class FixedDateTime(datetime):
         return datetime(2026, 3, 15, 12, 0, 0, tzinfo=tz)
 
 
+class FixedFridayDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        if tz is None:
+            return datetime(2026, 3, 13, 12, 0, 0)
+        return datetime(2026, 3, 13, 12, 0, 0, tzinfo=tz)
+
+
 class PostPriorityBugsTest(unittest.TestCase):
     def test_uses_linear_sla_windows_for_at_risk_and_overdue(self):
         posted = []
@@ -695,12 +703,12 @@ class PostPriorityBugsInvalidWhitelistFallbackTest(unittest.TestCase):
 
 
 class PostProjectUpdatesTest(unittest.TestCase):
-    def _run(self, projects, config):
+    def _run(self, projects, config, datetime_cls=FixedDateTime):
         posted = []
         with patch.object(jobs_module, "load_config", return_value=config):
             with patch.object(jobs_module, "get_projects", return_value=projects):
                 with patch.object(jobs_module, "post_to_slack", side_effect=posted.append):
-                    with patch.object(jobs_module, "datetime", FixedDateTime):
+                    with patch.object(jobs_module, "datetime", datetime_cls):
                         jobs_module.post_project_updates()
         return posted
 
@@ -911,6 +919,113 @@ class PostProjectUpdatesTest(unittest.TestCase):
         }
 
         posted = self._run(projects, config)
+        self.assertEqual(posted, [])
+
+    def test_lists_started_projects_with_overdue_friday_updates(self):
+        projects = [
+            {
+                "name": "Old Update",
+                "url": "https://linear.app/project/old-update",
+                "targetDate": "2026-03-31",
+                "status": {"name": "In Development", "type": "started"},
+                "lead": {"displayName": "Alex"},
+                "lastUpdate": {"createdAt": "2026-03-12T16:00:00.000Z"},
+            },
+            {
+                "name": "No Update",
+                "url": "https://linear.app/project/no-update",
+                "targetDate": "2026-03-31",
+                "status": {"name": "In Development", "type": "started"},
+                "lead": {"displayName": "Alex"},
+                "lastUpdate": None,
+            },
+            {
+                "name": "Updated Friday",
+                "url": "https://linear.app/project/updated-friday",
+                "targetDate": "2026-03-31",
+                "status": {"name": "In Development", "type": "started"},
+                "lead": {"displayName": "Alex"},
+                "lastUpdate": {"createdAt": "2026-03-13T09:00:00.000Z"},
+            },
+            {
+                "name": "Missing End Date",
+                "url": "https://linear.app/project/missing-end-date",
+                "status": {"name": "In Development", "type": "started"},
+                "lead": {"displayName": "Alex"},
+                "lastUpdate": None,
+            },
+            {
+                "name": "Backlog Missing Update",
+                "url": "https://linear.app/project/backlog",
+                "status": {"name": "Define", "type": "backlog"},
+                "lead": {"displayName": "Alex"},
+                "lastUpdate": None,
+            },
+            {
+                "name": "Product Lead Missing Update",
+                "url": "https://linear.app/project/product-lead",
+                "status": {"name": "In Development", "type": "started"},
+                "lead": {"displayName": "Pat"},
+                "lastUpdate": None,
+            },
+        ]
+        config = {
+            "people": {
+                "alex": {
+                    "linear_username": "Alex",
+                    "slack_id": "U1",
+                    "team": "engineering",
+                },
+                "pat": {
+                    "linear_username": "Pat",
+                    "slack_id": "U2",
+                    "team": "product",
+                },
+            }
+        }
+
+        posted = self._run(projects, config)
+
+        self.assertEqual(len(posted), 1)
+        message = posted[0]
+        self.assertIn("*Projects With Overdue Updates*", message)
+        self.assertIn(
+            "- <https://linear.app/project/no-update|No Update> - Due Mar 13; "
+            "no updates yet - Lead: <@U1>",
+            message,
+        )
+        self.assertIn(
+            "- <https://linear.app/project/old-update|Old Update> - Due Mar 13; "
+            "last update Mar 12 - Lead: <@U1>",
+            message,
+        )
+        self.assertNotIn("Missing End Date", message)
+        self.assertNotIn("Updated Friday", message)
+        self.assertNotIn("Backlog Missing Update", message)
+        self.assertNotIn("Product Lead Missing Update", message)
+
+    def test_does_not_require_current_friday_update_until_saturday(self):
+        projects = [
+            {
+                "name": "Already Updated For Previous Friday",
+                "url": "https://linear.app/project/previous-friday",
+                "targetDate": "2026-03-31",
+                "status": {"name": "In Development", "type": "started"},
+                "lead": {"displayName": "Alex"},
+                "lastUpdate": {"createdAt": "2026-03-06T16:00:00.000Z"},
+            }
+        ]
+        config = {
+            "people": {
+                "alex": {
+                    "linear_username": "Alex",
+                    "slack_id": "U1",
+                    "team": "engineering",
+                },
+            }
+        }
+
+        posted = self._run(projects, config, datetime_cls=FixedFridayDateTime)
         self.assertEqual(posted, [])
 
 

--- a/tests/test_linear_projects.py
+++ b/tests/test_linear_projects.py
@@ -53,8 +53,10 @@ class GetProjectsTest(unittest.TestCase):
             },
         ]
         calls = []
+        queries = []
 
         def fake_execute(_query, variable_values=None):
+            queries.append(str(_query))
             calls.append(variable_values)
             return responses[len(calls) - 1]
 
@@ -78,6 +80,7 @@ class GetProjectsTest(unittest.TestCase):
         )
         self.assertEqual(projects[0]["members"], ["Austin Witherow"])
         self.assertEqual(projects[1]["members"], ["Nathan Lewis"])
+        self.assertIn("lastUpdate", queries[0])
 
 
 class GetCompletedProjectIssueAssigneesTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds a `Projects With Overdue Updates` section to the project Slack digest.

The section flags active engineering-led Linear projects whose latest project update predates the most recent completed Friday. Projects are only eligible when they are started, not inactive, and have a valid end date (`targetDate`) set, so placeholder projects without an end date are excluded.

## Validation

- `ruff check . && ruff format --check .`
- `python -m unittest discover -s tests -p 'test_*.py'`
- `mypy .`

## Proof

Non-posting live dry run of `post_project_updates()` against current Linear data:

```text
messages=1
Ministry Platform Integration: False
Admin React Router Migration: False
Charges as source of truth (decouple from stripe_events): True
Migration Nudges: Web Embed Popups: True
```
