### PR TITLE
[codex] Use three-week stale issue threshold

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -47,6 +47,7 @@ MAX_DIFF_FILES = 20
 FLEET_HEALTH_REFRESH_DEFAULT_SECONDS = 60
 AIRFLOW_FLEET_HEARTBEAT_TIMEOUT_SECONDS = 10
 AIRFLOW_FLEET_UNKNOWN_HEARTBEAT_FAILURE_THRESHOLD = 3
+STALE_LINEAR_ISSUE_DAYS = 21
 INACTIVE_PROJECT_STATUS_NAMES = {
     "completed",
     "incomplete",
@@ -608,7 +609,7 @@ def post_stale():
         prs = {}
     stale_issues = get_stale_issues_by_assignee(
         get_open_stale_issues(),
-        7,
+        STALE_LINEAR_ISSUE_DAYS,
     )
     if not prs and not stale_issues:
         return

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -227,7 +227,7 @@ class PostStaleTest(unittest.TestCase):
 
         def fake_get_stale_issues(issues, days):
             self.assertIs(issues, open_issues)
-            self.assertEqual(days, 7)
+            self.assertEqual(days, 21)
             return {
                 "dylan": [
                     {
@@ -280,7 +280,7 @@ class PostStaleTest(unittest.TestCase):
 
         def fake_get_stale_issues(issues, days):
             self.assertIs(issues, open_issues)
-            self.assertEqual(days, 7)
+            self.assertEqual(days, 21)
             return {
                 "dylan": [
                     {


### PR DESCRIPTION
## Summary

- Change the stale open Linear issue reminder threshold from 7 days to 21 days.
- Extract the threshold into a named constant for the stale Slack summary job.
- Update stale reminder tests to lock the three-week cutoff.

## Impact

Linear issues will only appear in the stale open issues Slack reminder after more than three weeks without updates, reducing noise from recently touched items.

## Validation

- `ruff check .`
- `mypy .`
- `python -m unittest discover -s tests -p 'test_*.py'`