### PR TITLE
Show Apps platform labels

### DIFF
--- a/templates/app_versions.html
+++ b/templates/app_versions.html
@@ -59,7 +59,7 @@
     border: 1px solid var(--pico-muted-border-color);
     border-radius: 999px;
     background: transparent;
-    color: var(--pico-color);
+    color: var(--pico-contrast);
     font-size: 0.9rem;
     line-height: 1.2;
   }


### PR DESCRIPTION
## Issue

Inactive platform labels on the Apps dashboard render white on a white background. Pico assigns buttons a local `--pico-color` value of white, so the tab rule was resolving to the button's inverse color; only the selected tab's explicit primary color remained visible.

## Solution

Use Pico's theme-aware contrast color for inactive tab labels. Counts, alerts, wrapping, and selected-tab styling are unchanged.

## To Test

- Open `/apps` at a mobile width.
- Select Android.
- Confirm Amazon, AndroidTV, iOS, Roku, tvOS, and Unknown remain visible.
- Confirm the selected Android state, row counts, and outdated badges are unchanged.

Local validation: Ruff lint/format, Vulture, MyPy, 112 unit tests, Gunicorn health smoke, and `git diff --check`.

## Proof

Before — production at 393 px; only the selected platform name is visible:

![Apps platform tabs before](https://github.com/user-attachments/assets/e4340088-7014-4276-b03d-09f84b2e8843)

After — local Flask app with this branch at 393 px; every platform name remains visible:

![Apps platform tabs after](https://github.com/user-attachments/assets/afde03ce-b7fb-4b0b-978e-5405080a1328)
