### PR TITLE
Update support availability header

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -458,7 +458,7 @@ def post_priority_bugs():
                 notified_lines.append(f"<@{slack_id}>")
 
             notified_text = "\n".join(notified_lines)
-            unassigned_section += f"\n\nattn:\n\n{notified_text}"
+            unassigned_section += f"\n\nAvailable for Support\n\n{notified_text}"
         sections.append(unassigned_section)
     if at_risk:
         sections.append(

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -598,7 +598,7 @@ class PostPriorityBugsTest(unittest.TestCase):
                             jobs_module.post_priority_bugs()
 
         self.assertEqual(len(posted), 1)
-        self.assertIn("attn:\n\n<@U2>\n<@U3>\n<@U4>", posted[0])
+        self.assertIn("Available for Support\n\n<@U2>\n<@U3>\n<@U4>", posted[0])
         self.assertNotIn("<@U1>", posted[0])
         self.assertNotIn("Lead)", posted[0])
 
@@ -660,7 +660,7 @@ class PostPriorityBugsTest(unittest.TestCase):
                             jobs_module.post_priority_bugs()
 
         self.assertEqual(len(posted), 1)
-        self.assertIn("attn:\n\n<@U2>\n<@U4>", posted[0])
+        self.assertIn("Available for Support\n\n<@U2>\n<@U4>", posted[0])
         self.assertNotIn("<@U1>", posted[0])
         self.assertNotIn("<@U3>", posted[0])
 
@@ -750,7 +750,7 @@ class PostPriorityBugsInvalidWhitelistFallbackTest(unittest.TestCase):
                                 jobs_module.post_priority_bugs()
 
         self.assertEqual(len(posted), 1)
-        self.assertIn("attn:\n\n<@U1>\n<@U2>", posted[0])
+        self.assertIn("Available for Support\n\n<@U1>\n<@U2>", posted[0])
         self.assertNotIn("<@U3>", posted[0])
         warning.assert_called_once()
 


### PR DESCRIPTION
## Summary

- Rename the Slack priority-bug availability section from `attn:` to `Available for Support`.
- Update the worker tests to assert the new wording.

## Why

The scheduled Slack summary used shorthand copy that was less clear for recipients. The new header keeps the same mention list behavior while making the section intent explicit.

## Validation

- `source venv/bin/activate && python -m unittest tests.test_jobs`
- `git diff --check`
