### PR TITLE
Fix stale PR checker timeouts

### DIFF
--- a/github.py
+++ b/github.py
@@ -28,6 +28,7 @@ TRACKED_REPOSITORIES = (
     "apollosproject/apollos-embeds",
     "differential/crossroads-anywhere",
 )
+GITHUB_GRAPHQL_EXECUTE_TIMEOUT_SECONDS = 30
 
 
 class GitHubDataError(RuntimeError):
@@ -44,7 +45,11 @@ def _get_client():
             url="https://api.github.com/graphql",
             headers=headers,
         )
-        client = Client(transport=transport, fetch_schema_from_transport=False)
+        client = Client(
+            transport=transport,
+            fetch_schema_from_transport=False,
+            execute_timeout=GITHUB_GRAPHQL_EXECUTE_TIMEOUT_SECONDS,
+        )
         _thread_local.client = client
     return client
 

--- a/jobs.py
+++ b/jobs.py
@@ -589,6 +589,14 @@ def post_leaderboard():
     post_to_slack(markdown)
 
 
+def _get_prs_waiting_for_review_with_retry():
+    try:
+        return get_prs_waiting_for_review_by_reviewer()
+    except GitHubDataError as exc:
+        logging.warning("Retrying GitHub PR review reminders after failure: %s", exc)
+        return get_prs_waiting_for_review_by_reviewer()
+
+
 @with_retries
 def post_stale():
     engineering_team_members = get_team_members(ENGINEERING_TEAM_SLUG)
@@ -602,19 +610,27 @@ def post_stale():
         for person in engineering_team_members.values()
         if person.get("linear_username")
     }
+    github_prs_unavailable = False
     try:
-        prs = get_prs_waiting_for_review_by_reviewer()
+        prs = _get_prs_waiting_for_review_with_retry()
     except GitHubDataError as exc:
-        logging.warning("Skipping GitHub PR review reminders: %s", exc)
+        logging.warning("Skipping GitHub PR review reminders after retry: %s", exc)
         prs = {}
+        github_prs_unavailable = True
     stale_issues = get_stale_issues_by_assignee(
         get_open_stale_issues(),
         STALE_LINEAR_ISSUE_DAYS,
     )
-    if not prs and not stale_issues:
+    if not prs and not stale_issues and not github_prs_unavailable:
         return
 
     markdown = ""
+    if github_prs_unavailable:
+        markdown += (
+            "*Stale PR Check Unavailable*\n\n"
+            "GitHub did not return complete PR data after retrying, "
+            "so review reminders were skipped.\n\n"
+        )
     filtered = {}
     for reviewer, pr_list in prs.items():
         if reviewer not in people_by_github_username:
@@ -662,7 +678,7 @@ def post_stale():
         if assignee in engineering_linear_usernames and issues
     }
 
-    if not prs and not filtered_stale_issues:
+    if not prs and not filtered_stale_issues and not github_prs_unavailable:
         return
 
     if any(filtered_stale_issues.values()):

--- a/jobs.py
+++ b/jobs.py
@@ -621,16 +621,17 @@ def post_stale():
         get_open_stale_issues(),
         STALE_LINEAR_ISSUE_DAYS,
     )
-    if not prs and not stale_issues and not github_prs_unavailable:
-        return
-
-    markdown = ""
     if github_prs_unavailable:
-        markdown += (
+        post_to_manager_slack(
             "*Stale PR Check Unavailable*\n\n"
             "GitHub did not return complete PR data after retrying, "
             "so review reminders were skipped.\n\n"
+            f"<{os.getenv('APP_URL')}|View Bug Board>"
         )
+    if not prs and not stale_issues:
+        return
+
+    markdown = ""
     filtered = {}
     for reviewer, pr_list in prs.items():
         if reviewer not in people_by_github_username:
@@ -678,7 +679,7 @@ def post_stale():
         if assignee in engineering_linear_usernames and issues
     }
 
-    if not prs and not filtered_stale_issues and not github_prs_unavailable:
+    if not prs and not filtered_stale_issues:
         return
 
     if any(filtered_stale_issues.values()):

--- a/tests/test_gql_client_requests.py
+++ b/tests/test_gql_client_requests.py
@@ -18,6 +18,26 @@ class _RecordingClient:
 
 
 class GraphQLClientRequestTests(unittest.TestCase):
+    def test_github_client_allows_slow_repository_queries(self):
+        previous_client = getattr(github._thread_local, "client", None)
+        if hasattr(github._thread_local, "client"):
+            del github._thread_local.client
+        try:
+            with patch.object(github, "AIOHTTPTransport") as transport:
+                with patch.object(github, "Client") as client:
+                    github._get_client()
+
+            client.assert_called_once_with(
+                transport=transport.return_value,
+                fetch_schema_from_transport=False,
+                execute_timeout=github.GITHUB_GRAPHQL_EXECUTE_TIMEOUT_SECONDS,
+            )
+        finally:
+            if previous_client is not None:
+                github._thread_local.client = previous_client
+            elif hasattr(github._thread_local, "client"):
+                del github._thread_local.client
+
     def test_github_execute_embeds_variables_in_graphql_request(self):
         client = _RecordingClient()
         query = gql("query RepoId($owner: String!) { __typename }")

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -222,6 +222,24 @@ class RunDebugJobsTest(unittest.TestCase):
 
 
 class PostStaleTest(unittest.TestCase):
+    def test_retries_transient_github_pr_fetch_failure(self):
+        reminders = {"redreceipt": [{"url": "https://github.com/example/repo/pull/1"}]}
+        timeout_error = jobs_module.GitHubDataError("GitHub timed out")
+        with patch.object(
+            jobs_module,
+            "get_prs_waiting_for_review_by_reviewer",
+            side_effect=[timeout_error, reminders],
+        ) as fetch:
+            with patch.object(jobs_module.logging, "warning") as warning:
+                result = jobs_module._get_prs_waiting_for_review_with_retry()
+
+        self.assertEqual(result, reminders)
+        self.assertEqual(fetch.call_count, 2)
+        warning.assert_called_once_with(
+            "Retrying GitHub PR review reminders after failure: %s",
+            timeout_error,
+        )
+
     def test_uses_open_stale_issues_without_label_or_priority_queries(self):
         open_issues = [{"id": "APO-7555"}]
 
@@ -318,14 +336,47 @@ class PostStaleTest(unittest.TestCase):
                                 with patch.object(jobs_module, "post_to_slack") as post:
                                     jobs_module.post_stale()
 
-        warning.assert_called_once()
-        self.assertEqual(warning.call_args.args[0], "Skipping GitHub PR review reminders: %s")
-        self.assertEqual(str(warning.call_args.args[1]), "GitHub timed out")
+        self.assertEqual(warning.call_count, 2)
+        self.assertEqual(
+            warning.call_args_list[-1].args[0],
+            "Skipping GitHub PR review reminders after retry: %s",
+        )
+        self.assertEqual(str(warning.call_args_list[-1].args[1]), "GitHub timed out")
         post.assert_called_once()
         message = post.call_args.args[0]
+        self.assertIn("*Stale PR Check Unavailable*", message)
         self.assertIn("*Stale Open Issues*", message)
         self.assertIn("APO-7555", message)
         self.assertNotIn("*PRs - Checks Passing", message)
+
+    def test_posts_degraded_notice_when_github_fails_and_no_stale_issues_exist(self):
+        with patch.object(
+            jobs_module,
+            "get_team_members",
+            return_value={"dylan": {"linear_username": "dylan", "slack_id": "U03LD9MJLNP"}},
+        ):
+            with patch.object(
+                jobs_module,
+                "get_prs_waiting_for_review_by_reviewer",
+                side_effect=jobs_module.GitHubDataError("GitHub timed out"),
+            ) as fetch:
+                with patch.object(jobs_module, "get_open_stale_issues", return_value=[]):
+                    with patch.object(jobs_module, "get_stale_issues_by_assignee", return_value={}):
+                        with patch.dict(
+                            jobs_module.os.environ,
+                            {"APP_URL": "https://bug-board.example"},
+                            clear=False,
+                        ):
+                            with patch.object(jobs_module, "post_to_slack") as post:
+                                jobs_module.post_stale()
+
+        self.assertEqual(fetch.call_count, 2)
+        post.assert_called_once()
+        message = post.call_args.args[0]
+        self.assertIn("*Stale PR Check Unavailable*", message)
+        self.assertIn("GitHub did not return complete PR data after retrying", message)
+        self.assertNotIn("*PRs - Checks Passing", message)
+        self.assertNotIn("*Stale Open Issues*", message)
 
 
 class AirflowFleetHeartbeatTest(unittest.TestCase):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -333,8 +333,11 @@ class PostStaleTest(unittest.TestCase):
                             clear=False,
                         ):
                             with patch.object(jobs_module.logging, "warning") as warning:
-                                with patch.object(jobs_module, "post_to_slack") as post:
-                                    jobs_module.post_stale()
+                                with patch.object(
+                                    jobs_module, "post_to_manager_slack"
+                                ) as manager_post:
+                                    with patch.object(jobs_module, "post_to_slack") as post:
+                                        jobs_module.post_stale()
 
         self.assertEqual(warning.call_count, 2)
         self.assertEqual(
@@ -342,14 +345,18 @@ class PostStaleTest(unittest.TestCase):
             "Skipping GitHub PR review reminders after retry: %s",
         )
         self.assertEqual(str(warning.call_args_list[-1].args[1]), "GitHub timed out")
+        manager_post.assert_called_once()
+        manager_message = manager_post.call_args.args[0]
+        self.assertIn("*Stale PR Check Unavailable*", manager_message)
+        self.assertIn("https://bug-board.example", manager_message)
         post.assert_called_once()
         message = post.call_args.args[0]
-        self.assertIn("*Stale PR Check Unavailable*", message)
+        self.assertNotIn("*Stale PR Check Unavailable*", message)
         self.assertIn("*Stale Open Issues*", message)
         self.assertIn("APO-7555", message)
         self.assertNotIn("*PRs - Checks Passing", message)
 
-    def test_posts_degraded_notice_when_github_fails_and_no_stale_issues_exist(self):
+    def test_posts_degraded_notice_to_manager_when_no_stale_issues_exist(self):
         with patch.object(
             jobs_module,
             "get_team_members",
@@ -367,14 +374,17 @@ class PostStaleTest(unittest.TestCase):
                             {"APP_URL": "https://bug-board.example"},
                             clear=False,
                         ):
-                            with patch.object(jobs_module, "post_to_slack") as post:
-                                jobs_module.post_stale()
+                            with patch.object(jobs_module, "post_to_manager_slack") as manager_post:
+                                with patch.object(jobs_module, "post_to_slack") as post:
+                                    jobs_module.post_stale()
 
         self.assertEqual(fetch.call_count, 2)
-        post.assert_called_once()
-        message = post.call_args.args[0]
+        post.assert_not_called()
+        manager_post.assert_called_once()
+        message = manager_post.call_args.args[0]
         self.assertIn("*Stale PR Check Unavailable*", message)
         self.assertIn("GitHub did not return complete PR data after retrying", message)
+        self.assertIn("https://bug-board.example", message)
         self.assertNotIn("*PRs - Checks Passing", message)
         self.assertNotIn("*Stale Open Issues*", message)
 


### PR DESCRIPTION
## Summary

- Extend the GitHub GraphQL execution deadline from 10 to 30 seconds for the repository-heavy PR query.
- Retry the stale PR aggregation once before degrading.
- Send an explicit warning through the manager Slack webhook when GitHub remains unavailable.
- Keep normal PR and stale-issue reminders on the public Slack webhook.
- Cover the timeout, retry, manager-warning, and empty-Linear-fallback paths with regression tests.

## Root cause

At the July 11 10:00 EDT production run, the `differential/crossroads-anywhere` GraphQL request exceeded the client's default deadline. `post_stale()` caught the aggregate `GitHubDataError` and replaced the PR result with an empty mapping. Once there were no matching stale Linear issues, the function returned before calling Slack, making the scheduled run look like it never happened.

## Impact

Transient GitHub latency should now recover on the retry. If both attempts fail, the manager Slack channel receives a concise degraded-status message while the public channel receives only normal PR and stale-issue reminders.

## Validation

- `python -m unittest discover -s tests -p 'test_*.py'` — 107 tests passed
- `ruff check .`
- `ruff format --check .`
- `mypy .`
- `git diff --check`

## Proof

Before, the July 11 production worker discarded the PR reminder section at 10:00 EDT:

```text
WARNING Failed to fetch GitHub PRs for differential/crossroads-anywhere
WARNING Skipping GitHub PR review reminders: Failed to fetch complete GitHub PR data
```

After, a non-posting run of the patched job against the real GitHub and Linear APIs produced the expected PR payload:

```text
elapsed=10.7s posts=1
has_prs=True
has_stale_issues=False
has_degraded_notice=False
payload_chars=3823
```