### PR TITLE
Clarify apps version columns

### DIFF
--- a/templates/app_versions.html
+++ b/templates/app_versions.html
@@ -100,6 +100,10 @@
     font-size: 0.9rem;
   }
 
+  .version-app-detail {
+    white-space: nowrap;
+  }
+
   .version-empty p:last-child,
   .version-setup p:last-child {
     margin-bottom: 0;
@@ -159,8 +163,7 @@
               <tr>
                 <th>Church</th>
                 <th>App</th>
-                <th>Latest App</th>
-                <th>Observed Version</th>
+                <th>Apollos Runtime</th>
                 <th>Source</th>
                 <th>Status</th>
                 <th>Seen</th>
@@ -177,13 +180,11 @@
                   </td>
                   <td>
                     {{ row.application_name }}<br />
-                    <span class="version-muted">Observed {{ row.app_version or "unknown" }}</span>
-                  </td>
-                  <td>
-                    <code>{{ row.latest_app_version or "unknown" }}</code><br />
-                    <span class="version-muted">
-                      {{ row.latest_app_version_source_label or "Observed" }}
-                    </span>
+                    <span class="version-muted version-app-detail">Observed {{ row.app_version or "unknown" }}</span>
+                    {% if row.latest_app_version_source == "app_store" and row.latest_app_version != row.app_version %}
+                      <br />
+                      <span class="version-muted version-app-detail">App Store {{ row.latest_app_version }}</span>
+                    {% endif %}
                   </td>
                   <td><code>{{ row.apollos_version }}</code></td>
                   <td><code>{{ row.source_display or "TBD" }}</code></td>

--- a/tests/test_app_versions.py
+++ b/tests/test_app_versions.py
@@ -649,6 +649,7 @@ class AppVersionsRouteTest(unittest.TestCase):
                 "application_name": "One Church",
                 "app_version": "1.0.0",
                 "latest_app_version": "1.0.1",
+                "latest_app_version_source": "app_store",
                 "latest_app_version_source_label": "App Store",
                 "apollos_platform": "ios",
                 "apollos_version": "97",
@@ -665,6 +666,7 @@ class AppVersionsRouteTest(unittest.TestCase):
                 "application_name": "Two Church",
                 "app_version": "1.0.0",
                 "latest_app_version": "1.0.0",
+                "latest_app_version_source": "observed",
                 "latest_app_version_source_label": "Observed",
                 "apollos_platform": "android",
                 "apollos_version": "97",
@@ -699,10 +701,13 @@ class AppVersionsRouteTest(unittest.TestCase):
         self.assertIn('id="version-panel-ios"', body)
         self.assertNotIn("Latest observed", body)
         self.assertIn("One Church", body)
-        self.assertIn("Latest App", body)
+        self.assertNotIn("<th>Latest App</th>", body)
+        self.assertNotIn("<th>Observed Version</th>", body)
+        self.assertIn("<th>Apollos Runtime</th>", body)
         self.assertIn("<th>Source</th>", body)
         self.assertIn("1.0.1", body)
-        self.assertIn("App Store", body)
+        self.assertIn("App Store 1.0.1", body)
+        self.assertNotIn("App Store 1.0.0", body)
         self.assertIn("v2026.05.12.00 (abc1234)", body)
         self.assertIn("<code>TBD</code>", body)
         self.assertIn("Two Church", body)


### PR DESCRIPTION
## Issue

The Apps table rendered `latest_app_version` in its own “Latest App” column. Outside successful iOS App Store lookups, that value falls back to the already displayed observed app version, so the column was usually redundant. “Observed Version” also described the Apollos runtime rather than the native app version.

## Solution

- fold a differing App Store version into the existing named App cell
- remove the redundant “Latest App” column
- rename “Observed Version” to “Apollos Runtime”
- keep the consolidated version details on readable single lines

## To test

- `python -m unittest tests.test_app_versions`
- `ruff check .`
- `ruff format --check .`
- `vulture . --config pyproject.toml`
- `mypy .`
- `python -m unittest discover -s tests -p 'test_*.py'`
- Gunicorn `/healthz` smoke check

## Proof

Rendered `/apps` locally against the live Segment-backed data to verify the consolidated columns across platform tabs. The screenshot below uses representative values so internal analytics are not published.

![Apps table with the consolidated App column and Apollos Runtime header](https://github.com/user-attachments/assets/da4857fa-9034-47ee-b417-a969a6dc5a8a)