### PR TITLE
Reflect platform-specific app freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ python -m unittest discover -s tests -p 'test_*.py'
 2. Provide the required environment variables. The application expects the following values:
 
 - `LINEAR_API_KEY` – API token for Linear
-- `GITHUB_TOKEN` – GitHub token used for pull‑request data
+- `GITHUB_TOKEN` – GitHub token used for pull-request data and Platforms release/commit lookups
 - `SLACK_WEBHOOK_URL` – Webhook URL used by the worker to post messages
 - `MANAGER_SLACK_WEBHOOK_URL` – Webhook URL used for manager-facing summaries
 - `APP_URL` – Public URL where the app is hosted
@@ -118,27 +118,32 @@ The legacy `GET /airflow-fleet-health` Better Stack monitor endpoint has been re
 
 ## Apps dashboard
 
-`GET /apps` reads the Segment BigQuery export and shows the highest observed Apollos
-version signal per church/app/platform. It uses the analytics metadata sent by the mobile and TV
-apps, including the exported `apollos_version`, `app_version`, `app_update_id`, `bundle_id`,
-`application_name`, `church`, `apollos_platform`, `source_revision`, and `source_version` fields.
-Public App Store versions are also looked up by bundle ID when available so iOS rows can distinguish
-the observed installed app version from the current production App Store version. Roku Segment
-exports currently do not expose `apollos_version`, so Roku rows use the exported
-`context_library_version` and are labelled as analytics library versions.
+`GET /apps` reads the Segment BigQuery export and reports production freshness using the release
+signal appropriate to each platform:
+
+- iOS and Android compare the observed Expo runtime with the latest production runtime for that
+  platform.
+- tvOS, AndroidTV, and Amazon compare stable `apollos-platforms` release tags. An alpha observation
+  is treated as a prerelease unless its source revision exactly matches a published stable tag, in
+  which case the stable tag is displayed.
+- Roku compares its embedded source revision with the latest commit on `master` that changed
+  `templates/roku`. This reports source freshness without implying that the manual Roku deployment
+  itself was automated.
+
+New builds send `deployment_track` alongside `source_revision` and `source_version`, allowing the
+dashboard to keep internal and prerelease builds out of production baselines. Older observations
+without that field are classified from their release tag and revision. Public App Store versions
+are also looked up by bundle ID for iOS, but are shown as informational app-version context rather
+than used to determine Expo runtime freshness.
 
 The page first inspects `INFORMATION_SCHEMA.COLUMNS` for the configured Segment tables and only
 queries tables that expose a supported version signal, so Segment lifecycle-only app-store
-`version` fields are not mistaken for Apollos runtime versions. Runtime rows are marked outdated
-when their highest observed runtime is behind the highest runtime observed for the same platform in
-the lookback window, or when the observed app version is behind an available App Store version. If
-older clients are still active after a release, the dashboard keeps the highest observed runtime for
-the app instead of letting the most recent older-client event hide it. Mobile rows prefer the
-`apollos` Segment dataset, TV rows prefer `apollos_tv`, and Roku rows prefer `apollos_roku` so the
-same app event is not counted twice when Segment exports overlap.
-TV rows show `TBD` until source metadata appears in Segment exports. Once those fields are present,
-TV freshness uses the highest observed `source_version` for each TV platform instead of the static
-Expo runtime version.
+`version` fields are not mistaken for Apollos runtime versions. If older clients are still active
+after a release, the dashboard keeps the highest production observation for the app instead of
+letting the most recent older-client event hide it. Mobile rows prefer the `apollos` Segment
+dataset, TV rows prefer `apollos_tv`, and Roku rows prefer `apollos_roku` so the same app event is
+not counted twice when Segment exports overlap. Rows show `TBD` until the metadata required by their
+platform's freshness flow appears.
 
 To make the dashboard query live data locally, in production, or in review apps, set
 `BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64`. The value should be a base64-encoded Google service

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ python -m unittest discover -s tests -p 'test_*.py'
 2. Provide the required environment variables. The application expects the following values:
 
 - `LINEAR_API_KEY` – API token for Linear
-- `GITHUB_TOKEN` – GitHub token used for pull-request data and Platforms release/commit lookups
+- `GITHUB_TOKEN` – GitHub token used for pull‑request data
 - `SLACK_WEBHOOK_URL` – Webhook URL used by the worker to post messages
 - `MANAGER_SLACK_WEBHOOK_URL` – Webhook URL used for manager-facing summaries
 - `APP_URL` – Public URL where the app is hosted
@@ -118,32 +118,27 @@ The legacy `GET /airflow-fleet-health` Better Stack monitor endpoint has been re
 
 ## Apps dashboard
 
-`GET /apps` reads the Segment BigQuery export and reports production freshness using the release
-signal appropriate to each platform:
-
-- iOS and Android compare the observed Expo runtime with the latest production runtime for that
-  platform.
-- tvOS, AndroidTV, and Amazon compare stable `apollos-platforms` release tags. An alpha observation
-  is treated as a prerelease unless its source revision exactly matches a published stable tag, in
-  which case the stable tag is displayed.
-- Roku compares its embedded source revision with the latest commit on `master` that changed
-  `templates/roku`. This reports source freshness without implying that the manual Roku deployment
-  itself was automated.
-
-New builds send `deployment_track` alongside `source_revision` and `source_version`, allowing the
-dashboard to keep internal and prerelease builds out of production baselines. Older observations
-without that field are classified from their release tag and revision. Public App Store versions
-are also looked up by bundle ID for iOS, but are shown as informational app-version context rather
-than used to determine Expo runtime freshness.
+`GET /apps` reads the Segment BigQuery export and shows the highest observed Apollos
+version signal per church/app/platform. It uses the analytics metadata sent by the mobile and TV
+apps, including the exported `apollos_version`, `app_version`, `app_update_id`, `bundle_id`,
+`application_name`, `church`, `apollos_platform`, `source_revision`, and `source_version` fields.
+Public App Store versions are also looked up by bundle ID when available so iOS rows can distinguish
+the observed installed app version from the current production App Store version. Roku Segment
+exports currently do not expose `apollos_version`, so Roku rows use the exported
+`context_library_version` and are labelled as analytics library versions.
 
 The page first inspects `INFORMATION_SCHEMA.COLUMNS` for the configured Segment tables and only
 queries tables that expose a supported version signal, so Segment lifecycle-only app-store
-`version` fields are not mistaken for Apollos runtime versions. If older clients are still active
-after a release, the dashboard keeps the highest production observation for the app instead of
-letting the most recent older-client event hide it. Mobile rows prefer the `apollos` Segment
-dataset, TV rows prefer `apollos_tv`, and Roku rows prefer `apollos_roku` so the same app event is
-not counted twice when Segment exports overlap. Rows show `TBD` until the metadata required by their
-platform's freshness flow appears.
+`version` fields are not mistaken for Apollos runtime versions. Runtime rows are marked outdated
+when their highest observed runtime is behind the highest runtime observed for the same platform in
+the lookback window, or when the observed app version is behind an available App Store version. If
+older clients are still active after a release, the dashboard keeps the highest observed runtime for
+the app instead of letting the most recent older-client event hide it. Mobile rows prefer the
+`apollos` Segment dataset, TV rows prefer `apollos_tv`, and Roku rows prefer `apollos_roku` so the
+same app event is not counted twice when Segment exports overlap.
+TV rows show `TBD` until source metadata appears in Segment exports. Once those fields are present,
+TV freshness uses the highest observed `source_version` for each TV platform instead of the static
+Expo runtime version.
 
 To make the dashboard query live data locally, in production, or in review apps, set
 `BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64`. The value should be a base64-encoded Google service

--- a/app_versions.py
+++ b/app_versions.py
@@ -4,11 +4,9 @@ import json
 import logging
 import os
 import re
-import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import datetime
-from functools import lru_cache
 from typing import Any
 
 import requests
@@ -29,10 +27,7 @@ APP_STORE_LOOKUP_URL = "https://itunes.apple.com/lookup"
 APP_STORE_LOOKUP_LIMIT = 24
 APP_STORE_LOOKUP_TIMEOUT_SECONDS = 5
 APP_STORE_LOOKUP_WORKERS = 8
-PLATFORMS_GITHUB_REPOSITORY = "ApollosProject/apollos-platforms"
-PLATFORMS_GITHUB_API_URL = f"https://api.github.com/repos/{PLATFORMS_GITHUB_REPOSITORY}"
-PLATFORM_SOURCE_CONTEXT_CACHE_SECONDS = 300
-GITHUB_LOOKUP_TIMEOUT_SECONDS = 5
+PLATFORMS_GITHUB_API_URL = "https://api.github.com/repos/ApollosProject/apollos-platforms"
 
 TIMESTAMP_COLUMN_CANDIDATES = (
     "timestamp",
@@ -58,10 +53,10 @@ FIELD_CANDIDATES = {
 }
 
 ROKU_ANALYTICS_VERSION_CANDIDATES = ("context_library_version",)
-MOBILE_PLATFORMS = {"android", "ios"}
 RELEASE_TAG_PLATFORMS = {"amazon", "androidtv", "tv", "tvos"}
 STABLE_RELEASE_TAG_PATTERN = re.compile(r"^v\d{4}\.\d{2}\.\d{2}\.\d{2}$")
 ALPHA_RELEASE_TAG_PATTERN = re.compile(r"^(v\d{4}\.\d{2}\.\d{2}\.\d{2})-alpha\.\d+$")
+SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{7,40}$")
 INTERNAL_DEPLOYMENT_TRACKS = {"beta", "development", "internal", "preview", "prerelease"}
 
 
@@ -123,8 +118,7 @@ def fetch_app_versions(config: AppVersionsConfig) -> tuple[list[dict[str, Any]],
     results = client.query(query, job_config=query_config).result()
     rows = [_row_to_dict(row) for row in results]
     source_context = _fetch_platform_source_context()
-    stable_release_revisions = source_context["stable_release_revisions"]
-    latest_rows = _select_latest_observed_versions(rows, stable_release_revisions)
+    latest_rows = _select_latest_observed_versions(rows, source_context["stable_release_revisions"])
     latest_rows = _enrich_app_store_versions(latest_rows)
     source_context["roku_revision_statuses"] = _fetch_roku_revision_statuses(
         latest_rows,
@@ -435,331 +429,132 @@ def _string_select_expression(
     return f"NULLIF(CAST(`{column}` AS STRING), '') AS {field_name}"
 
 
-def _github_request_headers() -> dict[str, str]:
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
+def _github_json(path: str, params: dict[str, str] | None = None) -> Any:
+    headers = {"Accept": "application/vnd.github+json"}
     if token := os.getenv("GITHUB_TOKEN", "").strip():
         headers["Authorization"] = f"Bearer {token}"
-    return headers
+    try:
+        response = requests.get(
+            f"{PLATFORMS_GITHUB_API_URL}/{path}",
+            params=params,
+            headers=headers,
+            timeout=APP_STORE_LOOKUP_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        return response.json()
+    except (requests.RequestException, ValueError):
+        logging.warning("Unable to load Platforms %s from GitHub", path, exc_info=True)
+        return None
 
 
 def _fetch_platform_source_context() -> dict[str, Any]:
-    cache_bucket = int(time.time() // PLATFORM_SOURCE_CONTEXT_CACHE_SECONDS)
-    cached = _fetch_platform_source_context_cached(cache_bucket)
+    tags = _github_json("tags", {"per_page": "100"}) or []
+    commits = _github_json("commits", {"sha": "master", "path": "templates/roku", "per_page": "1"})
     return {
-        "stable_release_revisions": dict(cached["stable_release_revisions"]),
-        "roku_target_revision": cached.get("roku_target_revision"),
-    }
-
-
-@lru_cache(maxsize=2)
-def _fetch_platform_source_context_cached(_cache_bucket: int) -> dict[str, Any]:
-    stable_release_revisions: dict[str, str] = {}
-    roku_target_revision = None
-    headers = _github_request_headers()
-
-    try:
-        response = requests.get(
-            f"{PLATFORMS_GITHUB_API_URL}/tags",
-            params={"per_page": 100},
-            headers=headers,
-            timeout=GITHUB_LOOKUP_TIMEOUT_SECONDS,
-        )
-        response.raise_for_status()
-        tags = response.json()
-        if isinstance(tags, list):
-            for tag in tags:
-                if not isinstance(tag, dict):
-                    continue
-                name = _string_value(tag.get("name"))
-                commit = tag.get("commit") or {}
-                revision = _string_value(commit.get("sha")) if isinstance(commit, dict) else None
-                if name and revision and STABLE_RELEASE_TAG_PATTERN.fullmatch(name):
-                    stable_release_revisions[name] = revision
-    except (requests.RequestException, ValueError, TypeError):
-        logging.warning("Unable to load Platforms release tags from GitHub", exc_info=True)
-
-    try:
-        response = requests.get(
-            f"{PLATFORMS_GITHUB_API_URL}/commits",
-            params={"sha": "master", "path": "templates/roku", "per_page": "1"},
-            headers=headers,
-            timeout=GITHUB_LOOKUP_TIMEOUT_SECONDS,
-        )
-        response.raise_for_status()
-        commits = response.json()
-        if isinstance(commits, list) and commits and isinstance(commits[0], dict):
-            roku_target_revision = _string_value(commits[0].get("sha"))
-    except (requests.RequestException, ValueError, TypeError):
-        logging.warning("Unable to load the latest Roku revision from GitHub", exc_info=True)
-
-    return {
-        "stable_release_revisions": stable_release_revisions,
-        "roku_target_revision": roku_target_revision,
+        "stable_release_revisions": {
+            tag["name"]: tag["commit"]["sha"]
+            for tag in tags
+            if STABLE_RELEASE_TAG_PATTERN.fullmatch(tag.get("name", ""))
+        },
+        "roku_target_revision": commits[0]["sha"] if commits else None,
     }
 
 
 def _fetch_roku_revision_statuses(
-    rows: list[dict[str, Any]],
-    target_revision: str | None,
+    rows: list[dict[str, Any]], target_revision: str | None
 ) -> dict[str, str]:
-    if not target_revision:
+    revisions = list(
+        {
+            revision
+            for row in rows
+            if (_string_value(row.get("apollos_platform")) or "").lower() == "roku"
+            and (revision := _string_value(row.get("source_revision")))
+        }
+    )
+    if not target_revision or not revisions:
         return {}
-    revisions = {
-        revision
-        for row in rows
-        if (_string_value(row.get("apollos_platform")) or "").lower() == "roku"
-        and (revision := _string_value(row.get("source_revision")))
-    }
-    return {
-        revision: status
-        for revision in revisions
-        if (status := _fetch_revision_compare_status(target_revision, revision))
-    }
+    with ThreadPoolExecutor(max_workers=min(APP_STORE_LOOKUP_WORKERS, len(revisions))) as executor:
+        statuses = executor.map(
+            lambda revision: _fetch_revision_compare_status(target_revision, revision),
+            revisions,
+        )
+    return {revision: status for revision, status in zip(revisions, statuses) if status}
 
 
-@lru_cache(maxsize=256)
 def _fetch_revision_compare_status(target_revision: str, deployed_revision: str) -> str | None:
     if _revisions_match(target_revision, deployed_revision):
         return "identical"
-    if not re.fullmatch(r"[0-9a-fA-F]{7,40}", deployed_revision):
+    if not SHA_PATTERN.fullmatch(target_revision) or not SHA_PATTERN.fullmatch(deployed_revision):
         return None
-    try:
-        response = requests.get(
-            f"{PLATFORMS_GITHUB_API_URL}/compare/{target_revision}...{deployed_revision}",
-            headers=_github_request_headers(),
-            timeout=GITHUB_LOOKUP_TIMEOUT_SECONDS,
-        )
-        response.raise_for_status()
-        payload = response.json()
-        if isinstance(payload, dict):
-            return _string_value(payload.get("status"))
-    except (requests.RequestException, ValueError, TypeError):
-        logging.warning(
-            "Unable to compare Roku revision %s with %s",
-            deployed_revision,
-            target_revision,
-            exc_info=True,
-        )
-    return None
+    payload = _github_json(f"compare/{target_revision}...{deployed_revision}")
+    return _string_value(payload.get("status")) if isinstance(payload, dict) else None
 
 
 def _revisions_match(left: str, right: str) -> bool:
-    left_normalized = left.strip().lower()
-    right_normalized = right.strip().lower()
-    return left_normalized.startswith(right_normalized) or right_normalized.startswith(
-        left_normalized
-    )
-
-
-def _canonical_release_version(
-    row: dict[str, Any],
-    stable_release_revisions: dict[str, str],
-) -> str | None:
-    source_version = _string_value(row.get("source_version"))
-    if not source_version:
-        return None
-    if STABLE_RELEASE_TAG_PATTERN.fullmatch(source_version):
-        return source_version
-    match = ALPHA_RELEASE_TAG_PATTERN.fullmatch(source_version)
-    if not match:
-        return None
-    stable_version = match.group(1)
-    stable_revision = stable_release_revisions.get(stable_version)
-    source_revision = _string_value(row.get("source_revision"))
-    if not stable_revision or not source_revision:
-        return None
-    if not _revisions_match(stable_revision, source_revision):
-        return None
-    return stable_version
-
-
-def _decorate_observation(
-    row: dict[str, Any],
-    stable_release_revisions: dict[str, str],
-) -> dict[str, Any]:
-    updated = dict(row)
-    deployment_track = (_string_value(row.get("deployment_track")) or "").lower()
-    canonical_source_version = _canonical_release_version(row, stable_release_revisions)
-    source_version = (_string_value(row.get("source_version")) or "").lower()
-
-    if deployment_track == "production":
-        observation_scope = "production"
-    elif deployment_track in INTERNAL_DEPLOYMENT_TRACKS:
-        observation_scope = "internal"
-    elif canonical_source_version:
-        observation_scope = "legacy_production"
-    elif ALPHA_RELEASE_TAG_PATTERN.fullmatch(source_version) or source_version == "master":
-        observation_scope = "legacy_internal"
-    else:
-        observation_scope = "legacy_unknown"
-
-    updated["deployment_track"] = deployment_track or None
-    updated["observation_scope"] = observation_scope
-    updated["canonical_source_version"] = canonical_source_version
-    updated["is_production_observation"] = observation_scope in {
-        "production",
-        "legacy_production",
-    }
-    updated["is_internal_observation"] = observation_scope in {
-        "internal",
-        "legacy_internal",
-    }
-    return updated
+    if not SHA_PATTERN.fullmatch(left) or not SHA_PATTERN.fullmatch(right):
+        return False
+    left, right = left.lower(), right.lower()
+    return left.startswith(right) or right.startswith(left)
 
 
 def _annotate_version_status(
-    rows: list[dict[str, Any]],
-    source_context: dict[str, Any] | None = None,
+    rows: list[dict[str, Any]], source_context: dict[str, Any] | None = None
 ) -> list[dict[str, Any]]:
     source_context = source_context or {}
-    stable_release_revisions = source_context.get("stable_release_revisions") or {}
-    roku_target_revision = _string_value(source_context.get("roku_target_revision"))
-    roku_revision_statuses = source_context.get("roku_revision_statuses") or {}
-    prepared_rows = [_decorate_observation(row, stable_release_revisions) for row in rows]
-
-    confirmed_runtime_by_platform: dict[str, str] = {}
-    fallback_runtime_by_platform: dict[str, str] = {}
-    latest_release_by_platform: dict[str, str] = {}
-
-    def record_latest(target: dict[str, str], platform: str, version: str | None) -> None:
-        if not version:
-            return
-        current = target.get(platform)
-        if current is None or compare_versions(version, current) > 0:
-            target[platform] = version
-
-    for row in prepared_rows:
+    roku_statuses = source_context.get("roku_revision_statuses") or {}
+    latest_by_platform: dict[str, str] = {}
+    for row in rows:
         platform = (_string_value(row.get("apollos_platform")) or "unknown").lower()
-        version = _string_value(row.get("apollos_version"))
-        if platform in MOBILE_PLATFORMS or platform == "unknown":
-            if row.get("is_production_observation"):
-                record_latest(confirmed_runtime_by_platform, platform, version)
-            elif not row.get("is_internal_observation"):
-                record_latest(fallback_runtime_by_platform, platform, version)
-        elif platform in RELEASE_TAG_PLATFORMS and row.get("is_production_observation"):
-            record_latest(
-                latest_release_by_platform,
-                platform,
-                _string_value(row.get("canonical_source_version")),
+        version = _string_value(
+            row.get(
+                "canonical_source_version"
+                if platform in RELEASE_TAG_PLATFORMS
+                else "apollos_version"
             )
+        )
+        if version and (
+            platform not in latest_by_platform
+            or compare_versions(version, latest_by_platform[platform]) > 0
+        ):
+            latest_by_platform[platform] = version
 
     annotated = []
-    for row in prepared_rows:
+    for row in rows:
         updated = dict(row)
         platform = (_string_value(row.get("apollos_platform")) or "unknown").lower()
-        version_source = _string_value(row.get("version_source")) or "runtime"
         version = _string_value(row.get("apollos_version"))
-        observed_app_version = _string_value(row.get("app_version"))
-        latest_app_version = _string_value(row.get("latest_app_version")) or observed_app_version
-        latest_app_version_source = (
-            _string_value(row.get("latest_app_version_source")) or "observed"
-        )
         source_version = _string_value(row.get("source_version"))
         source_revision = _string_value(row.get("source_revision"))
-        canonical_source_version = _string_value(row.get("canonical_source_version"))
-
-        updated["latest_app_version"] = latest_app_version
-        updated["latest_app_version_source"] = latest_app_version_source
-        updated["latest_app_version_source_label"] = format_app_version_source_label(
-            latest_app_version_source
-        )
-        updated["version_source_label"] = format_version_source_label(version_source)
-
-        is_app_version_outdated = False
-        if observed_app_version and latest_app_version:
-            is_app_version_outdated = compare_versions(observed_app_version, latest_app_version) < 0
-        updated["is_app_version_outdated"] = is_app_version_outdated
-
-        is_runtime_outdated = False
-        is_source_outdated = False
-        is_source_status_tbd = False
+        release_version = _string_value(row.get("canonical_source_version"))
+        latest_version = latest_by_platform.get(platform)
         is_outdated = False
-        latest_runtime = None
-        latest_source_version = None
-        source_display = format_source_display(source_version, source_revision)
         freshness_display = version or "TBD"
-        version_status_label = "Observed"
-        version_status_class = "observed"
-
-        if platform in MOBILE_PLATFORMS or platform == "unknown":
-            latest_runtime = confirmed_runtime_by_platform.get(
-                platform
-            ) or fallback_runtime_by_platform.get(platform)
-            if version and latest_runtime:
-                is_runtime_outdated = compare_versions(version, latest_runtime) < 0
-            if row.get("is_internal_observation"):
-                version_status_label = (
-                    "Prerelease"
-                    if source_version and ALPHA_RELEASE_TAG_PATTERN.fullmatch(source_version)
-                    else "Internal"
-                )
-            elif not version:
-                version_status_label = "TBD"
-            else:
-                is_outdated = is_runtime_outdated
-                version_status_label = "Outdated" if is_outdated else "Current"
-                version_status_class = "outdated" if is_outdated else "current"
-        elif platform in RELEASE_TAG_PLATFORMS:
-            latest_source_version = latest_release_by_platform.get(platform)
-            source_display = canonical_source_version or source_version or "TBD"
-            freshness_display = source_display
-            is_source_status_tbd = not source_version and not source_revision
-            if row.get("is_internal_observation"):
-                version_status_label = (
-                    "Prerelease"
-                    if source_version and ALPHA_RELEASE_TAG_PATTERN.fullmatch(source_version)
-                    else "Internal"
-                )
-            elif canonical_source_version:
-                if latest_source_version:
-                    is_source_outdated = (
-                        compare_versions(canonical_source_version, latest_source_version) < 0
-                    )
-                is_outdated = is_source_outdated
-                version_status_label = "Outdated" if is_outdated else "Current"
-                version_status_class = "outdated" if is_outdated else "current"
-            elif is_source_status_tbd:
-                version_status_label = "TBD"
-            else:
-                version_status_label = "Unverified"
+        revision_status = None
+        if platform in RELEASE_TAG_PLATFORMS:
+            freshness_display = release_version or source_version or "TBD"
+            if release_version and latest_version:
+                is_outdated = compare_versions(release_version, latest_version) < 0
         elif platform == "roku":
-            source_display = source_revision[:7] if source_revision else "TBD"
-            freshness_display = source_display
-            is_source_status_tbd = not source_revision
-            revision_status = roku_revision_statuses.get(source_revision or "")
-            if (
-                source_revision
-                and roku_target_revision
-                and _revisions_match(source_revision, roku_target_revision)
-            ):
-                revision_status = "identical"
-            if not source_revision:
-                version_status_label = "TBD"
-            elif not roku_target_revision or not revision_status:
-                version_status_label = "Observed"
-            elif revision_status in {"ahead", "identical"}:
-                version_status_label = "Current"
-                version_status_class = "current"
-            elif revision_status == "behind":
-                is_source_outdated = True
-                is_outdated = True
-                version_status_label = "Outdated"
-                version_status_class = "outdated"
-            else:
-                version_status_label = "Unverified"
-            updated["latest_source_revision"] = roku_target_revision
+            freshness_display = source_revision[:7] if source_revision else "TBD"
+            revision_status = roku_statuses.get(source_revision or "")
+            is_outdated = revision_status == "behind"
+        elif version and latest_version:
+            is_outdated = compare_versions(version, latest_version) < 0
 
-        updated["latest_apollos_version"] = latest_runtime or version
-        updated["latest_source_version"] = latest_source_version
-        updated["is_runtime_outdated"] = is_runtime_outdated
-        updated["is_source_outdated"] = is_source_outdated
-        updated["is_source_status_tbd"] = is_source_status_tbd
         updated["is_outdated"] = is_outdated
-        updated["source_display"] = source_display
         updated["freshness_display"] = freshness_display
+        if freshness_display == "TBD":
+            version_status_label = "TBD"
+            version_status_class = "observed"
+        elif platform == "roku" and revision_status not in {"ahead", "behind", "identical"}:
+            version_status_label = "Unverified" if revision_status else "Observed"
+            version_status_class = "observed"
+        elif platform in RELEASE_TAG_PLATFORMS and not release_version:
+            version_status_label = "Unverified"
+            version_status_class = "observed"
+        else:
+            version_status_label = "Outdated" if is_outdated else "Current"
+            version_status_class = "outdated" if is_outdated else "current"
         updated["version_status_label"] = version_status_label
         updated["version_status_class"] = version_status_class
         updated["latest_seen_display"] = format_timestamp(row.get("latest_seen_at"))
@@ -876,31 +671,40 @@ def _select_latest_observed_versions(
     stable_release_revisions: dict[str, str] | None = None,
 ) -> list[dict[str, Any]]:
     stable_release_revisions = stable_release_revisions or {}
-    observations_by_app: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    latest_by_app: dict[tuple[str, str, str], dict[str, Any]] = {}
     for row in rows:
-        decorated = _decorate_observation(row, stable_release_revisions)
-        observations_by_app.setdefault(_app_identity_key(decorated), []).append(decorated)
-
-    selected = []
-    for observations in observations_by_app.values():
-        production = [row for row in observations if row["is_production_observation"]]
-        non_internal = [row for row in observations if not row["is_internal_observation"]]
-        candidates = production or non_internal or observations
-        current = candidates[0]
-        for candidate in candidates[1:]:
-            if _is_newer_observed_version(
-                candidate,
-                current,
-                stable_release_revisions,
-            ):
-                current = candidate
-        selected.append(current)
-    return selected
+        source_version = _string_value(row.get("source_version")) or ""
+        release_version = (
+            source_version if STABLE_RELEASE_TAG_PATTERN.fullmatch(source_version) else None
+        )
+        match = ALPHA_RELEASE_TAG_PATTERN.fullmatch(source_version)
+        if match and _revisions_match(
+            _string_value(row.get("source_revision")) or "",
+            stable_release_revisions.get(match.group(1), ""),
+        ):
+            release_version = match.group(1)
+        track = (_string_value(row.get("deployment_track")) or "").lower()
+        if track in INTERNAL_DEPLOYMENT_TRACKS or (
+            (match and not release_version) or source_version.lower() == "master"
+        ):
+            continue
+        candidate = dict(row)
+        candidate["canonical_source_version"] = release_version
+        platform = (_string_value(row.get("apollos_platform")) or "unknown").lower()
+        if platform in RELEASE_TAG_PLATFORMS:
+            candidate["apollos_version"] = release_version
+        elif platform == "roku":
+            candidate["apollos_version"] = _string_value(row.get("source_version"))
+        key = _app_identity_key(candidate)
+        current = latest_by_app.get(key)
+        if current is None or _is_newer_observed_version(candidate, current):
+            latest_by_app[key] = candidate
+    return list(latest_by_app.values())
 
 
 def _app_identity_key(row: dict[str, Any]) -> tuple[str, str, str]:
     church = _string_value(row.get("church")) or "Unknown church"
-    platform = _string_value(row.get("apollos_platform")) or "unknown"
+    platform = (_string_value(row.get("apollos_platform")) or "unknown").lower()
     bundle_id = (_string_value(row.get("bundle_id")) or "unknown").lower()
     if bundle_id in {"unknown", "roku"}:
         return church, platform, bundle_id
@@ -910,50 +714,15 @@ def _app_identity_key(row: dict[str, Any]) -> tuple[str, str, str]:
 def _is_newer_observed_version(
     candidate: dict[str, Any],
     current: dict[str, Any],
-    stable_release_revisions: dict[str, str] | None = None,
 ) -> bool:
-    stable_release_revisions = stable_release_revisions or {}
-    platform = (_string_value(candidate.get("apollos_platform")) or "unknown").lower()
-
-    if platform in RELEASE_TAG_PLATFORMS:
-        candidate_source_version = _string_value(
-            candidate.get("canonical_source_version")
-        ) or _canonical_release_version(candidate, stable_release_revisions)
-        candidate_source_version = candidate_source_version or _string_value(
-            candidate.get("source_version")
-        )
-        current_source_version = _string_value(
-            current.get("canonical_source_version")
-        ) or _canonical_release_version(current, stable_release_revisions)
-        current_source_version = current_source_version or _string_value(
-            current.get("source_version")
-        )
-        if candidate_source_version and current_source_version:
-            source_compare = compare_versions(candidate_source_version, current_source_version)
-            if source_compare != 0:
-                return source_compare > 0
-        elif candidate_source_version != current_source_version:
-            return bool(candidate_source_version)
-
-    if platform == "roku":
-        candidate_source_version = _string_value(candidate.get("source_version"))
-        current_source_version = _string_value(current.get("source_version"))
-        if candidate_source_version and current_source_version:
-            source_compare = compare_versions(candidate_source_version, current_source_version)
-            if source_compare != 0:
-                return source_compare > 0
-        elif candidate_source_version != current_source_version:
-            return bool(candidate_source_version)
-
-    if platform not in RELEASE_TAG_PLATFORMS and platform != "roku":
-        candidate_version = _string_value(candidate.get("apollos_version"))
-        current_version = _string_value(current.get("apollos_version"))
-        if candidate_version and current_version:
-            version_compare = compare_versions(candidate_version, current_version)
-            if version_compare != 0:
-                return version_compare > 0
-        elif candidate_version != current_version:
-            return bool(candidate_version)
+    candidate_version = _string_value(candidate.get("apollos_version"))
+    current_version = _string_value(current.get("apollos_version"))
+    if candidate_version and current_version:
+        version_compare = compare_versions(candidate_version, current_version)
+        if version_compare != 0:
+            return version_compare > 0
+    elif candidate_version != current_version:
+        return bool(candidate_version)
 
     candidate_app_version = _string_value(candidate.get("app_version"))
     current_app_version = _string_value(current.get("app_version"))
@@ -963,6 +732,15 @@ def _is_newer_observed_version(
             return app_version_compare > 0
     elif candidate_app_version != current_app_version:
         return bool(candidate_app_version)
+
+    candidate_source_version = _string_value(candidate.get("source_version"))
+    current_source_version = _string_value(current.get("source_version"))
+    if candidate_source_version and current_source_version:
+        source_version_compare = compare_versions(candidate_source_version, current_source_version)
+        if source_version_compare != 0:
+            return source_version_compare > 0
+    elif candidate_source_version != current_source_version:
+        return bool(candidate_source_version)
 
     candidate_church = _string_value(candidate.get("church")) or "Unknown church"
     current_church = _string_value(current.get("church")) or "Unknown church"
@@ -978,7 +756,7 @@ def build_platform_tabs(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     tabs = []
     rows_by_platform: dict[str, list[dict[str, Any]]] = {}
     for row in rows:
-        platform = _string_value(row.get("apollos_platform")) or "unknown"
+        platform = (_string_value(row.get("apollos_platform")) or "unknown").lower()
         rows_by_platform.setdefault(platform, []).append(row)
 
     for platform, platform_rows in sorted(
@@ -992,23 +770,12 @@ def build_platform_tabs(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
             {
                 "key": platform,
                 "label": format_platform_label(platform),
-                "freshness_column_label": format_freshness_column_label(platform),
                 "rows": platform_rows,
                 "row_count": len(platform_rows),
                 "outdated_count": sum(1 for row in platform_rows if row.get("is_outdated")),
             }
         )
     return tabs
-
-
-def format_freshness_column_label(platform: str) -> str:
-    if platform in MOBILE_PLATFORMS:
-        return "Expo Runtime"
-    if platform in RELEASE_TAG_PLATFORMS:
-        return "Release"
-    if platform == "roku":
-        return "Commit"
-    return "Version"
 
 
 def format_platform_label(platform: str) -> str:
@@ -1023,32 +790,6 @@ def format_platform_label(platform: str) -> str:
         "unknown": "Unknown",
     }
     return labels.get(platform, platform.replace("_", " ").title())
-
-
-def format_version_source_label(version_source: str) -> str:
-    labels = {
-        "analytics_library": "Analytics library",
-        "runtime": "Runtime",
-    }
-    return labels.get(version_source, version_source.replace("_", " ").title())
-
-
-def format_app_version_source_label(version_source: str) -> str:
-    labels = {
-        "app_store": "App Store",
-        "observed": "Observed",
-    }
-    return labels.get(version_source, version_source.replace("_", " ").title())
-
-
-def format_source_display(source_version: str | None, source_revision: str | None) -> str:
-    if source_version and source_revision:
-        return f"{source_version} ({source_revision[:7]})"
-    if source_version:
-        return source_version
-    if source_revision:
-        return source_revision[:7]
-    return "TBD"
 
 
 def compare_versions(left: str, right: str) -> int:

--- a/app_versions.py
+++ b/app_versions.py
@@ -4,9 +4,11 @@ import json
 import logging
 import os
 import re
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import datetime
+from functools import lru_cache
 from typing import Any
 
 import requests
@@ -27,6 +29,10 @@ APP_STORE_LOOKUP_URL = "https://itunes.apple.com/lookup"
 APP_STORE_LOOKUP_LIMIT = 24
 APP_STORE_LOOKUP_TIMEOUT_SECONDS = 5
 APP_STORE_LOOKUP_WORKERS = 8
+PLATFORMS_GITHUB_REPOSITORY = "ApollosProject/apollos-platforms"
+PLATFORMS_GITHUB_API_URL = f"https://api.github.com/repos/{PLATFORMS_GITHUB_REPOSITORY}"
+PLATFORM_SOURCE_CONTEXT_CACHE_SECONDS = 300
+GITHUB_LOOKUP_TIMEOUT_SECONDS = 5
 
 TIMESTAMP_COLUMN_CANDIDATES = (
     "timestamp",
@@ -46,12 +52,17 @@ FIELD_CANDIDATES = {
     "application_name": ("application_name", "applicationName"),
     "source_revision": ("source_revision", "sourceRevision"),
     "source_version": ("source_version", "sourceVersion"),
+    "deployment_track": ("deployment_track", "deploymentTrack"),
     "user_id": ("user_id", "userId"),
     "anonymous_id": ("anonymous_id", "anonymousId"),
 }
 
 ROKU_ANALYTICS_VERSION_CANDIDATES = ("context_library_version",)
-TV_PLATFORMS = {"amazon", "androidtv", "roku", "tv", "tvos"}
+MOBILE_PLATFORMS = {"android", "ios"}
+RELEASE_TAG_PLATFORMS = {"amazon", "androidtv", "tv", "tvos"}
+STABLE_RELEASE_TAG_PATTERN = re.compile(r"^v\d{4}\.\d{2}\.\d{2}\.\d{2}$")
+ALPHA_RELEASE_TAG_PATTERN = re.compile(r"^(v\d{4}\.\d{2}\.\d{2}\.\d{2})-alpha\.\d+$")
+INTERNAL_DEPLOYMENT_TRACKS = {"beta", "development", "internal", "preview", "prerelease"}
 
 
 @dataclass(frozen=True)
@@ -111,12 +122,21 @@ def fetch_app_versions(config: AppVersionsConfig) -> tuple[list[dict[str, Any]],
     query, query_config = _build_app_versions_query(config, schema_by_table)
     results = client.query(query, job_config=query_config).result()
     rows = [_row_to_dict(row) for row in results]
-    latest_rows = _select_latest_observed_versions(rows)
+    source_context = _fetch_platform_source_context()
+    stable_release_revisions = source_context["stable_release_revisions"]
+    latest_rows = _select_latest_observed_versions(rows, stable_release_revisions)
     latest_rows = _enrich_app_store_versions(latest_rows)
+    source_context["roku_revision_statuses"] = _fetch_roku_revision_statuses(
+        latest_rows,
+        source_context.get("roku_target_revision"),
+    )
     discovered_tables = tuple(
         f"{dataset}.{table_name}" for dataset, table_name in schema_by_table.keys()
     )
-    return _annotate_version_status(latest_rows)[: config.limit], discovered_tables
+    return (
+        _annotate_version_status(latest_rows, source_context)[: config.limit],
+        discovered_tables,
+    )
 
 
 def _build_bigquery_client(project_id: str):
@@ -286,6 +306,7 @@ def _build_app_versions_query(
             app_update_id,
             source_revision,
             source_version,
+            deployment_track,
             source_dataset,
             source_table,
             version_source,
@@ -342,6 +363,7 @@ def _build_app_versions_query(
             events.app_update_id,
             events.source_revision,
             events.source_version,
+            events.deployment_track,
             events.source_dataset,
             events.source_table,
             events.version_source,
@@ -361,6 +383,7 @@ def _build_app_versions_query(
             events.app_update_id,
             events.source_revision,
             events.source_version,
+            events.deployment_track,
             events.source_dataset,
             events.source_table,
             events.version_source
@@ -383,6 +406,7 @@ def _build_app_versions_query(
           observation.app_update_id,
           observation.source_revision,
           observation.source_version,
+          observation.deployment_track,
           observation.source_dataset,
           observation.source_table,
           observation.version_source,
@@ -411,79 +435,331 @@ def _string_select_expression(
     return f"NULLIF(CAST(`{column}` AS STRING), '') AS {field_name}"
 
 
-def _annotate_version_status(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    latest_by_platform: dict[str, str] = {}
-    latest_source_version_by_platform: dict[str, str] = {}
-    for row in rows:
-        platform = _string_value(row.get("apollos_platform")) or "unknown"
-        version_source = _string_value(row.get("version_source")) or "runtime"
-        if platform != "unknown" and version_source == "runtime":
-            version = _string_value(row.get("apollos_version"))
-            if version:
-                current_latest = latest_by_platform.get(platform)
-                if current_latest is None or compare_versions(version, current_latest) > 0:
-                    latest_by_platform[platform] = version
+def _github_request_headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token := os.getenv("GITHUB_TOKEN", "").strip():
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
 
-        source_version = _string_value(row.get("source_version"))
-        if platform in TV_PLATFORMS and source_version:
-            current_latest_source = latest_source_version_by_platform.get(platform)
-            if (
-                current_latest_source is None
-                or compare_versions(source_version, current_latest_source) > 0
-            ):
-                latest_source_version_by_platform[platform] = source_version
+
+def _fetch_platform_source_context() -> dict[str, Any]:
+    cache_bucket = int(time.time() // PLATFORM_SOURCE_CONTEXT_CACHE_SECONDS)
+    cached = _fetch_platform_source_context_cached(cache_bucket)
+    return {
+        "stable_release_revisions": dict(cached["stable_release_revisions"]),
+        "roku_target_revision": cached.get("roku_target_revision"),
+    }
+
+
+@lru_cache(maxsize=2)
+def _fetch_platform_source_context_cached(_cache_bucket: int) -> dict[str, Any]:
+    stable_release_revisions: dict[str, str] = {}
+    roku_target_revision = None
+    headers = _github_request_headers()
+
+    try:
+        response = requests.get(
+            f"{PLATFORMS_GITHUB_API_URL}/tags",
+            params={"per_page": 100},
+            headers=headers,
+            timeout=GITHUB_LOOKUP_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        tags = response.json()
+        if isinstance(tags, list):
+            for tag in tags:
+                if not isinstance(tag, dict):
+                    continue
+                name = _string_value(tag.get("name"))
+                commit = tag.get("commit") or {}
+                revision = _string_value(commit.get("sha")) if isinstance(commit, dict) else None
+                if name and revision and STABLE_RELEASE_TAG_PATTERN.fullmatch(name):
+                    stable_release_revisions[name] = revision
+    except (requests.RequestException, ValueError, TypeError):
+        logging.warning("Unable to load Platforms release tags from GitHub", exc_info=True)
+
+    try:
+        response = requests.get(
+            f"{PLATFORMS_GITHUB_API_URL}/commits",
+            params={"sha": "master", "path": "templates/roku", "per_page": "1"},
+            headers=headers,
+            timeout=GITHUB_LOOKUP_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        commits = response.json()
+        if isinstance(commits, list) and commits and isinstance(commits[0], dict):
+            roku_target_revision = _string_value(commits[0].get("sha"))
+    except (requests.RequestException, ValueError, TypeError):
+        logging.warning("Unable to load the latest Roku revision from GitHub", exc_info=True)
+
+    return {
+        "stable_release_revisions": stable_release_revisions,
+        "roku_target_revision": roku_target_revision,
+    }
+
+
+def _fetch_roku_revision_statuses(
+    rows: list[dict[str, Any]],
+    target_revision: str | None,
+) -> dict[str, str]:
+    if not target_revision:
+        return {}
+    revisions = {
+        revision
+        for row in rows
+        if (_string_value(row.get("apollos_platform")) or "").lower() == "roku"
+        and (revision := _string_value(row.get("source_revision")))
+    }
+    return {
+        revision: status
+        for revision in revisions
+        if (status := _fetch_revision_compare_status(target_revision, revision))
+    }
+
+
+@lru_cache(maxsize=256)
+def _fetch_revision_compare_status(target_revision: str, deployed_revision: str) -> str | None:
+    if _revisions_match(target_revision, deployed_revision):
+        return "identical"
+    if not re.fullmatch(r"[0-9a-fA-F]{7,40}", deployed_revision):
+        return None
+    try:
+        response = requests.get(
+            f"{PLATFORMS_GITHUB_API_URL}/compare/{target_revision}...{deployed_revision}",
+            headers=_github_request_headers(),
+            timeout=GITHUB_LOOKUP_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if isinstance(payload, dict):
+            return _string_value(payload.get("status"))
+    except (requests.RequestException, ValueError, TypeError):
+        logging.warning(
+            "Unable to compare Roku revision %s with %s",
+            deployed_revision,
+            target_revision,
+            exc_info=True,
+        )
+    return None
+
+
+def _revisions_match(left: str, right: str) -> bool:
+    left_normalized = left.strip().lower()
+    right_normalized = right.strip().lower()
+    return left_normalized.startswith(right_normalized) or right_normalized.startswith(
+        left_normalized
+    )
+
+
+def _canonical_release_version(
+    row: dict[str, Any],
+    stable_release_revisions: dict[str, str],
+) -> str | None:
+    source_version = _string_value(row.get("source_version"))
+    if not source_version:
+        return None
+    if STABLE_RELEASE_TAG_PATTERN.fullmatch(source_version):
+        return source_version
+    match = ALPHA_RELEASE_TAG_PATTERN.fullmatch(source_version)
+    if not match:
+        return None
+    stable_version = match.group(1)
+    stable_revision = stable_release_revisions.get(stable_version)
+    source_revision = _string_value(row.get("source_revision"))
+    if not stable_revision or not source_revision:
+        return None
+    if not _revisions_match(stable_revision, source_revision):
+        return None
+    return stable_version
+
+
+def _decorate_observation(
+    row: dict[str, Any],
+    stable_release_revisions: dict[str, str],
+) -> dict[str, Any]:
+    updated = dict(row)
+    deployment_track = (_string_value(row.get("deployment_track")) or "").lower()
+    canonical_source_version = _canonical_release_version(row, stable_release_revisions)
+    source_version = (_string_value(row.get("source_version")) or "").lower()
+
+    if deployment_track == "production":
+        observation_scope = "production"
+    elif deployment_track in INTERNAL_DEPLOYMENT_TRACKS:
+        observation_scope = "internal"
+    elif canonical_source_version:
+        observation_scope = "legacy_production"
+    elif ALPHA_RELEASE_TAG_PATTERN.fullmatch(source_version) or source_version == "master":
+        observation_scope = "legacy_internal"
+    else:
+        observation_scope = "legacy_unknown"
+
+    updated["deployment_track"] = deployment_track or None
+    updated["observation_scope"] = observation_scope
+    updated["canonical_source_version"] = canonical_source_version
+    updated["is_production_observation"] = observation_scope in {
+        "production",
+        "legacy_production",
+    }
+    updated["is_internal_observation"] = observation_scope in {
+        "internal",
+        "legacy_internal",
+    }
+    return updated
+
+
+def _annotate_version_status(
+    rows: list[dict[str, Any]],
+    source_context: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    source_context = source_context or {}
+    stable_release_revisions = source_context.get("stable_release_revisions") or {}
+    roku_target_revision = _string_value(source_context.get("roku_target_revision"))
+    roku_revision_statuses = source_context.get("roku_revision_statuses") or {}
+    prepared_rows = [_decorate_observation(row, stable_release_revisions) for row in rows]
+
+    confirmed_runtime_by_platform: dict[str, str] = {}
+    fallback_runtime_by_platform: dict[str, str] = {}
+    latest_release_by_platform: dict[str, str] = {}
+
+    def record_latest(target: dict[str, str], platform: str, version: str | None) -> None:
+        if not version:
+            return
+        current = target.get(platform)
+        if current is None or compare_versions(version, current) > 0:
+            target[platform] = version
+
+    for row in prepared_rows:
+        platform = (_string_value(row.get("apollos_platform")) or "unknown").lower()
+        version = _string_value(row.get("apollos_version"))
+        if platform in MOBILE_PLATFORMS or platform == "unknown":
+            if row.get("is_production_observation"):
+                record_latest(confirmed_runtime_by_platform, platform, version)
+            elif not row.get("is_internal_observation"):
+                record_latest(fallback_runtime_by_platform, platform, version)
+        elif platform in RELEASE_TAG_PLATFORMS and row.get("is_production_observation"):
+            record_latest(
+                latest_release_by_platform,
+                platform,
+                _string_value(row.get("canonical_source_version")),
+            )
 
     annotated = []
-    for row in rows:
+    for row in prepared_rows:
         updated = dict(row)
-        platform = _string_value(row.get("apollos_platform")) or "unknown"
+        platform = (_string_value(row.get("apollos_platform")) or "unknown").lower()
         version_source = _string_value(row.get("version_source")) or "runtime"
         version = _string_value(row.get("apollos_version"))
-        latest_version = latest_by_platform.get(platform) or version
-        updated["latest_apollos_version"] = latest_version
         observed_app_version = _string_value(row.get("app_version"))
         latest_app_version = _string_value(row.get("latest_app_version")) or observed_app_version
         latest_app_version_source = (
             _string_value(row.get("latest_app_version_source")) or "observed"
         )
+        source_version = _string_value(row.get("source_version"))
+        source_revision = _string_value(row.get("source_revision"))
+        canonical_source_version = _string_value(row.get("canonical_source_version"))
+
         updated["latest_app_version"] = latest_app_version
         updated["latest_app_version_source"] = latest_app_version_source
         updated["latest_app_version_source_label"] = format_app_version_source_label(
             latest_app_version_source
         )
-        is_runtime_outdated = False
-        if platform != "unknown" and version_source == "runtime" and version and latest_version:
-            is_runtime_outdated = compare_versions(version, latest_version) < 0
+        updated["version_source_label"] = format_version_source_label(version_source)
+
         is_app_version_outdated = False
         if observed_app_version and latest_app_version:
             is_app_version_outdated = compare_versions(observed_app_version, latest_app_version) < 0
-        source_version = _string_value(row.get("source_version"))
-        source_revision = _string_value(row.get("source_revision"))
-        latest_source_version = latest_source_version_by_platform.get(platform) or source_version
+        updated["is_app_version_outdated"] = is_app_version_outdated
+
+        is_runtime_outdated = False
         is_source_outdated = False
         is_source_status_tbd = False
-        if platform in TV_PLATFORMS:
+        is_outdated = False
+        latest_runtime = None
+        latest_source_version = None
+        source_display = format_source_display(source_version, source_revision)
+        freshness_display = version or "TBD"
+        version_status_label = "Observed"
+        version_status_class = "observed"
+
+        if platform in MOBILE_PLATFORMS or platform == "unknown":
+            latest_runtime = confirmed_runtime_by_platform.get(
+                platform
+            ) or fallback_runtime_by_platform.get(platform)
+            if version and latest_runtime:
+                is_runtime_outdated = compare_versions(version, latest_runtime) < 0
+            if row.get("is_internal_observation"):
+                version_status_label = (
+                    "Prerelease"
+                    if source_version and ALPHA_RELEASE_TAG_PATTERN.fullmatch(source_version)
+                    else "Internal"
+                )
+            elif not version:
+                version_status_label = "TBD"
+            else:
+                is_outdated = is_runtime_outdated
+                version_status_label = "Outdated" if is_outdated else "Current"
+                version_status_class = "outdated" if is_outdated else "current"
+        elif platform in RELEASE_TAG_PLATFORMS:
+            latest_source_version = latest_release_by_platform.get(platform)
+            source_display = canonical_source_version or source_version or "TBD"
+            freshness_display = source_display
             is_source_status_tbd = not source_version and not source_revision
-            if source_version and latest_source_version:
-                is_source_outdated = compare_versions(source_version, latest_source_version) < 0
-        is_outdated = is_runtime_outdated or is_app_version_outdated or is_source_outdated
+            if row.get("is_internal_observation"):
+                version_status_label = (
+                    "Prerelease"
+                    if source_version and ALPHA_RELEASE_TAG_PATTERN.fullmatch(source_version)
+                    else "Internal"
+                )
+            elif canonical_source_version:
+                if latest_source_version:
+                    is_source_outdated = (
+                        compare_versions(canonical_source_version, latest_source_version) < 0
+                    )
+                is_outdated = is_source_outdated
+                version_status_label = "Outdated" if is_outdated else "Current"
+                version_status_class = "outdated" if is_outdated else "current"
+            elif is_source_status_tbd:
+                version_status_label = "TBD"
+            else:
+                version_status_label = "Unverified"
+        elif platform == "roku":
+            source_display = source_revision[:7] if source_revision else "TBD"
+            freshness_display = source_display
+            is_source_status_tbd = not source_revision
+            revision_status = roku_revision_statuses.get(source_revision or "")
+            if (
+                source_revision
+                and roku_target_revision
+                and _revisions_match(source_revision, roku_target_revision)
+            ):
+                revision_status = "identical"
+            if not source_revision:
+                version_status_label = "TBD"
+            elif not roku_target_revision or not revision_status:
+                version_status_label = "Observed"
+            elif revision_status in {"ahead", "identical"}:
+                version_status_label = "Current"
+                version_status_class = "current"
+            elif revision_status == "behind":
+                is_source_outdated = True
+                is_outdated = True
+                version_status_label = "Outdated"
+                version_status_class = "outdated"
+            else:
+                version_status_label = "Unverified"
+            updated["latest_source_revision"] = roku_target_revision
+
+        updated["latest_apollos_version"] = latest_runtime or version
+        updated["latest_source_version"] = latest_source_version
         updated["is_runtime_outdated"] = is_runtime_outdated
-        updated["is_app_version_outdated"] = is_app_version_outdated
         updated["is_source_outdated"] = is_source_outdated
         updated["is_source_status_tbd"] = is_source_status_tbd
         updated["is_outdated"] = is_outdated
-        updated["latest_source_version"] = latest_source_version
-        updated["source_display"] = format_source_display(source_version, source_revision)
-        updated["version_source_label"] = format_version_source_label(version_source)
-        if is_source_status_tbd:
-            version_status_label = "TBD"
-            version_status_class = "observed"
-        elif version_source != "runtime":
-            version_status_label = "Observed"
-            version_status_class = "observed"
-        else:
-            version_status_label = "Outdated" if is_outdated else "Current"
-            version_status_class = "outdated" if is_outdated else "current"
+        updated["source_display"] = source_display
+        updated["freshness_display"] = freshness_display
         updated["version_status_label"] = version_status_label
         updated["version_status_class"] = version_status_class
         updated["latest_seen_display"] = format_timestamp(row.get("latest_seen_at"))
@@ -595,14 +871,31 @@ def _should_lookup_app_store_version(row: dict[str, Any]) -> bool:
     return "." in normalized and normalized not in {"unknown", "roku"}
 
 
-def _select_latest_observed_versions(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    latest_by_app: dict[tuple[str, str, str], dict[str, Any]] = {}
+def _select_latest_observed_versions(
+    rows: list[dict[str, Any]],
+    stable_release_revisions: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    stable_release_revisions = stable_release_revisions or {}
+    observations_by_app: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
     for row in rows:
-        key = _app_identity_key(row)
-        current = latest_by_app.get(key)
-        if current is None or _is_newer_observed_version(row, current):
-            latest_by_app[key] = row
-    return list(latest_by_app.values())
+        decorated = _decorate_observation(row, stable_release_revisions)
+        observations_by_app.setdefault(_app_identity_key(decorated), []).append(decorated)
+
+    selected = []
+    for observations in observations_by_app.values():
+        production = [row for row in observations if row["is_production_observation"]]
+        non_internal = [row for row in observations if not row["is_internal_observation"]]
+        candidates = production or non_internal or observations
+        current = candidates[0]
+        for candidate in candidates[1:]:
+            if _is_newer_observed_version(
+                candidate,
+                current,
+                stable_release_revisions,
+            ):
+                current = candidate
+        selected.append(current)
+    return selected
 
 
 def _app_identity_key(row: dict[str, Any]) -> tuple[str, str, str]:
@@ -614,15 +907,53 @@ def _app_identity_key(row: dict[str, Any]) -> tuple[str, str, str]:
     return "", platform, bundle_id
 
 
-def _is_newer_observed_version(candidate: dict[str, Any], current: dict[str, Any]) -> bool:
-    candidate_version = _string_value(candidate.get("apollos_version"))
-    current_version = _string_value(current.get("apollos_version"))
-    if candidate_version and current_version:
-        version_compare = compare_versions(candidate_version, current_version)
-        if version_compare != 0:
-            return version_compare > 0
-    elif candidate_version != current_version:
-        return bool(candidate_version)
+def _is_newer_observed_version(
+    candidate: dict[str, Any],
+    current: dict[str, Any],
+    stable_release_revisions: dict[str, str] | None = None,
+) -> bool:
+    stable_release_revisions = stable_release_revisions or {}
+    platform = (_string_value(candidate.get("apollos_platform")) or "unknown").lower()
+
+    if platform in RELEASE_TAG_PLATFORMS:
+        candidate_source_version = _string_value(
+            candidate.get("canonical_source_version")
+        ) or _canonical_release_version(candidate, stable_release_revisions)
+        candidate_source_version = candidate_source_version or _string_value(
+            candidate.get("source_version")
+        )
+        current_source_version = _string_value(
+            current.get("canonical_source_version")
+        ) or _canonical_release_version(current, stable_release_revisions)
+        current_source_version = current_source_version or _string_value(
+            current.get("source_version")
+        )
+        if candidate_source_version and current_source_version:
+            source_compare = compare_versions(candidate_source_version, current_source_version)
+            if source_compare != 0:
+                return source_compare > 0
+        elif candidate_source_version != current_source_version:
+            return bool(candidate_source_version)
+
+    if platform == "roku":
+        candidate_source_version = _string_value(candidate.get("source_version"))
+        current_source_version = _string_value(current.get("source_version"))
+        if candidate_source_version and current_source_version:
+            source_compare = compare_versions(candidate_source_version, current_source_version)
+            if source_compare != 0:
+                return source_compare > 0
+        elif candidate_source_version != current_source_version:
+            return bool(candidate_source_version)
+
+    if platform not in RELEASE_TAG_PLATFORMS and platform != "roku":
+        candidate_version = _string_value(candidate.get("apollos_version"))
+        current_version = _string_value(current.get("apollos_version"))
+        if candidate_version and current_version:
+            version_compare = compare_versions(candidate_version, current_version)
+            if version_compare != 0:
+                return version_compare > 0
+        elif candidate_version != current_version:
+            return bool(candidate_version)
 
     candidate_app_version = _string_value(candidate.get("app_version"))
     current_app_version = _string_value(current.get("app_version"))
@@ -632,15 +963,6 @@ def _is_newer_observed_version(candidate: dict[str, Any], current: dict[str, Any
             return app_version_compare > 0
     elif candidate_app_version != current_app_version:
         return bool(candidate_app_version)
-
-    candidate_source_version = _string_value(candidate.get("source_version"))
-    current_source_version = _string_value(current.get("source_version"))
-    if candidate_source_version and current_source_version:
-        source_version_compare = compare_versions(candidate_source_version, current_source_version)
-        if source_version_compare != 0:
-            return source_version_compare > 0
-    elif candidate_source_version != current_source_version:
-        return bool(candidate_source_version)
 
     candidate_church = _string_value(candidate.get("church")) or "Unknown church"
     current_church = _string_value(current.get("church")) or "Unknown church"
@@ -670,12 +992,23 @@ def build_platform_tabs(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
             {
                 "key": platform,
                 "label": format_platform_label(platform),
+                "freshness_column_label": format_freshness_column_label(platform),
                 "rows": platform_rows,
                 "row_count": len(platform_rows),
                 "outdated_count": sum(1 for row in platform_rows if row.get("is_outdated")),
             }
         )
     return tabs
+
+
+def format_freshness_column_label(platform: str) -> str:
+    if platform in MOBILE_PLATFORMS:
+        return "Expo Runtime"
+    if platform in RELEASE_TAG_PLATFORMS:
+        return "Release"
+    if platform == "roku":
+        return "Commit"
+    return "Version"
 
 
 def format_platform_label(platform: str) -> str:

--- a/templates/app_versions.html
+++ b/templates/app_versions.html
@@ -163,7 +163,7 @@
               <tr>
                 <th>Church</th>
                 <th>App</th>
-                <th>{{ tab.freshness_column_label }}</th>
+                <th>{{ "Expo Runtime" if tab.key in ("ios", "android") else "Release" if tab.key in ("amazon", "androidtv", "tv", "tvos") else "Commit" if tab.key == "roku" else "Version" }}</th>
                 <th>Status</th>
                 <th>Seen</th>
                 <th>Users</th>
@@ -185,7 +185,7 @@
                       <span class="version-muted version-app-detail">App Store {{ row.latest_app_version }}</span>
                     {% endif %}
                   </td>
-                  <td><code>{{ row.freshness_display or "TBD" }}</code></td>
+                  <td><code>{{ row.freshness_display or row.apollos_version or "TBD" }}</code></td>
                   <td>
                     <span class="version-status version-status--{{ row.version_status_class or ('outdated' if row.is_outdated else 'current') }}">
                       {{ row.version_status_label or ("Outdated" if row.is_outdated else "Current") }}

--- a/templates/app_versions.html
+++ b/templates/app_versions.html
@@ -116,8 +116,8 @@
   <div>
     <h1>Apps</h1>
     <p>
-      Observed app and platform version signals from Segment over the last {{ lookback_days }} days,
-      compared with public App Store versions when available.
+      Production freshness observed through Segment over the last {{ lookback_days }} days:
+      Expo runtime for mobile, release tag for TV, and source commit for Roku.
     </p>
   </div>
 </section>
@@ -163,8 +163,7 @@
               <tr>
                 <th>Church</th>
                 <th>App</th>
-                <th>Apollos Runtime</th>
-                <th>Source</th>
+                <th>{{ tab.freshness_column_label }}</th>
                 <th>Status</th>
                 <th>Seen</th>
                 <th>Users</th>
@@ -186,8 +185,7 @@
                       <span class="version-muted version-app-detail">App Store {{ row.latest_app_version }}</span>
                     {% endif %}
                   </td>
-                  <td><code>{{ row.apollos_version }}</code></td>
-                  <td><code>{{ row.source_display or "TBD" }}</code></td>
+                  <td><code>{{ row.freshness_display or "TBD" }}</code></td>
                   <td>
                     <span class="version-status version-status--{{ row.version_status_class or ('outdated' if row.is_outdated else 'current') }}">
                       {{ row.version_status_label or ("Outdated" if row.is_outdated else "Current") }}

--- a/tests/test_app_versions.py
+++ b/tests/test_app_versions.py
@@ -204,7 +204,7 @@ class AppVersionsContextTest(unittest.TestCase):
         self.assertEqual(tv_church["source_display"], "TBD")
         self.assertTrue(old_tv_church["is_outdated"])
         self.assertTrue(old_tv_church["is_source_outdated"])
-        self.assertEqual(old_tv_church["source_display"], "v2026.05.01.00 (abcdef1)")
+        self.assertEqual(old_tv_church["source_display"], "v2026.05.01.00")
         self.assertFalse(new_tv_church["is_outdated"])
         self.assertFalse(unknown_platform["is_outdated"])
         self.assertEqual(unknown_platform["latest_apollos_version"], "8.2.13")
@@ -245,11 +245,134 @@ class AppVersionsContextTest(unittest.TestCase):
 
         bayside = next(row for row in annotated if row["church"] == "bayside")
         red_rocks = next(row for row in annotated if row["church"] == "red-rocks")
-        self.assertTrue(bayside["is_outdated"])
+        self.assertFalse(bayside["is_outdated"])
         self.assertFalse(bayside["is_runtime_outdated"])
         self.assertTrue(bayside["is_app_version_outdated"])
         self.assertEqual(bayside["latest_app_version_source_label"], "App Store")
         self.assertFalse(red_rocks["is_outdated"])
+
+    def test_prefers_production_runtime_over_newer_internal_runtime(self):
+        rows = [
+            {
+                "church": "preview",
+                "apollos_platform": "ios",
+                "bundle_id": "com.apollos.preview",
+                "apollos_version": "101",
+                "app_version": "1.0.0",
+                "source_version": "v2026.07.06.00",
+                "deployment_track": "production",
+            },
+            {
+                "church": "preview",
+                "apollos_platform": "ios",
+                "bundle_id": "com.apollos.preview",
+                "apollos_version": "102",
+                "app_version": "1.0.1",
+                "source_version": "v2026.07.13.00-alpha.1",
+                "deployment_track": "internal",
+            },
+        ]
+
+        selected = app_versions._select_latest_observed_versions(rows)
+
+        self.assertEqual(len(selected), 1)
+        self.assertEqual(selected[0]["apollos_version"], "101")
+        self.assertEqual(selected[0]["observation_scope"], "production")
+
+    def test_promoted_legacy_alpha_resolves_to_stable_release(self):
+        stable_revision = "d84ce358279ff5c020200e4087df7abdcbb6f552"
+        rows = [
+            {
+                "church": "preview",
+                "apollos_platform": "androidtv",
+                "bundle_id": "com.apollos.preview",
+                "source_version": "v2026.07.06.00-alpha.1",
+                "source_revision": stable_revision,
+                "app_version": "1.0.1",
+            },
+            {
+                "church": "preview",
+                "apollos_platform": "androidtv",
+                "bundle_id": "com.apollos.preview",
+                "source_version": "v2026.07.13.00-alpha.1",
+                "source_revision": "74365acc061c543ea0f7a6b89acd38dde8e17d6d",
+                "app_version": "1.0.2",
+            },
+        ]
+
+        selected = app_versions._select_latest_observed_versions(
+            rows,
+            {"v2026.07.06.00": stable_revision},
+        )
+        annotated = app_versions._annotate_version_status(
+            selected,
+            {"stable_release_revisions": {"v2026.07.06.00": stable_revision}},
+        )
+
+        self.assertEqual(len(selected), 1)
+        self.assertEqual(selected[0]["source_version"], "v2026.07.06.00-alpha.1")
+        self.assertEqual(selected[0]["canonical_source_version"], "v2026.07.06.00")
+        self.assertEqual(annotated[0]["freshness_display"], "v2026.07.06.00")
+        self.assertEqual(annotated[0]["version_status_label"], "Current")
+
+    def test_does_not_promote_legacy_alpha_without_matching_revision(self):
+        row = {
+            "church": "preview",
+            "apollos_platform": "androidtv",
+            "bundle_id": "com.apollos.preview",
+            "source_version": "v2026.07.06.00-alpha.1",
+        }
+
+        decorated = app_versions._decorate_observation(
+            row,
+            {"v2026.07.06.00": "d84ce358279ff5c020200e4087df7abdcbb6f552"},
+        )
+
+        self.assertIsNone(decorated["canonical_source_version"])
+        self.assertEqual(decorated["observation_scope"], "legacy_internal")
+
+    def test_annotates_roku_against_latest_roku_commit_on_master(self):
+        current_revision = "82938ad63d6ba28c5913b366ae53503cdce4992b"
+        old_revision = "ba95e2f5fe554f430d113f79761c1655376b8239"
+        rows = [
+            {
+                "church": "current-roku",
+                "apollos_platform": "roku",
+                "bundle_id": "roku",
+                "source_revision": current_revision,
+                "source_version": "2.1.5407",
+                "version_source": "analytics_library",
+            },
+            {
+                "church": "old-roku",
+                "apollos_platform": "roku",
+                "bundle_id": "roku",
+                "source_revision": old_revision,
+                "source_version": "2.0.5384",
+                "version_source": "analytics_library",
+            },
+        ]
+
+        annotated = app_versions._annotate_version_status(
+            rows,
+            {
+                "stable_release_revisions": {},
+                "roku_target_revision": current_revision,
+                "roku_revision_statuses": {
+                    current_revision: "identical",
+                    old_revision: "behind",
+                },
+            },
+        )
+
+        current = next(row for row in annotated if row["church"] == "current-roku")
+        old = next(row for row in annotated if row["church"] == "old-roku")
+        self.assertEqual(current["freshness_display"], "82938ad")
+        self.assertEqual(current["version_status_label"], "Current")
+        self.assertFalse(current["is_outdated"])
+        self.assertEqual(old["freshness_display"], "ba95e2f")
+        self.assertEqual(old["version_status_label"], "Outdated")
+        self.assertTrue(old["is_outdated"])
 
     def test_enriches_app_store_versions_by_bundle_id(self):
         rows = [
@@ -508,10 +631,12 @@ class AppVersionsContextTest(unittest.TestCase):
         )
         ios_tab = next(tab for tab in tabs if tab["key"] == "ios")
         self.assertEqual(ios_tab["label"], "iOS")
+        self.assertEqual(ios_tab["freshness_column_label"], "Expo Runtime")
         self.assertEqual(ios_tab["row_count"], 2)
         self.assertEqual(ios_tab["outdated_count"], 1)
         androidtv_tab = next(tab for tab in tabs if tab["key"] == "androidtv")
         self.assertEqual(androidtv_tab["label"], "AndroidTV")
+        self.assertEqual(androidtv_tab["freshness_column_label"], "Release")
 
     def test_builds_query_from_discovered_segment_columns(self):
         config = app_versions.AppVersionsConfig(
@@ -529,6 +654,7 @@ class AppVersionsContextTest(unittest.TestCase):
                 "app_version": "app_version",
                 "source_revision": "source_revision",
                 "source_version": "source_version",
+                "deployment_track": "deployment_track",
                 "bundle_id": "bundle_id",
                 "application_name": "application_name",
                 "apollos_platform": "apollos_platform",
@@ -540,6 +666,7 @@ class AppVersionsContextTest(unittest.TestCase):
                 "appversion": "appVersion",
                 "sourcerevision": "sourceRevision",
                 "sourceversion": "sourceVersion",
+                "deploymenttrack": "deploymentTrack",
             },
             ("apollos_roku", "identifies"): {
                 "timestamp": "timestamp",
@@ -565,10 +692,19 @@ class AppVersionsContextTest(unittest.TestCase):
         self.assertIn("NULLIF(CAST(`source_revision` AS STRING), '') AS source_revision", query)
         self.assertIn("NULLIF(CAST(`sourceVersion` AS STRING), '') AS source_version", query)
         self.assertIn(
+            "NULLIF(CAST(`deployment_track` AS STRING), '') AS deployment_track",
+            query,
+        )
+        self.assertIn(
+            "NULLIF(CAST(`deploymentTrack` AS STRING), '') AS deployment_track",
+            query,
+        )
+        self.assertIn(
             "NULLIF(CAST(`context_library_version` AS STRING), '') AS apollos_version",
             query,
         )
         self.assertIn("CAST(NULL AS STRING) AS source_revision", query)
+        self.assertIn("CAST(NULL AS STRING) AS deployment_track", query)
         self.assertIn("NULLIF(CAST(`groupId` AS STRING), '') AS church", query)
         self.assertIn("'analytics_library' AS version_source", query)
         self.assertIn("TIMESTAMP_SUB(", query)
@@ -654,6 +790,7 @@ class AppVersionsRouteTest(unittest.TestCase):
                 "apollos_platform": "ios",
                 "apollos_version": "97",
                 "latest_apollos_version": "101",
+                "freshness_display": "97",
                 "source_display": "v2026.05.12.00 (abc1234)",
                 "is_outdated": True,
                 "latest_seen_display": "2026-05-12 10:00 AM EDT",
@@ -671,6 +808,7 @@ class AppVersionsRouteTest(unittest.TestCase):
                 "apollos_platform": "android",
                 "apollos_version": "97",
                 "latest_apollos_version": "97",
+                "freshness_display": "97",
                 "source_display": "TBD",
                 "is_outdated": False,
                 "latest_seen_display": "2026-05-12 10:00 AM EDT",
@@ -703,13 +841,12 @@ class AppVersionsRouteTest(unittest.TestCase):
         self.assertIn("One Church", body)
         self.assertNotIn("<th>Latest App</th>", body)
         self.assertNotIn("<th>Observed Version</th>", body)
-        self.assertIn("<th>Apollos Runtime</th>", body)
-        self.assertIn("<th>Source</th>", body)
+        self.assertIn("<th>Expo Runtime</th>", body)
+        self.assertNotIn("<th>Source</th>", body)
         self.assertIn("1.0.1", body)
         self.assertIn("App Store 1.0.1", body)
         self.assertNotIn("App Store 1.0.0", body)
-        self.assertIn("v2026.05.12.00 (abc1234)", body)
-        self.assertIn("<code>TBD</code>", body)
+        self.assertIn("<code>97</code>", body)
         self.assertIn("Two Church", body)
         self.assertNotIn("<th>Platform</th>", body)
         self.assertNotIn("<th>Latest Observed</th>", body)

--- a/tests/test_app_versions.py
+++ b/tests/test_app_versions.py
@@ -148,7 +148,7 @@ class AppVersionsContextTest(unittest.TestCase):
                 "bundle_id": "com.oldtv",
                 "apollos_version": "1.0.0",
                 "app_version": "1.0.0",
-                "source_version": "v2026.05.01.00",
+                "source_version": "v2026.05.01.00-alpha.1",
                 "source_revision": "abcdef123456",
                 "version_source": "runtime",
                 "latest_seen_at": datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
@@ -180,12 +180,19 @@ class AppVersionsContextTest(unittest.TestCase):
                 "application_name": "Roku",
                 "bundle_id": "roku",
                 "apollos_version": "2.0.0",
+                "source_revision": "ba95e2f5fe554f430d113f79761c1655376b8239",
                 "version_source": "analytics_library",
                 "latest_seen_at": datetime(2026, 5, 4, 12, 0, tzinfo=timezone.utc),
             },
         ]
 
-        annotated = app_versions._annotate_version_status(rows)
+        selected = app_versions._select_latest_observed_versions(
+            rows, {"v2026.05.01.00": "abcdef123456"}
+        )
+        annotated = app_versions._annotate_version_status(
+            selected,
+            {"roku_revision_statuses": {rows[-1]["source_revision"]: "behind"}},
+        )
 
         one_church = next(row for row in annotated if row["church"] == "one-church")
         two_church = next(row for row in annotated if row["church"] == "two-church")
@@ -195,23 +202,18 @@ class AppVersionsContextTest(unittest.TestCase):
         unknown_platform = next(row for row in annotated if row["church"] == "unknown-platform")
         roku_church = next(row for row in annotated if row["church"] == "roku-church")
         self.assertTrue(one_church["is_outdated"])
-        self.assertEqual(one_church["latest_apollos_version"], "101")
-        self.assertEqual(one_church["version_source_label"], "Runtime")
+        self.assertEqual(one_church["freshness_display"], "97")
         self.assertFalse(two_church["is_outdated"])
-        self.assertFalse(tv_church["is_outdated"])
-        self.assertTrue(tv_church["is_source_status_tbd"])
         self.assertEqual(tv_church["version_status_label"], "TBD")
-        self.assertEqual(tv_church["source_display"], "TBD")
         self.assertTrue(old_tv_church["is_outdated"])
-        self.assertTrue(old_tv_church["is_source_outdated"])
-        self.assertEqual(old_tv_church["source_display"], "v2026.05.01.00")
+        self.assertEqual(old_tv_church["freshness_display"], "v2026.05.01.00")
         self.assertFalse(new_tv_church["is_outdated"])
         self.assertFalse(unknown_platform["is_outdated"])
-        self.assertEqual(unknown_platform["latest_apollos_version"], "8.2.13")
-        self.assertFalse(roku_church["is_outdated"])
-        self.assertEqual(roku_church["version_source_label"], "Analytics library")
-        self.assertEqual(roku_church["version_status_label"], "TBD")
+        self.assertTrue(roku_church["is_outdated"])
+        self.assertEqual(roku_church["freshness_display"], "ba95e2f")
         self.assertEqual(annotated[0]["church"], "one-church")
+        self.assertTrue(app_versions._revisions_match("abcdef123456", "abcdef1"))
+        self.assertFalse(app_versions._revisions_match("abcdef123456", "abc"))
 
     def test_annotates_outdated_apps_by_app_store_version(self):
         rows = [
@@ -246,133 +248,7 @@ class AppVersionsContextTest(unittest.TestCase):
         bayside = next(row for row in annotated if row["church"] == "bayside")
         red_rocks = next(row for row in annotated if row["church"] == "red-rocks")
         self.assertFalse(bayside["is_outdated"])
-        self.assertFalse(bayside["is_runtime_outdated"])
-        self.assertTrue(bayside["is_app_version_outdated"])
-        self.assertEqual(bayside["latest_app_version_source_label"], "App Store")
         self.assertFalse(red_rocks["is_outdated"])
-
-    def test_prefers_production_runtime_over_newer_internal_runtime(self):
-        rows = [
-            {
-                "church": "preview",
-                "apollos_platform": "ios",
-                "bundle_id": "com.apollos.preview",
-                "apollos_version": "101",
-                "app_version": "1.0.0",
-                "source_version": "v2026.07.06.00",
-                "deployment_track": "production",
-            },
-            {
-                "church": "preview",
-                "apollos_platform": "ios",
-                "bundle_id": "com.apollos.preview",
-                "apollos_version": "102",
-                "app_version": "1.0.1",
-                "source_version": "v2026.07.13.00-alpha.1",
-                "deployment_track": "internal",
-            },
-        ]
-
-        selected = app_versions._select_latest_observed_versions(rows)
-
-        self.assertEqual(len(selected), 1)
-        self.assertEqual(selected[0]["apollos_version"], "101")
-        self.assertEqual(selected[0]["observation_scope"], "production")
-
-    def test_promoted_legacy_alpha_resolves_to_stable_release(self):
-        stable_revision = "d84ce358279ff5c020200e4087df7abdcbb6f552"
-        rows = [
-            {
-                "church": "preview",
-                "apollos_platform": "androidtv",
-                "bundle_id": "com.apollos.preview",
-                "source_version": "v2026.07.06.00-alpha.1",
-                "source_revision": stable_revision,
-                "app_version": "1.0.1",
-            },
-            {
-                "church": "preview",
-                "apollos_platform": "androidtv",
-                "bundle_id": "com.apollos.preview",
-                "source_version": "v2026.07.13.00-alpha.1",
-                "source_revision": "74365acc061c543ea0f7a6b89acd38dde8e17d6d",
-                "app_version": "1.0.2",
-            },
-        ]
-
-        selected = app_versions._select_latest_observed_versions(
-            rows,
-            {"v2026.07.06.00": stable_revision},
-        )
-        annotated = app_versions._annotate_version_status(
-            selected,
-            {"stable_release_revisions": {"v2026.07.06.00": stable_revision}},
-        )
-
-        self.assertEqual(len(selected), 1)
-        self.assertEqual(selected[0]["source_version"], "v2026.07.06.00-alpha.1")
-        self.assertEqual(selected[0]["canonical_source_version"], "v2026.07.06.00")
-        self.assertEqual(annotated[0]["freshness_display"], "v2026.07.06.00")
-        self.assertEqual(annotated[0]["version_status_label"], "Current")
-
-    def test_does_not_promote_legacy_alpha_without_matching_revision(self):
-        row = {
-            "church": "preview",
-            "apollos_platform": "androidtv",
-            "bundle_id": "com.apollos.preview",
-            "source_version": "v2026.07.06.00-alpha.1",
-        }
-
-        decorated = app_versions._decorate_observation(
-            row,
-            {"v2026.07.06.00": "d84ce358279ff5c020200e4087df7abdcbb6f552"},
-        )
-
-        self.assertIsNone(decorated["canonical_source_version"])
-        self.assertEqual(decorated["observation_scope"], "legacy_internal")
-
-    def test_annotates_roku_against_latest_roku_commit_on_master(self):
-        current_revision = "82938ad63d6ba28c5913b366ae53503cdce4992b"
-        old_revision = "ba95e2f5fe554f430d113f79761c1655376b8239"
-        rows = [
-            {
-                "church": "current-roku",
-                "apollos_platform": "roku",
-                "bundle_id": "roku",
-                "source_revision": current_revision,
-                "source_version": "2.1.5407",
-                "version_source": "analytics_library",
-            },
-            {
-                "church": "old-roku",
-                "apollos_platform": "roku",
-                "bundle_id": "roku",
-                "source_revision": old_revision,
-                "source_version": "2.0.5384",
-                "version_source": "analytics_library",
-            },
-        ]
-
-        annotated = app_versions._annotate_version_status(
-            rows,
-            {
-                "stable_release_revisions": {},
-                "roku_target_revision": current_revision,
-                "roku_revision_statuses": {
-                    current_revision: "identical",
-                    old_revision: "behind",
-                },
-            },
-        )
-
-        current = next(row for row in annotated if row["church"] == "current-roku")
-        old = next(row for row in annotated if row["church"] == "old-roku")
-        self.assertEqual(current["freshness_display"], "82938ad")
-        self.assertEqual(current["version_status_label"], "Current")
-        self.assertFalse(current["is_outdated"])
-        self.assertEqual(old["freshness_display"], "ba95e2f")
-        self.assertEqual(old["version_status_label"], "Outdated")
-        self.assertTrue(old["is_outdated"])
 
     def test_enriches_app_store_versions_by_bundle_id(self):
         rows = [
@@ -537,6 +413,7 @@ class AppVersionsContextTest(unittest.TestCase):
                 "user_count": 7,
             },
         ]
+        rows.append({**rows[0], "apollos_version": "999", "deployment_track": "internal"})
 
         selected = app_versions._select_latest_observed_versions(rows)
 
@@ -616,7 +493,7 @@ class AppVersionsContextTest(unittest.TestCase):
 
     def test_builds_platform_tabs_with_outdated_counts(self):
         rows = [
-            {"apollos_platform": "ios", "is_outdated": True},
+            {"apollos_platform": "iOS", "is_outdated": True},
             {"apollos_platform": "ios", "is_outdated": False},
             {"apollos_platform": "android", "is_outdated": False},
             {"apollos_platform": "androidtv", "is_outdated": False},
@@ -631,12 +508,10 @@ class AppVersionsContextTest(unittest.TestCase):
         )
         ios_tab = next(tab for tab in tabs if tab["key"] == "ios")
         self.assertEqual(ios_tab["label"], "iOS")
-        self.assertEqual(ios_tab["freshness_column_label"], "Expo Runtime")
         self.assertEqual(ios_tab["row_count"], 2)
         self.assertEqual(ios_tab["outdated_count"], 1)
         androidtv_tab = next(tab for tab in tabs if tab["key"] == "androidtv")
         self.assertEqual(androidtv_tab["label"], "AndroidTV")
-        self.assertEqual(androidtv_tab["freshness_column_label"], "Release")
 
     def test_builds_query_from_discovered_segment_columns(self):
         config = app_versions.AppVersionsConfig(
@@ -691,20 +566,12 @@ class AppVersionsContextTest(unittest.TestCase):
         self.assertIn("NULLIF(CAST(`apollosVersion` AS STRING), '') AS apollos_version", query)
         self.assertIn("NULLIF(CAST(`source_revision` AS STRING), '') AS source_revision", query)
         self.assertIn("NULLIF(CAST(`sourceVersion` AS STRING), '') AS source_version", query)
-        self.assertIn(
-            "NULLIF(CAST(`deployment_track` AS STRING), '') AS deployment_track",
-            query,
-        )
-        self.assertIn(
-            "NULLIF(CAST(`deploymentTrack` AS STRING), '') AS deployment_track",
-            query,
-        )
+        self.assertIn("AS deployment_track", query)
         self.assertIn(
             "NULLIF(CAST(`context_library_version` AS STRING), '') AS apollos_version",
             query,
         )
         self.assertIn("CAST(NULL AS STRING) AS source_revision", query)
-        self.assertIn("CAST(NULL AS STRING) AS deployment_track", query)
         self.assertIn("NULLIF(CAST(`groupId` AS STRING), '') AS church", query)
         self.assertIn("'analytics_library' AS version_source", query)
         self.assertIn("TIMESTAMP_SUB(", query)
@@ -790,7 +657,6 @@ class AppVersionsRouteTest(unittest.TestCase):
                 "apollos_platform": "ios",
                 "apollos_version": "97",
                 "latest_apollos_version": "101",
-                "freshness_display": "97",
                 "source_display": "v2026.05.12.00 (abc1234)",
                 "is_outdated": True,
                 "latest_seen_display": "2026-05-12 10:00 AM EDT",
@@ -808,7 +674,6 @@ class AppVersionsRouteTest(unittest.TestCase):
                 "apollos_platform": "android",
                 "apollos_version": "97",
                 "latest_apollos_version": "97",
-                "freshness_display": "97",
                 "source_display": "TBD",
                 "is_outdated": False,
                 "latest_seen_display": "2026-05-12 10:00 AM EDT",


### PR DESCRIPTION
## Summary

- replace the generic Source column with platform-specific freshness signals
- use production Expo runtime observations for iOS and Android
- use stable release tags for tvOS, AndroidTV, and Amazon
- compare Roku builds with the latest `master` commit affecting `templates/roku`
- keep internal and prerelease observations out of production baselines

## Why

The Apps dashboard treated every platform as if it shared one version flow. Internal alpha observations could become the apparent TV baseline, App Store version differences could mark otherwise-current mobile runtimes outdated, and Roku commits were displayed without being checked against the source branch.

The dashboard now follows the actual release mechanism for each platform. Legacy alpha observations are only canonicalized to a stable release when their recorded revision matches that stable tag.

## Impact

The Apps page labels freshness as Expo Runtime, Release, or Commit depending on the selected platform. App Store versions remain visible as informational context, while status reflects the platform's production freshness signal.

## Related

- ApollosProject/apollos-platforms#6724 emits the deterministic deployment-track and source metadata consumed by this dashboard.

## Proof

- `ruff check .`
- `mypy .`
- `python -m unittest discover -s tests -p 'test_*.py'` (112 tests)
- live `/apps` request against production BigQuery and GitHub data returned 200 with 210 rows
- rendered Expo Runtime, Release, and Commit flows with zero alpha freshness values and zero internal-track rows

### TV release freshness

![TV release freshness](https://github.com/user-attachments/assets/055822fe-e6f0-4f61-8723-575cca3b9426)

### Mobile Expo runtime freshness

![Mobile Expo runtime freshness](https://github.com/user-attachments/assets/bf97deb7-f56c-48e6-9110-4ad94dd7e4b2)

### Roku commit freshness

![Roku commit freshness](https://github.com/user-attachments/assets/d2326c4f-6f43-4e4c-9574-4c5e400e8b65)
