### PR TITLE
Defer project update reminders until projects start

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -115,10 +115,13 @@ def _latest_completed_project_update_due_date(today: date) -> date:
     return today - timedelta(days=days_since_friday)
 
 
-def _requires_weekly_project_update(project: dict) -> bool:
+def _requires_weekly_project_update(project: dict, update_due_date: date) -> bool:
     if _is_inactive_project(project):
         return False
     if parse_iso_date(project.get("targetDate")) is None:
+        return False
+    start_date = parse_iso_date(project.get("startDate"))
+    if start_date is not None and update_due_date <= start_date:
         return False
     status_type = ((project.get("status") or {}).get("type") or "").strip().lower()
     return status_type == "started"
@@ -749,7 +752,7 @@ def post_project_updates():
         lead_md = get_slack_markdown_by_linear_username(lead) if lead else "No Lead"
         inactive = _is_inactive_project(project)
 
-        if _requires_weekly_project_update(project):
+        if _requires_weekly_project_update(project, update_due_date):
             update_detail = _format_overdue_project_update_detail(project, update_due_date)
             if update_detail:
                 last_update_date, update_status_text = update_detail

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -476,6 +476,22 @@ class FixedFridayDateTime(datetime):
         return datetime(2026, 3, 13, 12, 0, 0, tzinfo=tz)
 
 
+class FixedMondayDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        if tz is None:
+            return datetime(2026, 3, 16, 12, 0, 0)
+        return datetime(2026, 3, 16, 12, 0, 0, tzinfo=tz)
+
+
+class FixedSaturdayDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        if tz is None:
+            return datetime(2026, 3, 21, 12, 0, 0)
+        return datetime(2026, 3, 21, 12, 0, 0, tzinfo=tz)
+
+
 class PostPriorityBugsTest(unittest.TestCase):
     def test_uses_linear_sla_windows_for_at_risk_and_overdue(self):
         posted = []
@@ -1159,6 +1175,40 @@ class PostProjectUpdatesTest(unittest.TestCase):
 
         posted = self._run(projects, config, datetime_cls=FixedFridayDateTime)
         self.assertEqual(posted, [])
+
+    def test_waits_for_first_project_update_deadline_after_start_date(self):
+        projects = [
+            {
+                "name": "Starting Sunday",
+                "url": "https://linear.app/project/starting-sunday",
+                "startDate": "2026-03-15",
+                "targetDate": "2026-03-31",
+                "status": {"name": "In Development", "type": "started"},
+                "lead": {"displayName": "Alex"},
+                "lastUpdate": None,
+            }
+        ]
+        config = {
+            "people": {
+                "alex": {
+                    "linear_username": "Alex",
+                    "slack_id": "U1",
+                    "team": "engineering",
+                },
+            }
+        }
+
+        posted_on_start_date = self._run(projects, config)
+        posted_after_start_date = self._run(projects, config, datetime_cls=FixedMondayDateTime)
+        posted_after_first_deadline = self._run(
+            projects, config, datetime_cls=FixedSaturdayDateTime
+        )
+
+        self.assertEqual(posted_on_start_date, [])
+        self.assertEqual(posted_after_start_date, [])
+        self.assertEqual(len(posted_after_first_deadline), 1)
+        self.assertIn("*Projects With Overdue Updates*", posted_after_first_deadline[0])
+        self.assertIn("Starting Sunday", posted_after_first_deadline[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue

Project update reminders depended on Linear's status type alone. If a project moved to a started status before its scheduled start date, the digest could list an update deadline from before the project began.

## Solution

Require the latest completed weekly update deadline to fall after a project's start date before including it in the overdue-update section. Projects without a start date retain the existing behavior.

## To Test

- `source venv/bin/activate && python -m unittest discover -s tests -p 'test_*.py'`
- `source venv/bin/activate && ruff check .`
- `source venv/bin/activate && ruff format --check .`
- `source venv/bin/activate && mypy .`

## Proof

Local worker-path dry run using the linked project's live July 20 start date, forcing an early `started` status and capturing the Slack output locally:

```text
2026-07-20: slack_posts=0
2026-07-21: slack_posts=0
2026-07-25: slack_posts=1
*Projects With Overdue Updates*
- PushPay Giving Export - Due Jul 24; no updates yet
```

This shows the notifier waits for the first weekly deadline after the project starts instead of reporting the prior July 17 deadline.