### PR TITLE
Allow project updates up to two days early

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -56,6 +56,7 @@ INACTIVE_PROJECT_STATUS_NAMES = {
     "released",
 }
 PROJECT_UPDATE_DUE_WEEKDAY = 4
+PROJECT_UPDATE_EARLY_WINDOW_DAYS = 2
 _airflow_fleet_unknown_heartbeat_failures = 0
 
 
@@ -132,7 +133,10 @@ def _format_overdue_project_update_detail(
     project: dict, update_due_date: date
 ) -> tuple[date, str] | None:
     last_update_dt = _get_project_last_update_dt(project)
-    if last_update_dt and last_update_dt.date() >= update_due_date:
+    earliest_on_time_update_date = update_due_date - timedelta(
+        days=PROJECT_UPDATE_EARLY_WINDOW_DAYS
+    )
+    if last_update_dt and last_update_dt.date() >= earliest_on_time_update_date:
         return None
 
     last_update_date = last_update_dt.date() if last_update_dt else date.min

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1043,7 +1043,7 @@ class PostProjectUpdatesTest(unittest.TestCase):
                 "targetDate": "2026-03-31",
                 "status": {"name": "In Development", "type": "started"},
                 "lead": {"displayName": "Alex"},
-                "lastUpdate": {"createdAt": "2026-03-12T16:00:00.000Z"},
+                "lastUpdate": {"createdAt": "2026-03-10T16:00:00.000Z"},
             },
             {
                 "name": "No Update",
@@ -1052,6 +1052,22 @@ class PostProjectUpdatesTest(unittest.TestCase):
                 "status": {"name": "In Development", "type": "started"},
                 "lead": {"displayName": "Alex"},
                 "lastUpdate": None,
+            },
+            {
+                "name": "Updated Wednesday",
+                "url": "https://linear.app/project/updated-wednesday",
+                "targetDate": "2026-03-31",
+                "status": {"name": "In Development", "type": "started"},
+                "lead": {"displayName": "Alex"},
+                "lastUpdate": {"createdAt": "2026-03-11T09:00:00.000Z"},
+            },
+            {
+                "name": "Updated Thursday",
+                "url": "https://linear.app/project/updated-thursday",
+                "targetDate": "2026-03-31",
+                "status": {"name": "In Development", "type": "started"},
+                "lead": {"displayName": "Alex"},
+                "lastUpdate": {"createdAt": "2026-03-12T09:00:00.000Z"},
             },
             {
                 "name": "Updated Friday",
@@ -1110,10 +1126,12 @@ class PostProjectUpdatesTest(unittest.TestCase):
         )
         self.assertIn(
             "- <https://linear.app/project/old-update|Old Update> - Due Mar 13; "
-            "last update Mar 12 - Lead: <@U1>",
+            "last update Mar 10 - Lead: <@U1>",
             message,
         )
         self.assertNotIn("Missing End Date", message)
+        self.assertNotIn("Updated Wednesday", message)
+        self.assertNotIn("Updated Thursday", message)
         self.assertNotIn("Updated Friday", message)
         self.assertNotIn("Backlog Missing Update", message)
         self.assertNotIn("Product Lead Missing Update", message)


### PR DESCRIPTION
## Issue

Weekly project updates were considered overdue unless they were submitted on or after the Friday due date. That flagged projects such as Ministry Platform Integration even though its lead updated it the day before the deadline.

## Solution

Treat project updates submitted up to two calendar days before the Friday deadline as on time. Wednesday, Thursday, and Friday updates now satisfy the deadline; Tuesday or older updates remain overdue.

## To test

- `source venv/bin/activate && python -m unittest discover -s tests -p 'test_*.py'`
- `source venv/bin/activate && ruff check jobs.py tests/test_jobs.py`
- `git diff --check`

## Proof

Ran the production project-fetch and overdue-formatting path against live Linear data without posting to Slack:

```text
project=Ministry Platform Integration
due_date=2026-07-10
last_update=2026-07-09
listed_as_overdue=False
```
