### PR TITLE
Show unassigned ready projects

### DIFF
--- a/app.py
+++ b/app.py
@@ -1108,8 +1108,10 @@ def _build_team_context(_cache_epoch: int) -> dict:
     for name, projects in list(projects_by_initiative.items()):
         remaining = []
         for project in projects:
-            is_ready = get_project_status_name(project) == "ready"
-            if not project_has_engineering_member(project) and not is_ready:
+            is_unassigned_ready = get_project_status_name(project) == "ready" and not (
+                project.get("lead") or {}
+            ).get("displayName")
+            if not project_has_engineering_member(project) and not is_unassigned_ready:
                 continue
             if project.get("is_inactive"):
                 completed_projects.append(project)
@@ -1146,6 +1148,8 @@ def _build_team_context(_cache_epoch: int) -> dict:
         if not is_completed and get_project_status_name(project) == "ready":
             ready_row_slugs: set[str | None] = set(assigned_slugs)
             if not ready_row_slugs:
+                if (project.get("lead") or {}).get("displayName"):
+                    continue
                 ready_row_slugs.add(None)
             for slug in ready_row_slugs:
                 ready_projects_by_developer[slug].append(project)

--- a/app.py
+++ b/app.py
@@ -1085,6 +1085,15 @@ def _build_team_context(_cache_epoch: int) -> dict:
     _annotate_project_schedule_fields(cycle_projects)
     for proj in cycle_projects:
         proj["is_inactive"] = is_inactive_project(proj)
+    unassigned_ready_projects = sorted(
+        [
+            project
+            for project in cycle_projects
+            if get_project_status_name(project) == "ready"
+            and not (project.get("lead") or {}).get("displayName")
+        ],
+        key=lambda project: project.get("name") or "",
+    )
 
     # group projects by initiatives
     projects_by_initiative: dict[str, list[dict[str, Any]]] = {}
@@ -1108,10 +1117,7 @@ def _build_team_context(_cache_epoch: int) -> dict:
     for name, projects in list(projects_by_initiative.items()):
         remaining = []
         for project in projects:
-            is_unassigned_ready = get_project_status_name(project) == "ready" and not (
-                project.get("lead") or {}
-            ).get("displayName")
-            if not project_has_engineering_member(project) and not is_unassigned_ready:
+            if not project_has_engineering_member(project):
                 continue
             if project.get("is_inactive"):
                 completed_projects.append(project)
@@ -1135,25 +1141,12 @@ def _build_team_context(_cache_epoch: int) -> dict:
         [{"slug": slug, "name": format_name(slug)} for slug in engineering_team_slugs],
         key=lambda developer: developer["name"],
     )
-    timeline_rows = [*timeline_developers, {"slug": None, "name": "Unassigned"}]
-    projects_by_developer: dict[str | None, list[dict[str, Any]]] = {
-        developer["slug"]: [] for developer in timeline_rows
-    }
-    ready_projects_by_developer: dict[str | None, list[dict[str, Any]]] = {
-        developer["slug"]: [] for developer in timeline_rows
+    projects_by_developer: dict[str, list[dict[str, Any]]] = {
+        developer["slug"]: [] for developer in timeline_developers
     }
     for project in timeline_projects:
         is_completed = bool(project.get("is_inactive"))
         assigned_slugs = engineering_participant_slugs(project)
-        if not is_completed and get_project_status_name(project) == "ready":
-            ready_row_slugs: set[str | None] = set(assigned_slugs)
-            if not ready_row_slugs:
-                if (project.get("lead") or {}).get("displayName"):
-                    continue
-                ready_row_slugs.add(None)
-            for slug in ready_row_slugs:
-                ready_projects_by_developer[slug].append(project)
-            continue
         start = parse_iso_date(project.get("startDate"))
         target = parse_iso_date(project.get("targetDate"))
         completed = parse_iso_date(project.get("completedAt"))
@@ -1187,7 +1180,7 @@ def _build_team_context(_cache_epoch: int) -> dict:
         for slug in assigned_slugs:
             projects_by_developer[slug].append(dict(bar))
 
-    for developer in timeline_rows:
+    for developer in timeline_developers:
         bars = projects_by_developer[developer["slug"]]
         lane_ends: list[Any] = []
         for bar in sorted(bars, key=lambda item: (item["_start"], item["_end"])):
@@ -1201,10 +1194,6 @@ def _build_team_context(_cache_epoch: int) -> dict:
                 lane_ends[lane] = bar["_end"]
             bar["lane"] = lane + 1
         developer["projects"] = bars
-        developer["ready_projects"] = sorted(
-            ready_projects_by_developer[developer["slug"]],
-            key=lambda project: project.get("name") or "",
-        )
         developer["lane_count"] = max(len(lane_ends), 1)
 
     timeline_weeks = []
@@ -1218,7 +1207,8 @@ def _build_team_context(_cache_epoch: int) -> dict:
     return {
         "project_timeline": {
             "weeks": timeline_weeks,
-            "rows": timeline_rows,
+            "rows": timeline_developers,
+            "unassigned_ready_projects": unassigned_ready_projects,
             "date_range": f"{timeline_weeks[0]['start']} – {timeline_weeks[-1]['end']}",
             "today_percent": ((today - timeline_start).days + 0.5) / 42 * 100,
         },

--- a/app.py
+++ b/app.py
@@ -1062,19 +1062,24 @@ def _build_team_context(_cache_epoch: int) -> dict:
             return None
         return name_to_slug.get(parts[0])
 
-    def project_has_engineering_member(project: dict) -> bool:
-        """Return True when a project includes an engineering team member."""
+    def engineering_participant_slugs(project: dict) -> set[str]:
+        """Return the engineering team members participating in a project."""
         participants: list[str] = []
         lead = (project.get("lead") or {}).get("displayName")
         if lead:
             participants.append(lead)
         members = project.get("members") or []
         participants.extend(members)
+        slugs = set()
         for name in participants:
             slug = slug_for_name(name)
             if slug and slug in engineering_team_slugs:
-                return True
-        return False
+                slugs.add(slug)
+        return slugs
+
+    def project_has_engineering_member(project: dict) -> bool:
+        """Return True when a project includes an engineering team member."""
+        return bool(engineering_participant_slugs(project))
 
     cycle_projects = get_projects()
     _annotate_project_schedule_fields(cycle_projects)
@@ -1103,7 +1108,8 @@ def _build_team_context(_cache_epoch: int) -> dict:
     for name, projects in list(projects_by_initiative.items()):
         remaining = []
         for project in projects:
-            if not project_has_engineering_member(project):
+            is_ready = get_project_status_name(project) == "ready"
+            if not project_has_engineering_member(project) and not is_ready:
                 continue
             if project.get("is_inactive"):
                 completed_projects.append(project)
@@ -1127,11 +1133,23 @@ def _build_team_context(_cache_epoch: int) -> dict:
         [{"slug": slug, "name": format_name(slug)} for slug in engineering_team_slugs],
         key=lambda developer: developer["name"],
     )
-    projects_by_developer: dict[str, list[dict[str, Any]]] = {
-        developer["slug"]: [] for developer in timeline_developers
+    timeline_rows = [*timeline_developers, {"slug": None, "name": "Unassigned"}]
+    projects_by_developer: dict[str | None, list[dict[str, Any]]] = {
+        developer["slug"]: [] for developer in timeline_rows
+    }
+    ready_projects_by_developer: dict[str | None, list[dict[str, Any]]] = {
+        developer["slug"]: [] for developer in timeline_rows
     }
     for project in timeline_projects:
         is_completed = bool(project.get("is_inactive"))
+        assigned_slugs = engineering_participant_slugs(project)
+        if not is_completed and get_project_status_name(project) == "ready":
+            ready_row_slugs: set[str | None] = set(assigned_slugs)
+            if not ready_row_slugs:
+                ready_row_slugs.add(None)
+            for slug in ready_row_slugs:
+                ready_projects_by_developer[slug].append(project)
+            continue
         start = parse_iso_date(project.get("startDate"))
         target = parse_iso_date(project.get("targetDate"))
         completed = parse_iso_date(project.get("completedAt"))
@@ -1162,19 +1180,10 @@ def _build_team_context(_cache_epoch: int) -> dict:
             "_start": visible_start,
             "_end": visible_end,
         }
-        lead = (project.get("lead") or {}).get("displayName")
-        participants = []
-        if lead:
-            participants.append(lead)
-        participants.extend(project.get("members", []))
-        assigned_slugs = set()
-        for name in participants:
-            slug = slug_for_name(name)
-            if slug and slug in engineering_team_slugs and slug not in assigned_slugs:
-                projects_by_developer[slug].append(dict(bar))
-                assigned_slugs.add(slug)
+        for slug in assigned_slugs:
+            projects_by_developer[slug].append(dict(bar))
 
-    for developer in timeline_developers:
+    for developer in timeline_rows:
         bars = projects_by_developer[developer["slug"]]
         lane_ends: list[Any] = []
         for bar in sorted(bars, key=lambda item: (item["_start"], item["_end"])):
@@ -1188,6 +1197,10 @@ def _build_team_context(_cache_epoch: int) -> dict:
                 lane_ends[lane] = bar["_end"]
             bar["lane"] = lane + 1
         developer["projects"] = bars
+        developer["ready_projects"] = sorted(
+            ready_projects_by_developer[developer["slug"]],
+            key=lambda project: project.get("name") or "",
+        )
         developer["lane_count"] = max(len(lane_ends), 1)
 
     timeline_weeks = []
@@ -1201,7 +1214,7 @@ def _build_team_context(_cache_epoch: int) -> dict:
     return {
         "project_timeline": {
             "weeks": timeline_weeks,
-            "rows": timeline_developers,
+            "rows": timeline_rows,
             "date_range": f"{timeline_weeks[0]['start']} – {timeline_weeks[-1]['end']}",
             "today_percent": ((today - timeline_start).days + 0.5) / 42 * 100,
         },

--- a/static/styles.css
+++ b/static/styles.css
@@ -67,13 +67,35 @@ details.dropdown.site-menu > summary + ul {
   gap: 0.5rem 1rem; justify-content: space-between; margin: 1.5rem 0 0.75rem;
 }
 .project-timeline-heading h3 { margin: 0; }
+.project-ready-section {
+  border: 1px solid var(--pico-muted-border-color); border-radius: 0.5rem;
+  margin-bottom: 0.75rem; padding: 0.65rem;
+}
+.project-ready-section-heading {
+  align-items: baseline; display: flex; gap: 0.5rem; margin-bottom: 0.5rem;
+}
+.project-ready-section-heading strong {
+  color: var(--pico-muted-color); font-size: 0.7rem; text-transform: uppercase;
+}
+.project-ready-section-heading span { color: var(--pico-muted-color); font-size: 0.8rem; }
+.project-ready-projects {
+  display: grid; gap: 0.35rem;
+  grid-template-columns: repeat(auto-fit, minmax(min(17rem, 100%), 1fr));
+}
+.project-ready-project {
+  align-items: center; background: #5d6b89; border-radius: 0.35rem; color: #fff;
+  display: flex; font-size: 0.75rem; font-weight: 600; min-height: 1.8rem;
+  min-width: 0; overflow: hidden; padding: 0.25rem 0.55rem; text-decoration: none;
+  text-overflow: ellipsis; white-space: nowrap;
+}
+.project-ready-project:hover { color: #fff; }
 .project-timeline-scroll {
   border: 1px solid var(--pico-muted-border-color); border-radius: 0.5rem; overflow-x: auto;
 }
-.project-timeline { min-width: 64rem; }
+.project-timeline { min-width: 52rem; }
 .project-timeline-header,
 .project-timeline-row {
-  display: grid; grid-template-columns: 7.5rem 12rem minmax(42rem, 1fr);
+  display: grid; grid-template-columns: 7.5rem minmax(42rem, 1fr);
 }
 .project-timeline-header {
   align-items: stretch; background: var(--pico-card-sectioning-background-color);
@@ -87,10 +109,6 @@ details.dropdown.site-menu > summary + ul {
   display: flex; left: 0; padding: 0.5rem 0.65rem; position: sticky; z-index: 4;
 }
 .project-timeline-header > strong { background: var(--pico-card-sectioning-background-color); }
-.project-timeline-ready-heading {
-  align-items: center; border-right: 1px solid var(--pico-muted-border-color);
-  display: flex; font-weight: 700; padding: 0.5rem 0.65rem;
-}
 .project-timeline-weeks {
   display: grid; grid-template-columns: repeat(6, 1fr);
 }
@@ -100,20 +118,6 @@ details.dropdown.site-menu > summary + ul {
 .project-timeline-row:not(:last-child) {
   border-bottom: 1px solid var(--pico-muted-border-color);
 }
-.project-timeline-ready {
-  align-content: start; border-right: 1px solid var(--pico-muted-border-color);
-  display: grid; grid-auto-rows: 1.8rem; padding: 0.3rem;
-}
-.project-timeline-ready-empty {
-  align-self: center; color: var(--pico-muted-color); padding-left: 0.35rem;
-}
-.project-timeline-ready-project {
-  align-items: center; align-self: center; background: #5d6b89; border-radius: 0.35rem;
-  color: #fff; display: flex; font-size: 0.68rem; font-weight: 600; height: 1.4rem;
-  min-width: 0; overflow: hidden; padding: 0 0.45rem; text-decoration: none;
-  text-overflow: ellipsis; white-space: nowrap;
-}
-.project-timeline-ready-project:hover { color: #fff; }
 .project-timeline-track {
   background-image: linear-gradient(
     to right, transparent calc(100% - 1px), var(--pico-muted-border-color) 0

--- a/static/styles.css
+++ b/static/styles.css
@@ -70,10 +70,10 @@ details.dropdown.site-menu > summary + ul {
 .project-timeline-scroll {
   border: 1px solid var(--pico-muted-border-color); border-radius: 0.5rem; overflow-x: auto;
 }
-.project-timeline { min-width: 52rem; }
+.project-timeline { min-width: 64rem; }
 .project-timeline-header,
 .project-timeline-row {
-  display: grid; grid-template-columns: 7.5rem minmax(42rem, 1fr);
+  display: grid; grid-template-columns: 7.5rem 12rem minmax(42rem, 1fr);
 }
 .project-timeline-header {
   align-items: stretch; background: var(--pico-card-sectioning-background-color);
@@ -87,6 +87,10 @@ details.dropdown.site-menu > summary + ul {
   display: flex; left: 0; padding: 0.5rem 0.65rem; position: sticky; z-index: 4;
 }
 .project-timeline-header > strong { background: var(--pico-card-sectioning-background-color); }
+.project-timeline-ready-heading {
+  align-items: center; border-right: 1px solid var(--pico-muted-border-color);
+  display: flex; font-weight: 700; padding: 0.5rem 0.65rem;
+}
 .project-timeline-weeks {
   display: grid; grid-template-columns: repeat(6, 1fr);
 }
@@ -96,6 +100,20 @@ details.dropdown.site-menu > summary + ul {
 .project-timeline-row:not(:last-child) {
   border-bottom: 1px solid var(--pico-muted-border-color);
 }
+.project-timeline-ready {
+  align-content: start; border-right: 1px solid var(--pico-muted-border-color);
+  display: grid; grid-auto-rows: 1.8rem; padding: 0.3rem;
+}
+.project-timeline-ready-empty {
+  align-self: center; color: var(--pico-muted-color); padding-left: 0.35rem;
+}
+.project-timeline-ready-project {
+  align-items: center; align-self: center; background: #5d6b89; border-radius: 0.35rem;
+  color: #fff; display: flex; font-size: 0.68rem; font-weight: 600; height: 1.4rem;
+  min-width: 0; overflow: hidden; padding: 0 0.45rem; text-decoration: none;
+  text-overflow: ellipsis; white-space: nowrap;
+}
+.project-timeline-ready-project:hover { color: #fff; }
 .project-timeline-track {
   background-image: linear-gradient(
     to right, transparent calc(100% - 1px), var(--pico-muted-border-color) 0

--- a/templates/partials/team_content.html
+++ b/templates/partials/team_content.html
@@ -7,13 +7,25 @@
   <div class="project-timeline">
     <div class="project-timeline-header">
       <strong>Developer</strong>
+      <span class="project-timeline-ready-heading">Ready</span>
       <div class="project-timeline-weeks">
         {% for week in project_timeline.weeks %}<span><b>{{ week.start }}</b> – {{ week.end }}</span>{% endfor %}
       </div>
     </div>
     {% for developer in project_timeline.rows %}
       <div class="project-timeline-row">
-        <a class="project-timeline-developer" href="{{ url_for('team_slug', slug=developer.slug) }}">{{ developer.name|first_name }}</a>
+        {% if developer.slug %}
+          <a class="project-timeline-developer" href="{{ url_for('team_slug', slug=developer.slug) }}">{{ developer.name|first_name }}</a>
+        {% else %}
+          <span class="project-timeline-developer">{{ developer.name }}</span>
+        {% endif %}
+        <div class="project-timeline-ready" aria-label="Ready projects for {{ developer.name }}">
+          {% for project in developer.ready_projects %}
+            <a href="{{ project.url }}" class="project-timeline-ready-project" title="{{ project.name }}">{{ project.name }}</a>
+          {% else %}
+            <span class="project-timeline-ready-empty" aria-hidden="true">—</span>
+          {% endfor %}
+        </div>
         <div class="project-timeline-track" style="--lanes: {{ developer.lane_count }}; --today: {{ project_timeline.today_percent }}%;">
           <i class="project-timeline-today" aria-hidden="true"></i>
           {% for project in developer.projects %}

--- a/templates/partials/team_content.html
+++ b/templates/partials/team_content.html
@@ -3,29 +3,30 @@
   <h3>Timeline</h3>
   <small>Six-week view · {{ project_timeline.date_range }} · Red line is today</small>
 </div>
+{% if project_timeline.unassigned_ready_projects %}
+  <section class="project-ready-section" aria-label="Ready unassigned projects">
+    <div class="project-ready-section-heading">
+      <strong>Ready</strong>
+      <span>Unassigned projects</span>
+    </div>
+    <div class="project-ready-projects">
+      {% for project in project_timeline.unassigned_ready_projects %}
+        <a href="{{ project.url }}" class="project-ready-project" title="{{ project.name }}">{{ project.name }}</a>
+      {% endfor %}
+    </div>
+  </section>
+{% endif %}
 <div class="project-timeline-scroll" tabindex="0" role="region" aria-label="Developer project timeline">
   <div class="project-timeline">
     <div class="project-timeline-header">
       <strong>Developer</strong>
-      <span class="project-timeline-ready-heading">Ready</span>
       <div class="project-timeline-weeks">
         {% for week in project_timeline.weeks %}<span><b>{{ week.start }}</b> – {{ week.end }}</span>{% endfor %}
       </div>
     </div>
     {% for developer in project_timeline.rows %}
       <div class="project-timeline-row">
-        {% if developer.slug %}
-          <a class="project-timeline-developer" href="{{ url_for('team_slug', slug=developer.slug) }}">{{ developer.name|first_name }}</a>
-        {% else %}
-          <span class="project-timeline-developer">{{ developer.name }}</span>
-        {% endif %}
-        <div class="project-timeline-ready" aria-label="Ready projects for {{ developer.name }}">
-          {% for project in developer.ready_projects %}
-            <a href="{{ project.url }}" class="project-timeline-ready-project" title="{{ project.name }}">{{ project.name }}</a>
-          {% else %}
-            <span class="project-timeline-ready-empty" aria-hidden="true">—</span>
-          {% endfor %}
-        </div>
+        <a class="project-timeline-developer" href="{{ url_for('team_slug', slug=developer.slug) }}">{{ developer.name|first_name }}</a>
         <div class="project-timeline-track" style="--lanes: {{ developer.lane_count }}; --today: {{ project_timeline.today_percent }}%;">
           <i class="project-timeline-today" aria-hidden="true"></i>
           {% for project in developer.projects %}

--- a/tests/test_failing_dags.py
+++ b/tests/test_failing_dags.py
@@ -843,7 +843,7 @@ class TeamContextProjectFilteringTest(unittest.TestCase):
             ["16KB Page Sizes for Android"],
         )
 
-    def test_ready_project_without_engineering_member_uses_unassigned_row(self):
+    def test_only_ready_project_without_lead_uses_unassigned_row(self):
         config = {
             "people": {
                 "darryl": {
@@ -866,9 +866,21 @@ class TeamContextProjectFilteringTest(unittest.TestCase):
             "initiatives": {"nodes": []},
             "members": [],
         }
+        led_ready_project = {
+            **ready_project,
+            "id": "proj-2",
+            "name": "Universal Giving Exports",
+            "url": "https://linear.example/project/universal-giving-exports",
+            "lead": {"displayName": "vincent"},
+            "members": ["shahbano", "vincent"],
+        }
 
         with patch.object(app_module, "load_config", return_value=config):
-            with patch.object(app_module, "get_projects", return_value=[ready_project]):
+            with patch.object(
+                app_module,
+                "get_projects",
+                return_value=[ready_project, led_ready_project],
+            ):
                 context = app_module._build_team_context(1)
 
         unassigned_row = context["project_timeline"]["rows"][-1]

--- a/tests/test_failing_dags.py
+++ b/tests/test_failing_dags.py
@@ -833,7 +833,7 @@ class TeamContextProjectFilteringTest(unittest.TestCase):
 
         self.assertEqual(
             [developer["slug"] for developer in context["project_timeline"]["rows"]],
-            ["darryl"],
+            ["darryl", None],
         )
         self.assertEqual(context["project_timeline"]["rows"][0]["projects"], [])
         self.assertEqual(context["cycle_projects_by_initiative"], {})
@@ -841,6 +841,43 @@ class TeamContextProjectFilteringTest(unittest.TestCase):
         self.assertEqual(
             [project["name"] for project in context["completed_cycle_projects"]],
             ["16KB Page Sizes for Android"],
+        )
+
+    def test_ready_project_without_engineering_member_uses_unassigned_row(self):
+        config = {
+            "people": {
+                "darryl": {
+                    "team": "engineering",
+                    "linear_username": "darryl",
+                }
+            },
+            "platforms": {},
+        }
+        ready_project = {
+            "id": "proj-1",
+            "name": "Add Tap Feed to Shortcuts in Crossroads Anywhere",
+            "url": "https://linear.example/project/tap-feed-shortcuts",
+            "health": None,
+            "status": {"name": "Ready", "type": "planned"},
+            "completedAt": None,
+            "startDate": None,
+            "targetDate": None,
+            "lead": None,
+            "initiatives": {"nodes": []},
+            "members": [],
+        }
+
+        with patch.object(app_module, "load_config", return_value=config):
+            with patch.object(app_module, "get_projects", return_value=[ready_project]):
+                context = app_module._build_team_context(1)
+
+        unassigned_row = context["project_timeline"]["rows"][-1]
+        self.assertEqual(unassigned_row["name"], "Unassigned")
+        self.assertIsNone(unassigned_row["slug"])
+        self.assertEqual(unassigned_row["projects"], [])
+        self.assertEqual(
+            [project["name"] for project in unassigned_row["ready_projects"]],
+            ["Add Tap Feed to Shortcuts in Crossroads Anywhere"],
         )
 
     def test_released_project_is_not_counted_as_current(self):

--- a/tests/test_failing_dags.py
+++ b/tests/test_failing_dags.py
@@ -833,7 +833,7 @@ class TeamContextProjectFilteringTest(unittest.TestCase):
 
         self.assertEqual(
             [developer["slug"] for developer in context["project_timeline"]["rows"]],
-            ["darryl", None],
+            ["darryl"],
         )
         self.assertEqual(context["project_timeline"]["rows"][0]["projects"], [])
         self.assertEqual(context["cycle_projects_by_initiative"], {})
@@ -843,7 +843,7 @@ class TeamContextProjectFilteringTest(unittest.TestCase):
             ["16KB Page Sizes for Android"],
         )
 
-    def test_only_ready_project_without_lead_uses_unassigned_row(self):
+    def test_only_ready_project_without_lead_is_listed_as_unassigned(self):
         config = {
             "people": {
                 "darryl": {
@@ -883,13 +883,16 @@ class TeamContextProjectFilteringTest(unittest.TestCase):
             ):
                 context = app_module._build_team_context(1)
 
-        unassigned_row = context["project_timeline"]["rows"][-1]
-        self.assertEqual(unassigned_row["name"], "Unassigned")
-        self.assertIsNone(unassigned_row["slug"])
-        self.assertEqual(unassigned_row["projects"], [])
         self.assertEqual(
-            [project["name"] for project in unassigned_row["ready_projects"]],
+            [
+                project["name"]
+                for project in context["project_timeline"]["unassigned_ready_projects"]
+            ],
             ["Add Tap Feed to Shortcuts in Crossroads Anywhere"],
+        )
+        self.assertEqual(
+            [developer["slug"] for developer in context["project_timeline"]["rows"]],
+            ["darryl"],
         )
 
     def test_released_project_is_not_counted_as_current(self):

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -88,7 +88,20 @@ class NavigationTest(unittest.TestCase):
         context = {
             "project_timeline": {
                 "weeks": [],
-                "rows": [],
+                "rows": [
+                    {
+                        "slug": None,
+                        "name": "Unassigned",
+                        "ready_projects": [
+                            {
+                                "name": "Add Tap Feed to Shortcuts",
+                                "url": "https://linear.example/project/tap-feed-shortcuts",
+                            }
+                        ],
+                        "projects": [],
+                        "lane_count": 1,
+                    }
+                ],
                 "date_range": "Jul 13 – Aug 23",
                 "today_percent": 1.2,
             },
@@ -106,6 +119,15 @@ class NavigationTest(unittest.TestCase):
         self.assertEqual(partial_response.status_code, 200)
         self.assertIn("<h2>Projects</h2>", partial_body)
         self.assertIn("<h3>Timeline</h3>", partial_body)
+        self.assertIn('class="project-timeline-ready-heading">Ready</span>', partial_body)
+        self.assertIn(
+            'aria-label="Ready projects for Unassigned"',
+            partial_body,
+        )
+        self.assertIn(
+            'href="https://linear.example/project/tap-feed-shortcuts"',
+            partial_body,
+        )
         self.assertNotIn("Current Focus", partial_body)
 
     def test_legacy_team_url_renders_the_projects_page(self):

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -88,18 +88,11 @@ class NavigationTest(unittest.TestCase):
         context = {
             "project_timeline": {
                 "weeks": [],
-                "rows": [
+                "rows": [],
+                "unassigned_ready_projects": [
                     {
-                        "slug": None,
-                        "name": "Unassigned",
-                        "ready_projects": [
-                            {
-                                "name": "Add Tap Feed to Shortcuts",
-                                "url": "https://linear.example/project/tap-feed-shortcuts",
-                            }
-                        ],
-                        "projects": [],
-                        "lane_count": 1,
+                        "name": "Add Tap Feed to Shortcuts",
+                        "url": "https://linear.example/project/tap-feed-shortcuts",
                     }
                 ],
                 "date_range": "Jul 13 – Aug 23",
@@ -119,11 +112,8 @@ class NavigationTest(unittest.TestCase):
         self.assertEqual(partial_response.status_code, 200)
         self.assertIn("<h2>Projects</h2>", partial_body)
         self.assertIn("<h3>Timeline</h3>", partial_body)
-        self.assertIn('class="project-timeline-ready-heading">Ready</span>', partial_body)
-        self.assertIn(
-            'aria-label="Ready projects for Unassigned"',
-            partial_body,
-        )
+        self.assertIn('aria-label="Ready unassigned projects"', partial_body)
+        self.assertIn("Unassigned projects", partial_body)
         self.assertIn(
             'href="https://linear.example/project/tap-feed-shortcuts"',
             partial_body,


### PR DESCRIPTION
## Summary

- Add a responsive `Ready · Unassigned projects` section above the six-week Projects timeline.
- List only Ready projects whose Linear `lead` field is empty.
- Keep the dated timeline focused on developer rows, with the first week beginning immediately after the developer column.
- Add regression coverage for project selection and rendered markup.

## Why

Ready projects without dates were skipped by the date-bar builder, and projects without a recognized engineering participant were filtered out even earlier. Putting them in a fixed column inside every timeline row introduced unused space for assigned developers and constrained long project names.

The separate section follows Linear's actual project assignment signal—the `lead` field—so a led project such as Universal Giving Exports is not mislabeled as unassigned.

## Impact

Unscheduled Ready work with no project lead is visible without inventing dates or consuming horizontal timeline space. The project cards wrap across the available page width, while dated project bars begin in the first week column.

[Add Tap Feed to Shortcuts in Crossroads Anywhere](https://linear.app/differential/project/add-tap-feed-to-shortcuts-in-crossroads-anywhere-07f94572c638/overview) appears in the new section; Universal Giving Exports does not.

## Validation

- `.venv-ci/bin/python -m unittest discover -s tests -p 'test_*.py'` — 113 tests passed
- `.venv-ci/bin/ruff check .`
- `.venv-ci/bin/ruff format --check .`
- `.venv-ci/bin/python -m mypy .`
- `git diff --check`
- Exact-head [Heroku review app](https://bug-board-agent-show-un-vkiiug.herokuapp.com/projects) rendered three unassigned Ready projects in the separate section, rendered the week headers directly after `Developer`, did not render Universal Giving Exports, and returned a healthy `/healthz`
