### PR TITLE
[codex] Handle GitHub PR timeouts in stale job

### DIFF
--- a/github.py
+++ b/github.py
@@ -73,6 +73,13 @@ def _format_failure(name: str, exc: Exception) -> str:
     return f"{name}: {type(exc).__name__}"
 
 
+def _format_exception(exc: Exception) -> str:
+    message = str(exc)
+    if message:
+        return message
+    return type(exc).__name__
+
+
 @lru_cache(maxsize=1)
 def get_repo_ids_by_name():
     if not token:
@@ -303,7 +310,9 @@ def _get_all_prs(pr_states: List[str]) -> List[Dict[str, Any]]:
             try:
                 all_prs.extend(future.result())
             except Exception as exc:
-                logging.exception("Failed to fetch GitHub PRs for %s", repo_name)
+                logging.warning(
+                    "Failed to fetch GitHub PRs for %s: %s", repo_name, _format_exception(exc)
+                )
                 failures.append(_format_failure(repo_name, exc))
         if failures:
             raise GitHubDataError("Failed to fetch complete GitHub PR data: " + "; ".join(failures))

--- a/jobs.py
+++ b/jobs.py
@@ -14,6 +14,7 @@ from config import load_config
 from constants import ENGINEERING_TEAM_SLUG, PRIORITY_TO_SCORE
 from fleet_health_cache import refresh_fleet_health_cache, should_use_redis_cache
 from github import (
+    GitHubDataError,
     get_pr_diff,
     get_prs_waiting_for_review_by_reviewer,
     merged_prs_by_author,
@@ -600,7 +601,11 @@ def post_stale():
         for person in engineering_team_members.values()
         if person.get("linear_username")
     }
-    prs = get_prs_waiting_for_review_by_reviewer()
+    try:
+        prs = get_prs_waiting_for_review_by_reviewer()
+    except GitHubDataError as exc:
+        logging.warning("Skipping GitHub PR review reminders: %s", exc)
+        prs = {}
     stale_issues = get_stale_issues_by_assignee(
         get_open_stale_issues(),
         7,

--- a/tests/test_gql_client_requests.py
+++ b/tests/test_gql_client_requests.py
@@ -121,12 +121,17 @@ class GraphQLClientRequestTests(unittest.TestCase):
         }
         with patch.object(github, "get_repo_ids_by_name", return_value=repo_ids):
             with patch.object(github, "get_prs", side_effect=fake_get_prs):
-                with patch.object(github.logging, "exception"):
+                with patch.object(github.logging, "warning") as warning:
                     with self.assertRaisesRegex(
                         github.GitHubDataError,
                         "apollosproject/apollos-cluster",
                     ):
                         github._get_all_prs(["OPEN"])
+        warning.assert_called_once_with(
+            "Failed to fetch GitHub PRs for %s: %s",
+            "apollosproject/apollos-cluster",
+            "rate limited",
+        )
 
     def test_waiting_for_review_uses_utc_timestamps(self):
         class FixedDateTime(datetime):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -43,6 +43,7 @@ def _install_import_shims() -> None:
     sys.modules.setdefault("fleet_health_cache", fleet_health_module)
 
     github_module = cast(Any, types.ModuleType("github"))
+    github_module.GitHubDataError = type("GitHubDataError", (RuntimeError,), {})
     github_module.get_pr_diff = lambda *args, **kwargs: ""
     github_module.get_prs_waiting_for_review_by_reviewer = lambda *args, **kwargs: {}
     github_module.merged_prs_by_author = lambda *args, **kwargs: {}
@@ -273,6 +274,58 @@ class PostStaleTest(unittest.TestCase):
         self.assertIn("*Stale Open Issues*", message)
         self.assertIn("APO-7555", message)
         self.assertIn("(74d)", message)
+
+    def test_continues_with_linear_stale_issues_when_github_pr_fetch_fails(self):
+        open_issues = [{"id": "APO-7555"}]
+
+        def fake_get_stale_issues(issues, days):
+            self.assertIs(issues, open_issues)
+            self.assertEqual(days, 7)
+            return {
+                "dylan": [
+                    {
+                        "title": "Regression in Apple Pay campus/fund confirmation flow",
+                        "url": "https://linear.app/differential/issue/APO-7555",
+                        "daysStale": 74,
+                        "priority": 0,
+                        "platform": None,
+                    }
+                ]
+            }
+
+        with patch.object(
+            jobs_module,
+            "get_team_members",
+            return_value={"dylan": {"linear_username": "dylan", "slack_id": "U03LD9MJLNP"}},
+        ):
+            with patch.object(
+                jobs_module,
+                "get_prs_waiting_for_review_by_reviewer",
+                side_effect=jobs_module.GitHubDataError("GitHub timed out"),
+            ):
+                with patch.object(jobs_module, "get_open_stale_issues", return_value=open_issues):
+                    with patch.object(
+                        jobs_module,
+                        "get_stale_issues_by_assignee",
+                        side_effect=fake_get_stale_issues,
+                    ):
+                        with patch.dict(
+                            jobs_module.os.environ,
+                            {"APP_URL": "https://bug-board.example"},
+                            clear=False,
+                        ):
+                            with patch.object(jobs_module.logging, "warning") as warning:
+                                with patch.object(jobs_module, "post_to_slack") as post:
+                                    jobs_module.post_stale()
+
+        warning.assert_called_once()
+        self.assertEqual(warning.call_args.args[0], "Skipping GitHub PR review reminders: %s")
+        self.assertEqual(str(warning.call_args.args[1]), "GitHub timed out")
+        post.assert_called_once()
+        message = post.call_args.args[0]
+        self.assertIn("*Stale Open Issues*", message)
+        self.assertIn("APO-7555", message)
+        self.assertNotIn("*PRs - Checks Passing", message)
 
 
 class AirflowFleetHeartbeatTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Prevents GitHub PR aggregation timeouts from aborting the whole stale Slack job.

`post_stale()` now treats `GitHubDataError` from the PR review-reminder subsection as a degraded GitHub-only condition: it logs one concise warning, skips the PR reminder section, and continues building Linear stale issue reminders. The lower-level GitHub aggregator still raises `GitHubDataError` so direct callers do not silently receive incomplete PR data, but per-repo fetch failures no longer emit full stack traces before the aggregate error is raised.

## Root Cause

Running `python jobs.py` in debug mode invokes `post_stale()` before the project update job. `post_stale()` fetched GitHub PR review reminders first, and a GitHub GraphQL timeout in that subsection propagated through tenacity, producing repeated large tracebacks and blocking the rest of the stale job.

## Validation

- `ruff check . && ruff format --check .`
- `python -m unittest discover -s tests -p 'test_*.py'`
- `mypy .`

## Proof

Non-posting direct run of `post_stale()` with GitHub PR fetch forced to raise `GitHubDataError`:

```text
warnings=1
posts=1
contains_pr_section=False
contains_stale_section=True
contains_issue=True
```
