### PR TITLE
Add six-week projects timeline

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import os
 import re
 import time
 from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from functools import lru_cache
 from typing import Any, TypedDict, TypeVar
 from urllib.parse import quote
@@ -29,7 +29,6 @@ from leaderboard import (
     calculate_cycle_project_member_points,
 )
 from linear.issues import (
-    by_assignee,
     by_platform,
     by_project,
     get_completed_issues_for_person,
@@ -997,12 +996,14 @@ def team_slug(slug):
 
 
 @app.route("/team")
-def team():
+@app.route("/projects")
+def projects():
     return render_template("team.html")
 
 
 @app.route("/partials/team/content")
-def team_content_partial():
+@app.route("/partials/projects/content")
+def projects_content_partial():
     cache_epoch = int(time.time() / INDEX_CACHE_TTL_SECONDS)
     context = _build_team_context(cache_epoch)
     return render_template("partials/team_content.html", **context)
@@ -1113,70 +1114,85 @@ def _build_team_context(_cache_epoch: int) -> dict:
         else:
             del projects_by_initiative[name]
 
-    # Determine which team members are participating in active projects
+    # Build a Monday-aligned six-week view for every engineering team member.
     active_projects = [p for projs in projects_by_initiative.values() for p in projs]
-
-    cycle_member_slugs = set()
-    member_projects: dict[str, set[tuple[str, str]]] = {}
+    today = datetime.now(timezone.utc).date()
+    timeline_start = today - timedelta(days=today.weekday())
+    timeline_end = timeline_start + timedelta(weeks=6)
+    timeline_developers = sorted(
+        [{"slug": slug, "name": format_name(slug)} for slug in engineering_team_slugs],
+        key=lambda developer: developer["name"],
+    )
+    projects_by_developer: dict[str, list[dict[str, Any]]] = {
+        developer["slug"]: [] for developer in timeline_developers
+    }
     for project in active_projects:
-        # Only include projects that have started (start date today or earlier)
-        starts_in = project.get("starts_in")
-        if starts_in is not None and starts_in > 0:
+        start = parse_iso_date(project.get("startDate"))
+        target = parse_iso_date(project.get("targetDate"))
+        if start is None and target is None:
             continue
+        visible_start = start or timeline_start
+        visible_end = target or (timeline_end - timedelta(days=1))
+        is_overdue = target is not None and target < today
+        if is_overdue:
+            visible_end = max(visible_end, today)
+        if visible_end < timeline_start or visible_start >= timeline_end:
+            continue
+        visible_start = max(visible_start, timeline_start)
+        visible_end = min(max(visible_end, visible_start), timeline_end - timedelta(days=1))
+        bar = {
+            **project,
+            "start_day": (visible_start - timeline_start).days + 1,
+            "span_days": (visible_end - visible_start).days + 1,
+            "health_class": "overdue" if is_overdue else project.get("health") or "neutral",
+            "_start": visible_start,
+            "_end": visible_end,
+        }
         lead = (project.get("lead") or {}).get("displayName")
         participants = []
         if lead:
             participants.append(lead)
         participants.extend(project.get("members", []))
+        assigned_slugs = set()
         for name in participants:
             slug = slug_for_name(name)
-            if slug and slug in engineering_team_slugs:
-                project_name = project.get("name")
-                project_url = project.get("url")
-                if not isinstance(project_name, str) or not isinstance(project_url, str):
-                    continue
-                cycle_member_slugs.add(slug)
-                member_projects.setdefault(slug, set()).add((project_name, project_url))
+            if slug and slug in engineering_team_slugs and slug not in assigned_slugs:
+                projects_by_developer[slug].append(dict(bar))
+                assigned_slugs.add(slug)
 
-    # Convert sets back to sorted lists of dicts
-    member_projects_list = {
-        slug: [{"name": name, "url": url} for name, url in sorted(projects, key=lambda x: x[0])]
-        for slug, projects in member_projects.items()
-    }
+    for developer in timeline_developers:
+        bars = projects_by_developer[developer["slug"]]
+        lane_ends: list[Any] = []
+        for bar in sorted(bars, key=lambda item: (item["_start"], item["_end"])):
+            lane = next(
+                (index for index, end in enumerate(lane_ends) if bar["_start"] > end),
+                len(lane_ends),
+            )
+            if lane == len(lane_ends):
+                lane_ends.append(bar["_end"])
+            else:
+                lane_ends[lane] = bar["_end"]
+            bar["lane"] = lane + 1
+        developer["projects"] = bars
+        developer["lane_count"] = max(len(lane_ends), 1)
 
-    developers = sorted(
-        [{"slug": slug, "name": format_name(slug)} for slug in cycle_member_slugs],
-        key=lambda d: d["name"],
-    )
-
-    support_slugs = [
-        slug
-        for slug in get_support_slugs(config=config, projects=cycle_projects)
-        if slug in engineering_team_slugs
-    ]
-    on_call_support = sorted(
-        [{"slug": name, "name": format_name(name)} for name in support_slugs],
-        key=lambda d: d["name"],
-    )
-
-    # Map open priority bug issues to on-call support members
-    priority_bugs = get_open_issues(2, "Bug")
-    bugs_by_assignee = by_assignee(priority_bugs)
-    support_issues = {}
-    for assignee, data in bugs_by_assignee.items():
-        slug = slug_for_name(assignee)
-        if slug and slug in engineering_team_slugs:
-            support_issues[slug] = [
-                {"title": issue["title"], "url": issue["url"]} for issue in data["issues"]
-            ]
+    timeline_weeks = []
+    for offset in range(6):
+        week_start = timeline_start + timedelta(weeks=offset)
+        week_end = week_start + timedelta(days=6)
+        timeline_weeks.append(
+            {"start": f"{week_start:%b} {week_start.day}", "end": f"{week_end:%b} {week_end.day}"}
+        )
 
     return {
-        "developers": developers,
-        "developer_projects": member_projects_list,
+        "project_timeline": {
+            "weeks": timeline_weeks,
+            "rows": timeline_developers,
+            "date_range": f"{timeline_weeks[0]['start']} – {timeline_weeks[-1]['end']}",
+            "today_percent": ((today - timeline_start).days + 0.5) / 42 * 100,
+        },
         "cycle_projects_by_initiative": projects_by_initiative,
         "completed_cycle_projects": completed_projects,
-        "on_call_support": on_call_support,
-        "support_issues": support_issues,
     }
 
 

--- a/linear/issues.py
+++ b/linear/issues.py
@@ -3,7 +3,6 @@ from datetime import datetime, timezone
 from gql import gql
 
 from config import get_linear_team_key, get_platforms
-from constants import PRIORITY_TO_SCORE
 from issue_timing import format_issue_sla_text
 
 from .client import _compute_assignee_time_to_fix, _execute
@@ -373,26 +372,6 @@ def get_created_issues(priority, label, days=30):
         else:
             issue["assignee_time_to_fix"] = None
     return issues
-
-
-def by_assignee(issues):
-    assignee_issues = {}
-    for issue in issues:
-        if not issue["assignee"]:
-            continue
-        assignee = issue["assignee"]["displayName"]
-        if assignee not in assignee_issues:
-            assignee_issues[assignee] = {"score": 0, "issues": []}
-        assignee_issues[assignee]["issues"].append(issue)
-        score = PRIORITY_TO_SCORE.get(issue["priority"], 1)
-        assignee_issues[assignee]["score"] += score
-    return dict(
-        sorted(
-            assignee_issues.items(),
-            key=lambda x: x[1]["score"],
-            reverse=True,
-        )
-    )
 
 
 def get_stale_issues_by_assignee(issues, days=30):

--- a/static/styles.css
+++ b/static/styles.css
@@ -61,3 +61,66 @@ details.dropdown.site-menu > summary + ul {
   border-right-color: transparent;
   box-sizing: border-box;
 }
+
+.project-timeline-heading {
+  align-items: baseline; display: flex; flex-wrap: wrap;
+  gap: 0.5rem 1rem; justify-content: space-between; margin: 1.5rem 0 0.75rem;
+}
+.project-timeline-heading h3 { margin: 0; }
+.project-timeline-scroll {
+  border: 1px solid var(--pico-muted-border-color); border-radius: 0.5rem; overflow-x: auto;
+}
+.project-timeline { min-width: 52rem; }
+.project-timeline-header,
+.project-timeline-row {
+  display: grid; grid-template-columns: 7.5rem minmax(42rem, 1fr);
+}
+.project-timeline-header {
+  align-items: stretch; background: var(--pico-card-sectioning-background-color);
+  border-bottom: 1px solid var(--pico-muted-border-color);
+  color: var(--pico-muted-color); font-size: 0.7rem; text-transform: uppercase;
+}
+.project-timeline-header > strong,
+.project-timeline-developer {
+  align-items: center; background: var(--pico-background-color);
+  border-right: 1px solid var(--pico-muted-border-color);
+  display: flex; left: 0; padding: 0.5rem 0.65rem; position: sticky; z-index: 4;
+}
+.project-timeline-header > strong { background: var(--pico-card-sectioning-background-color); }
+.project-timeline-weeks {
+  display: grid; grid-template-columns: repeat(6, 1fr);
+}
+.project-timeline-weeks span {
+  border-right: 1px solid var(--pico-muted-border-color); padding: 0.6rem;
+}
+.project-timeline-row:not(:last-child) {
+  border-bottom: 1px solid var(--pico-muted-border-color);
+}
+.project-timeline-track {
+  background-image: linear-gradient(
+    to right, transparent calc(100% - 1px), var(--pico-muted-border-color) 0
+  );
+  background-size: calc(100% / 6) 100%; display: grid; grid-auto-rows: 1.8rem;
+  grid-template-columns: repeat(42, minmax(0, 1fr));
+  min-height: calc(var(--lanes) * 1.8rem + 0.6rem); padding: 0.3rem 0; position: relative;
+}
+.project-timeline-today {
+  border-left: 2px solid #e45555; bottom: 0; left: var(--today);
+  pointer-events: none; position: absolute; top: 0; z-index: 3;
+}
+.project-timeline-empty {
+  align-self: center; color: var(--pico-muted-color);
+  grid-column: 1 / -1; grid-row: 1; padding-left: 0.65rem;
+}
+.project-timeline-bar {
+  align-items: center; align-self: center; background: #5d6b89; border-radius: 0.35rem;
+  color: #fff; display: flex; font-size: 0.68rem; font-weight: 600;
+  grid-column: var(--start) / span var(--span); grid-row: var(--lane); height: 1.4rem;
+  margin-inline: 0.12rem; min-width: 0; padding: 0 0.45rem; text-decoration: none;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; z-index: 2;
+}
+.project-timeline-bar:hover { color: #fff; }
+.project-timeline-bar--onTrack { background: #087f8c; }
+.project-timeline-bar--atRisk { background: #b26a00; }
+.project-timeline-bar--offTrack,
+.project-timeline-bar--overdue { background: #b83a3a; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,7 +33,7 @@
               </summary>
               <ul>
                 <li><a href="{{ url_for('apps_dashboard') }}">Apps</a></li>
-                <li><a href="{{ url_for('team') }}">Teams</a></li>
+                <li><a href="{{ url_for('projects') }}">Projects</a></li>
                 <li><a href="{{ url_for('failing_dags_dashboard') }}">Failing DAGs</a></li>
               </ul>
             </details>

--- a/templates/partials/team_content.html
+++ b/templates/partials/team_content.html
@@ -1,35 +1,34 @@
-<h2>Teams</h2>
-<h2>Current Focus</h2>
-{% if developers %}
-<h4>Projects</h4>
-<ul>
-{% for dev in developers %}
-  <li>
-    <a href="{{ url_for('team_slug', slug=dev.slug) }}">{{ dev.name|first_name }}</a>
-    {% set projs = developer_projects.get(dev.slug, []) %}
-    {% if projs %}&ndash;{% for proj in projs %}
-      <a href="{{ proj.url }}">{{ proj.name }}</a>{% if not loop.last %}, {% endif %}
-    {% endfor %}{% endif %}
-  </li>
-{% endfor %}
-</ul>
-<hr />
-{% endif %}
-<h4>Support</h4>
-<ul>
-{%- for person in on_call_support -%}
-  <li>
-    <a href="{{ url_for('team_slug', slug=person.slug) }}">{{ person.name|first_name }}</a>
-    {% set issues = support_issues.get(person.slug) %}
-    {% if issues %}&ndash;{% for issue in issues %}
-      <a href="{{ issue.url }}">{{ issue.title }}</a>{% if not loop.last %}, {% endif %}
-    {% endfor %}{% endif %}
-  </li>
-{%- endfor -%}
-</ul>
+<h2>Projects</h2>
+<div class="project-timeline-heading">
+  <h3>Timeline</h3>
+  <small>Six-week view · {{ project_timeline.date_range }} · Red line is today</small>
+</div>
+<div class="project-timeline-scroll" tabindex="0" role="region" aria-label="Developer project timeline">
+  <div class="project-timeline">
+    <div class="project-timeline-header">
+      <strong>Developer</strong>
+      <div class="project-timeline-weeks">
+        {% for week in project_timeline.weeks %}<span><b>{{ week.start }}</b> – {{ week.end }}</span>{% endfor %}
+      </div>
+    </div>
+    {% for developer in project_timeline.rows %}
+      <div class="project-timeline-row">
+        <a class="project-timeline-developer" href="{{ url_for('team_slug', slug=developer.slug) }}">{{ developer.name|first_name }}</a>
+        <div class="project-timeline-track" style="--lanes: {{ developer.lane_count }}; --today: {{ project_timeline.today_percent }}%;">
+          <i class="project-timeline-today" aria-hidden="true"></i>
+          {% for project in developer.projects %}
+            <a href="{{ project.url }}" class="project-timeline-bar project-timeline-bar--{{ project.health_class }}" style="--start: {{ project.start_day }}; --span: {{ project.span_days }}; --lane: {{ project.lane }};" title="{{ project.name }}{% if project.startDate or project.targetDate %}: {{ project.startDate or 'Earlier' }} – {{ project.targetDate or 'Ongoing' }}{% endif %}">{{ project.name }}</a>
+          {% else %}
+            <small class="project-timeline-empty">No dated projects</small>
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+</div>
 <hr />
 {% if cycle_projects_by_initiative %}
-<h3>Projects</h3>
+<h3>All Projects</h3>
 <ul>
 {% for initiative, projects in cycle_projects_by_initiative.items() %}
   {% for project in projects %}

--- a/templates/team.html
+++ b/templates/team.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Teams{% endblock %}
+{% block title %}Projects{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block content %}
-      <div id="team-content" aria-busy="true"></div>
+      <div id="projects-content" aria-busy="true"></div>
 {% endblock %}
 
 {% block extra_scripts %}
@@ -38,6 +38,6 @@
     }
   }
 
-  loadSection('team-content', '/partials/team/content');
+  loadSection('projects-content', '{{ url_for("projects_content_partial") }}');
 </script>
 {% endblock %}

--- a/tests/test_app_versions.py
+++ b/tests/test_app_versions.py
@@ -618,7 +618,7 @@ class AppVersionsRouteTest(unittest.TestCase):
         self.assertIn("<h1>Apps</h1>", body)
         self.assertIn("App data is unavailable", body)
         self.assertIn('href="/grid/apps"', body)
-        self.assertIn('href="/grid/team"', body)
+        self.assertIn('href="/grid/projects"', body)
 
     def test_legacy_app_versions_route_renders_apps_dashboard(self):
         with patch.object(

--- a/tests/test_failing_dags.py
+++ b/tests/test_failing_dags.py
@@ -386,7 +386,7 @@ class FailingDagsDashboardTest(unittest.TestCase):
         self.assertIn('href="/grid/static/pico.min.css"', body)
         self.assertIn('href="/grid/static/styles.css"', body)
         self.assertIn('href="/grid/"', body)
-        self.assertIn('href="/grid/team"', body)
+        self.assertIn('href="/grid/projects"', body)
         self.assertIn('href="/grid/failing-dags"', body)
 
     def test_build_astro_dag_url_strips_airflow_api_version_suffix(self):
@@ -831,8 +831,11 @@ class TeamContextProjectFilteringTest(unittest.TestCase):
                     with patch.object(app_module, "get_open_issues", return_value=[]):
                         context = app_module._build_team_context(1)
 
-        self.assertEqual(context["developers"], [])
-        self.assertEqual(context["developer_projects"], {})
+        self.assertEqual(
+            [developer["slug"] for developer in context["project_timeline"]["rows"]],
+            ["darryl"],
+        )
+        self.assertEqual(context["project_timeline"]["rows"][0]["projects"], [])
         self.assertEqual(context["cycle_projects_by_initiative"], {})
         self.assertNotIn("platform_teams", context)
         self.assertEqual(
@@ -981,6 +984,8 @@ class TeamContextProjectFilteringTest(unittest.TestCase):
 
         project = context["cycle_projects_by_initiative"]["Cycle"][0]
         self.assertEqual(project["target_status_text"], "6h left")
+        bar = context["project_timeline"]["rows"][0]["projects"][0]
+        self.assertEqual((bar["start_day"], bar["span_days"]), (1, 7))
 
 
 if __name__ == "__main__":

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -9,7 +9,7 @@ class NavigationTest(unittest.TestCase):
         self.client = app_module.app.test_client()
 
     def test_local_pages_render_in_header_menu_not_footer(self):
-        response = self.client.get("/team")
+        response = self.client.get("/projects")
 
         body = response.get_data(as_text=True)
         self.assertEqual(response.status_code, 200)
@@ -20,11 +20,12 @@ class NavigationTest(unittest.TestCase):
         self.assertIn('class="dropdown site-menu"', header)
         self.assertIn('aria-label="Open local pages menu"', header)
         self.assertIn('href="/apps"', header)
-        self.assertIn(">Teams</a>", header)
+        self.assertIn('href="/projects"', header)
+        self.assertIn(">Projects</a>", header)
         self.assertIn('href="/failing-dags"', header)
 
         self.assertNotIn('href="/apps"', footer)
-        self.assertNotIn('href="/team"', footer)
+        self.assertNotIn('href="/projects"', footer)
         self.assertNotIn('href="/failing-dags"', footer)
 
     def test_header_menu_overrides_pico_left_aligned_dropdown(self):
@@ -83,26 +84,35 @@ class NavigationTest(unittest.TestCase):
         counts.assert_called_once_with("bkraeling", 30)
         support.assert_called_once_with(config=config, projects=projects)
 
-    def test_team_labels_use_short_name(self):
+    def test_projects_page_and_timeline_use_project_labels(self):
         context = {
-            "developers": [],
-            "developer_projects": {},
+            "project_timeline": {
+                "weeks": [],
+                "rows": [],
+                "date_range": "Jul 13 – Aug 23",
+                "today_percent": 1.2,
+            },
             "cycle_projects_by_initiative": {},
             "completed_cycle_projects": [],
-            "on_call_support": [],
-            "support_issues": {},
         }
 
-        response = self.client.get("/team")
-        self.assertIn("<title>Teams</title>", response.get_data(as_text=True))
+        response = self.client.get("/projects")
+        self.assertIn("<title>Projects</title>", response.get_data(as_text=True))
 
         with patch.object(app_module, "_build_team_context", return_value=context):
-            partial_response = self.client.get("/partials/team/content")
+            partial_response = self.client.get("/partials/projects/content")
 
         partial_body = partial_response.get_data(as_text=True)
         self.assertEqual(partial_response.status_code, 200)
-        self.assertIn("<h2>Teams</h2>", partial_body)
-        self.assertNotIn("Engineering Teams", partial_body)
+        self.assertIn("<h2>Projects</h2>", partial_body)
+        self.assertIn("<h3>Timeline</h3>", partial_body)
+        self.assertNotIn("Current Focus", partial_body)
+
+    def test_legacy_team_url_renders_the_projects_page(self):
+        response = self.client.get("/team")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("<title>Projects</title>", response.get_data(as_text=True))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue

The team page only listed current focus, so upcoming project timing and developer overlap were hard to scan.

## Solution

- Rename the page and navigation from Teams to Projects while keeping `/team` compatibility.
- Replace Current Focus with a six-week, developer-row timeline backed by live Linear project dates.
- Keep the complete project list below the timeline under All Projects.

## To Test

- `source venv/bin/activate && python -m unittest discover -s tests -p 'test_*.py'`
- `source venv/bin/activate && ruff check .`
- `source venv/bin/activate && ruff format --check .`
- `source venv/bin/activate && mypy .`

## Proof

Verified with live Linear-backed data on the local Projects page in Safari.

![Six-week developer project timeline](https://files.catbox.moe/6k4avc.jpeg)

![All Projects section](https://files.catbox.moe/04he9i.jpeg)
