### PR TITLE
Fix spinner animation and speed up person pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,7 +19,11 @@ from fleet_health_cache import (
     get_cached_fleet_health,
     should_use_redis_cache,
 )
-from github import merged_prs_by_author, merged_prs_by_reviewer
+from github import (
+    get_merged_pr_counts_for_user,
+    merged_prs_by_author,
+    merged_prs_by_reviewer,
+)
 from leaderboard import (
     calculate_cycle_project_lead_points,
     calculate_cycle_project_member_points,
@@ -405,8 +409,8 @@ EXECUTOR_TIMEOUT_SECONDS = 30
 # Number of worker threads used in the index route for parallel data fetching
 INDEX_THREADPOOL_MAX_WORKERS = 12
 # Number of worker threads used in the /team/<slug> route when fetching
-# Linear and GitHub data concurrently
-TEAM_THREADPOOL_MAX_WORKERS = 3
+# Linear projects, issues, and GitHub data concurrently
+TEAM_THREADPOOL_MAX_WORKERS = 4
 # Cache time-to-live in seconds for the index page
 INDEX_CACHE_TTL_SECONDS = 60
 
@@ -1145,7 +1149,11 @@ def _build_team_context(_cache_epoch: int) -> dict:
         key=lambda d: d["name"],
     )
 
-    support_slugs = [slug for slug in get_support_slugs() if slug in engineering_team_slugs]
+    support_slugs = [
+        slug
+        for slug in get_support_slugs(config=config, projects=cycle_projects)
+        if slug in engineering_team_slugs
+    ]
     on_call_support = sorted(
         [{"slug": name, "name": format_name(name)} for name in support_slugs],
         key=lambda d: d["name"],
@@ -1187,13 +1195,13 @@ def _build_person_context(slug: str, days: int, _cache_epoch: int) -> dict:
     with ThreadPoolExecutor(max_workers=TEAM_THREADPOOL_MAX_WORKERS) as executor:
         open_future = executor.submit(get_open_issues_for_person, login)
         completed_future = executor.submit(get_completed_issues_for_person, login, days)
+        projects_future = executor.submit(get_projects)
         github_future = None
         if github_username:
             github_future = executor.submit(
-                lambda: (
-                    merged_prs_by_author(days),
-                    merged_prs_by_reviewer(days),
-                )
+                get_merged_pr_counts_for_user,
+                github_username,
+                days,
             )
         open_items = sorted(
             open_future.result(timeout=EXECUTOR_TIMEOUT_SECONDS),
@@ -1205,10 +1213,9 @@ def _build_person_context(slug: str, days: int, _cache_epoch: int) -> dict:
             key=lambda x: x["completedAt"],
             reverse=True,
         )
-        if github_future and github_username:
-            author_map, reviewer_map = github_future.result(timeout=EXECUTOR_TIMEOUT_SECONDS)
-            prs_merged = len(author_map.get(github_username, []))
-            prs_reviewed = len(reviewer_map.get(github_username, []))
+        cycle_projects = projects_future.result(timeout=EXECUTOR_TIMEOUT_SECONDS)
+        if github_future:
+            prs_merged, prs_reviewed = github_future.result(timeout=EXECUTOR_TIMEOUT_SECONDS)
         else:
             prs_merged = prs_reviewed = 0
 
@@ -1251,8 +1258,7 @@ def _build_person_context(slug: str, days: int, _cache_epoch: int) -> dict:
     for issues in completed_by_project.values():
         issues.sort(key=lambda x: x["completedAt"], reverse=True)
 
-    # Fetch all projects and annotate date helpers
-    cycle_projects = get_projects()
+    # Annotate the projects fetched alongside issue and GitHub data.
     _annotate_project_schedule_fields(cycle_projects)
     for proj in cycle_projects:
         proj["is_inactive"] = is_inactive_project(proj)
@@ -1294,7 +1300,7 @@ def _build_person_context(slug: str, days: int, _cache_epoch: int) -> dict:
 
     project_names = {proj.get("name") for proj in cycle_projects if proj.get("name")}
 
-    on_support = slug in get_support_slugs()
+    on_support = slug in get_support_slugs(config=config, projects=cycle_projects)
     if on_support:
         open_current_cycle = {
             proj: issues

--- a/github.py
+++ b/github.py
@@ -393,6 +393,77 @@ def _get_merged_prs(days: int = 30):
     return prs
 
 
+def get_merged_pr_counts_for_user(username: str, days: int = 30) -> tuple[int, int]:
+    """Return authored and approved-review PR counts for one GitHub user."""
+    if not token or not username:
+        return 0, 0
+    orgs = get_github_orgs()
+    if not orgs:
+        return 0, 0
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    cutoff_date = cutoff.date().isoformat()
+    org_filter = " ".join(f"org:{org}" for org in orgs)
+    base_query = f"{org_filter} is:pr is:merged merged:>={cutoff_date}"
+    authored_query = f"{base_query} author:{username}"
+    reviewed_query = f"{base_query} reviewed-by:{username}"
+    query = gql(
+        """
+        query MergedPRCounts($authored: String!, $reviewed: String!, $cursor: String) {
+          authored: search(type: ISSUE, query: $authored, first: 1) { issueCount }
+          reviewed: search(type: ISSUE, query: $reviewed, first: 100, after: $cursor) {
+            nodes {
+              ... on PullRequest {
+                reviews(first: 100, states: [APPROVED]) {
+                  nodes { author { login } }
+                }
+              }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+        """
+    )
+
+    authored_count = 0
+    reviewed_count = 0
+    cursor = None
+    normalized_username = username.casefold()
+    while True:
+        try:
+            data = _execute(
+                query,
+                variable_values={
+                    "authored": authored_query,
+                    "reviewed": reviewed_query,
+                    "cursor": cursor,
+                },
+            )
+        except Exception:
+            logging.exception("Failed to fetch merged PR counts for %s", username)
+            return 0, 0
+
+        authored = data.get("authored", {}) or {}
+        authored_count = authored.get("issueCount", 0) or 0
+        reviewed = data.get("reviewed", {}) or {}
+        reviewed_count += sum(
+            any(
+                ((review.get("author") or {}).get("login") or "").casefold() == normalized_username
+                for review in (pr.get("reviews") or {}).get("nodes", []) or []
+            )
+            for pr in reviewed.get("nodes", []) or []
+            if pr
+        )
+
+        page_info = reviewed.get("pageInfo", {}) or {}
+        next_cursor = page_info.get("endCursor") if page_info.get("hasNextPage") else None
+        if not next_cursor or next_cursor == cursor:
+            break
+        cursor = next_cursor
+
+    return authored_count, reviewed_count
+
+
 def merged_prs_by_author(days: int = 30) -> Dict[str, List[Dict[str, Any]]]:
     """Return merged PRs grouped by author within the given timeframe."""
     prs = _get_merged_prs(days)

--- a/static/styles.css
+++ b/static/styles.css
@@ -46,3 +46,18 @@ details.dropdown.site-menu > summary + ul {
   height: 0.12rem;
   width: 100%;
 }
+
+@keyframes busy-spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+[aria-busy="true"]:not(input, select, textarea, html)::before {
+  animation: busy-spinner 0.8s linear infinite;
+  background-image: none;
+  border: 0.12em solid currentColor;
+  border-radius: 50%;
+  border-right-color: transparent;
+  box-sizing: border-box;
+}

--- a/support.py
+++ b/support.py
@@ -65,7 +65,11 @@ def _is_active_today(project: Dict) -> bool:
     return True
 
 
-def get_support_slugs() -> Set[str]:
+def get_support_slugs(
+    *,
+    config: Dict | None = None,
+    projects: list[Dict] | None = None,
+) -> Set[str]:
     """
     Compute the set of people slugs who are on support today.
 
@@ -73,8 +77,10 @@ def get_support_slugs() -> Set[str]:
     on support. If assigned but today's date is outside the project's
     start/target window, they are on support.
     """
-    config = load_config()
-    projects = get_projects()
+    if config is None:
+        config = load_config()
+    if projects is None:
+        projects = get_projects()
     name_to_slug = _name_to_slug_map(config)
 
     assigned_active_slugs: Set[str] = set()

--- a/tests/test_gql_client_requests.py
+++ b/tests/test_gql_client_requests.py
@@ -18,6 +18,30 @@ class _RecordingClient:
 
 
 class GraphQLClientRequestTests(unittest.TestCase):
+    def test_person_pr_counts_use_scoped_searches_and_only_count_approvals(self):
+        response = {
+            "authored": {"issueCount": 60},
+            "reviewed": {
+                "nodes": [
+                    {"reviews": {"nodes": [{"author": {"login": "Bkraeling"}}]}},
+                    {"reviews": {"nodes": [{"author": {"login": "someone-else"}}]}},
+                ],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+            },
+        }
+
+        with (
+            patch.object(github, "token", "token"),
+            patch.object(github, "get_github_orgs", return_value=["apollosproject"]),
+            patch.object(github, "_execute", return_value=response) as execute,
+        ):
+            counts = github.get_merged_pr_counts_for_user("bkraeling", 30)
+
+        self.assertEqual(counts, (60, 1))
+        variables = execute.call_args.kwargs["variable_values"]
+        self.assertIn("author:bkraeling", variables["authored"])
+        self.assertIn("reviewed-by:bkraeling", variables["reviewed"])
+
     def test_github_client_allows_slow_repository_queries(self):
         previous_client = getattr(github._thread_local, "client", None)
         if hasattr(github._thread_local, "client"):

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -39,6 +39,50 @@ class NavigationTest(unittest.TestCase):
         self.assertIn("right: 0;", site_menu_rule)
         self.assertIn("max-width: calc(100vw - 2rem);", site_menu_rule)
 
+    def test_busy_indicators_use_a_css_rotation_animation(self):
+        with open("static/styles.css") as styles_file:
+            styles = styles_file.read()
+
+        self.assertIn("@keyframes busy-spinner", styles)
+        busy_rule = styles.split(
+            '[aria-busy="true"]:not(input, select, textarea, html)::before',
+            1,
+        )[1]
+        busy_rule = busy_rule.split("}", 1)[0]
+
+        self.assertIn("animation: busy-spinner 0.8s linear infinite;", busy_rule)
+        self.assertIn("background-image: none;", busy_rule)
+
+    def test_person_context_scopes_github_counts_and_reuses_projects(self):
+        config = {
+            "people": {
+                "brandon": {
+                    "linear_username": "brandon",
+                    "github_username": "bkraeling",
+                }
+            }
+        }
+        projects = []
+        app_module._build_person_context.cache_clear()
+        self.addCleanup(app_module._build_person_context.cache_clear)
+
+        with (
+            patch.object(app_module, "load_config", return_value=config),
+            patch.object(app_module, "get_open_issues_for_person", return_value=[]),
+            patch.object(app_module, "get_completed_issues_for_person", return_value=[]),
+            patch.object(app_module, "get_projects", return_value=projects) as fetch,
+            patch.object(
+                app_module, "get_merged_pr_counts_for_user", return_value=(60, 53)
+            ) as counts,
+            patch.object(app_module, "get_support_slugs", return_value={"brandon"}) as support,
+        ):
+            context = app_module._build_person_context("brandon", 30, 1)
+
+        self.assertEqual((context["prs_merged"], context["prs_reviewed"]), (60, 53))
+        fetch.assert_called_once_with()
+        counts.assert_called_once_with("bkraeling", 30)
+        support.assert_called_once_with(config=config, projects=projects)
+
     def test_team_labels_use_short_name(self):
         context = {
             "developers": [],


### PR DESCRIPTION
## What changed

- replace the Pico data-URI spinner animation with a CSS-native rotating indicator for every `aria-busy` surface
- query GitHub PR counts for the selected person instead of scanning merged PRs across both organizations twice
- fetch Linear projects alongside the other person-page requests and reuse that payload for support calculations
- add regression coverage for the spinner contract, scoped GitHub counts, and project reuse

## Why

The person-page shell was fast, but its 30-day partial took about 29.95 seconds in production. The cold path performed broad duplicate GitHub searches and fetched the same Linear project list again for support status. Meanwhile, Safari rendered Pico's SVG-backed busy indicator without animating it.

## Impact

Loading indicators animate consistently, and person pages avoid the redundant external API work that dominated their load time. The optimized live GitHub request completed in about 1.47 seconds while preserving authored and approved-review counts.

## Validation

- `ruff check .`
- `ruff format --check .`
- `mypy .`
- `python -m unittest discover -s tests -p 'test_*.py'` (110 passed)
- `git diff --check`
- one-worker Gunicorn smoke: `/`, `/team`, `/team/brandon`, `/healthz`, and `/static/styles.css` returned 200
- live person-scoped GitHub query returned current counts in about 1.47 seconds

The in-app browser had no available session, so visual after-state capture remains for the deployed review surface.