### PR TITLE
Add Rippling OOO to project timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ python -m unittest discover -s tests -p 'test_*.py'
 - `BIGQUERY_SERVICE_ACCOUNT_JSON_BASE64` – Base64-encoded Google service account JSON for BigQuery access
 - `APP_VERSIONS_LOOKBACK_DAYS` – Optional lookback window for `/apps` (default: `30`)
 - `APP_VERSIONS_LIMIT` – Optional maximum app rows rendered by `/apps` (default: `1000`)
+- `RIPPLING_PTO_CALENDAR_URL` – Optional private Rippling direct-reports calendar subscription URL used to add OOO bars to the project timeline; treat this value as a secret
+- `RIPPLING_PTO_TIMEZONE` – Optional IANA time zone used to place timed PTO entries on calendar days (default: `America/New_York`)
 
 These can be placed in a `.env` file or exported in your shell.
 

--- a/app.py
+++ b/app.py
@@ -45,6 +45,7 @@ from project_dates import (
     format_project_target_status,
     parse_iso_date,
 )
+from rippling_pto import get_rippling_pto_calendar
 from support import get_support_slugs
 
 
@@ -1141,7 +1142,32 @@ def _build_team_context(_cache_epoch: int) -> dict:
         [{"slug": slug, "name": format_name(slug)} for slug in engineering_team_slugs],
         key=lambda developer: developer["name"],
     )
+
+    def engineering_slug_for_ooo_summary(summary: str) -> str | None:
+        normalized_summary = normalize(summary)
+        full_name_matches = [
+            developer["slug"]
+            for developer in timeline_developers
+            if normalized_summary == developer["name"]
+            or normalized_summary.startswith(f"{developer['name']} ")
+        ]
+        if len(full_name_matches) == 1:
+            return full_name_matches[0]
+
+        summary_parts = normalized_summary.split()
+        if not summary_parts:
+            return None
+        first_name_matches = [
+            developer["slug"]
+            for developer in timeline_developers
+            if developer["name"].split()[0] == summary_parts[0]
+        ]
+        return first_name_matches[0] if len(first_name_matches) == 1 else None
+
     projects_by_developer: dict[str, list[dict[str, Any]]] = {
+        developer["slug"]: [] for developer in timeline_developers
+    }
+    ooo_by_developer: dict[str, list[dict[str, Any]]] = {
         developer["slug"]: [] for developer in timeline_developers
     }
     for project in timeline_projects:
@@ -1180,8 +1206,36 @@ def _build_team_context(_cache_epoch: int) -> dict:
         for slug in assigned_slugs:
             projects_by_developer[slug].append(dict(bar))
 
+    pto_calendar = get_rippling_pto_calendar()
+    for event in pto_calendar.events:
+        slug = engineering_slug_for_ooo_summary(event.summary)
+        if slug is None:
+            continue
+        if event.end < timeline_start or event.start >= timeline_end:
+            continue
+
+        visible_start = max(event.start, timeline_start)
+        visible_end = min(event.end, timeline_end - timedelta(days=1))
+        if event.start == event.end:
+            date_range = f"{event.start:%b} {event.start.day}"
+        else:
+            date_range = f"{event.start:%b} {event.start.day} – {event.end:%b} {event.end.day}"
+        title_prefix = "OOO" if event.is_all_day else "Partial-day OOO"
+        ooo_by_developer[slug].append(
+            {
+                "start_day": (visible_start - timeline_start).days + 1,
+                "span_days": (visible_end - visible_start).days + 1,
+                "title": f"{title_prefix} · {date_range}",
+                "is_partial_day": not event.is_all_day,
+                "_start": visible_start,
+                "_end": visible_end,
+            }
+        )
+
     for developer in timeline_developers:
-        bars = projects_by_developer[developer["slug"]]
+        project_bars = projects_by_developer[developer["slug"]]
+        ooo_bars = ooo_by_developer[developer["slug"]]
+        bars = project_bars + ooo_bars
         lane_ends: list[Any] = []
         for bar in sorted(bars, key=lambda item: (item["_start"], item["_end"])):
             lane = next(
@@ -1193,7 +1247,8 @@ def _build_team_context(_cache_epoch: int) -> dict:
             else:
                 lane_ends[lane] = bar["_end"]
             bar["lane"] = lane + 1
-        developer["projects"] = bars
+        developer["projects"] = project_bars
+        developer["ooo_events"] = ooo_bars
         developer["lane_count"] = max(len(lane_ends), 1)
 
     timeline_weeks = []
@@ -1211,6 +1266,8 @@ def _build_team_context(_cache_epoch: int) -> dict:
             "unassigned_ready_projects": unassigned_ready_projects,
             "date_range": f"{timeline_weeks[0]['start']} – {timeline_weeks[-1]['end']}",
             "today_percent": ((today - timeline_start).days + 0.5) / 42 * 100,
+            "ooo_configured": pto_calendar.configured,
+            "ooo_available": pto_calendar.available,
         },
         "cycle_projects_by_initiative": projects_by_initiative,
         "completed_cycle_projects": completed_projects,

--- a/rippling_pto.py
+++ b/rippling_pto.py
@@ -1,0 +1,269 @@
+import logging
+import os
+import re
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from urllib.parse import urlsplit, urlunsplit
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+RIPPLING_PTO_CALENDAR_ENV_VAR = "RIPPLING_PTO_CALENDAR_URL"
+RIPPLING_PTO_TIMEZONE_ENV_VAR = "RIPPLING_PTO_TIMEZONE"
+DEFAULT_RIPPLING_PTO_TIMEZONE = "America/New_York"
+RIPPLING_PTO_TIMEOUT_SECONDS = 10
+MAX_RIPPLING_PTO_CALENDAR_BYTES = 1_000_000
+RIPPLING_PTO_HOST = "app.rippling.com"
+RIPPLING_PTO_PATH_PREFIX = "/api/feed/calendar/pto/"
+
+
+@dataclass(frozen=True)
+class PTOEvent:
+    summary: str
+    start: date
+    end: date
+    is_all_day: bool
+
+
+@dataclass(frozen=True)
+class PTOCalendar:
+    configured: bool
+    available: bool
+    events: tuple[PTOEvent, ...] = ()
+
+
+def _https_calendar_url(value: str) -> str:
+    parsed = urlsplit(value)
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("invalid calendar URL port") from exc
+
+    if (
+        parsed.scheme.lower() not in {"https", "webcal"}
+        or parsed.hostname != RIPPLING_PTO_HOST
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+        or not parsed.path.startswith(RIPPLING_PTO_PATH_PREFIX)
+        or parsed.fragment
+    ):
+        raise ValueError("invalid Rippling PTO calendar URL")
+
+    return urlunsplit(("https", RIPPLING_PTO_HOST, parsed.path, parsed.query, ""))
+
+
+def _unfold_content_lines(calendar_data: bytes) -> list[str]:
+    text = calendar_data.decode("utf-8-sig")
+    raw_lines = text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    lines: list[str] = []
+    for raw_line in raw_lines:
+        if raw_line.startswith((" ", "\t")):
+            if not lines:
+                raise ValueError("invalid folded iCalendar line")
+            lines[-1] += raw_line[1:]
+        else:
+            lines.append(raw_line)
+    return lines
+
+
+def _parse_content_line(line: str) -> tuple[str, dict[str, str], str] | None:
+    header, separator, value = line.partition(":")
+    if not separator:
+        return None
+
+    header_parts = header.split(";")
+    name = header_parts[0].upper()
+    parameters: dict[str, str] = {}
+    for raw_parameter in header_parts[1:]:
+        key, equals, parameter_value = raw_parameter.partition("=")
+        if equals:
+            parameters[key.upper()] = parameter_value.strip('"')
+    return name, parameters, value
+
+
+def _unescape_text(value: str) -> str:
+    replacements = {"n": "\n", "N": "\n", ",": ",", ";": ";", "\\": "\\"}
+    return re.sub(r"\\([nN,;\\])", lambda match: replacements[match.group(1)], value)
+
+
+def _parse_calendar_datetime(
+    value: str,
+    parameters: dict[str, str],
+    display_timezone: ZoneInfo,
+) -> tuple[datetime, bool]:
+    value_type = parameters.get("VALUE", "").upper()
+    if value_type == "DATE" or re.fullmatch(r"\d{8}", value):
+        parsed_date = datetime.strptime(value, "%Y%m%d")
+        return parsed_date.replace(tzinfo=display_timezone), True
+
+    if value.endswith("Z"):
+        parsed_datetime = datetime.strptime(value, "%Y%m%dT%H%M%SZ")
+        return parsed_datetime.replace(tzinfo=timezone.utc), False
+
+    parsed_datetime = datetime.strptime(value, "%Y%m%dT%H%M%S")
+    timezone_name = parameters.get("TZID")
+    if timezone_name:
+        try:
+            event_timezone = ZoneInfo(timezone_name)
+        except ZoneInfoNotFoundError as exc:
+            raise ValueError("unknown iCalendar time zone") from exc
+    else:
+        event_timezone = display_timezone
+    return parsed_datetime.replace(tzinfo=event_timezone), False
+
+
+def _event_from_properties(
+    properties: dict[str, tuple[dict[str, str], str]],
+    display_timezone: ZoneInfo,
+) -> PTOEvent | None:
+    status_property = properties.get("STATUS")
+    if status_property and status_property[1].strip().upper() == "CANCELLED":
+        return None
+
+    uid_property = properties.get("UID")
+    summary_property = properties.get("SUMMARY")
+    start_property = properties.get("DTSTART")
+    if (
+        not uid_property
+        or not uid_property[1].strip()
+        or not summary_property
+        or not start_property
+    ):
+        raise ValueError("iCalendar event is missing a required property")
+
+    summary = _unescape_text(summary_property[1]).strip()
+    if not summary:
+        raise ValueError("iCalendar event has an empty summary")
+
+    start_datetime, start_is_all_day = _parse_calendar_datetime(
+        start_property[1],
+        start_property[0],
+        display_timezone,
+    )
+    end_property = properties.get("DTEND")
+    if end_property:
+        end_datetime, end_is_all_day = _parse_calendar_datetime(
+            end_property[1],
+            end_property[0],
+            display_timezone,
+        )
+        if start_is_all_day != end_is_all_day:
+            raise ValueError("iCalendar event start and end types do not match")
+    else:
+        end_datetime = start_datetime
+        end_is_all_day = start_is_all_day
+
+    if end_datetime < start_datetime:
+        raise ValueError("iCalendar event ends before it starts")
+
+    if start_is_all_day:
+        start_date = start_datetime.date()
+        end_date = (
+            (end_datetime - timedelta(days=1)).date()
+            if end_datetime > start_datetime
+            else start_date
+        )
+    else:
+        local_start = start_datetime.astimezone(display_timezone)
+        local_end = end_datetime.astimezone(display_timezone)
+        inclusive_end = (
+            local_end - timedelta(microseconds=1) if local_end > local_start else local_end
+        )
+        start_date = local_start.date()
+        end_date = max(inclusive_end.date(), start_date)
+
+    return PTOEvent(
+        summary=summary,
+        start=start_date,
+        end=end_date,
+        is_all_day=start_is_all_day,
+    )
+
+
+def parse_icalendar(
+    calendar_data: bytes,
+    timezone_name: str = DEFAULT_RIPPLING_PTO_TIMEZONE,
+) -> tuple[PTOEvent, ...]:
+    try:
+        display_timezone = ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError("unknown Rippling PTO display time zone") from exc
+
+    lines = _unfold_content_lines(calendar_data)
+    normalized_lines = {line.strip().upper() for line in lines}
+    if "BEGIN:VCALENDAR" not in normalized_lines or "END:VCALENDAR" not in normalized_lines:
+        raise ValueError("response is not an iCalendar")
+
+    events: list[PTOEvent] = []
+    current_event: dict[str, tuple[dict[str, str], str]] | None = None
+    invalid_event_count = 0
+    captured_properties = {"UID", "SUMMARY", "DTSTART", "DTEND", "STATUS"}
+
+    for line in lines:
+        parsed_line = _parse_content_line(line)
+        if parsed_line is None:
+            continue
+        name, parameters, value = parsed_line
+        normalized_value = value.strip().upper()
+
+        if name == "BEGIN" and normalized_value == "VEVENT":
+            if current_event is not None:
+                raise ValueError("nested iCalendar events are not supported")
+            current_event = {}
+            continue
+
+        if name == "END" and normalized_value == "VEVENT":
+            if current_event is None:
+                continue
+            try:
+                event = _event_from_properties(current_event, display_timezone)
+            except ValueError:
+                invalid_event_count += 1
+            else:
+                if event is not None:
+                    events.append(event)
+            current_event = None
+            continue
+
+        if current_event is not None and name in captured_properties:
+            current_event.setdefault(name, (parameters, value))
+
+    if current_event is not None:
+        raise ValueError("unterminated iCalendar event")
+    if invalid_event_count:
+        logger.warning("Skipped %d invalid Rippling PTO calendar event(s)", invalid_event_count)
+
+    return tuple(events)
+
+
+def get_rippling_pto_calendar() -> PTOCalendar:
+    configured_url = os.getenv(RIPPLING_PTO_CALENDAR_ENV_VAR, "").strip()
+    if not configured_url:
+        return PTOCalendar(configured=False, available=False)
+
+    try:
+        calendar_url = _https_calendar_url(configured_url)
+        response = requests.get(
+            calendar_url,
+            timeout=RIPPLING_PTO_TIMEOUT_SECONDS,
+            allow_redirects=False,
+        )
+        if response.status_code != 200:
+            raise ValueError("Rippling PTO calendar returned an unsuccessful status")
+        if len(response.content) > MAX_RIPPLING_PTO_CALENDAR_BYTES:
+            raise ValueError("Rippling PTO calendar response is too large")
+        timezone_name = (
+            os.getenv(RIPPLING_PTO_TIMEZONE_ENV_VAR, "").strip() or DEFAULT_RIPPLING_PTO_TIMEZONE
+        )
+        events = parse_icalendar(response.content, timezone_name=timezone_name)
+    except (OSError, UnicodeError, ValueError, requests.RequestException) as exc:
+        logger.warning(
+            "Rippling PTO calendar is unavailable (%s)",
+            type(exc).__name__,
+        )
+        return PTOCalendar(configured=True, available=False)
+
+    return PTOCalendar(configured=True, available=True, events=events)

--- a/static/styles.css
+++ b/static/styles.css
@@ -147,3 +147,17 @@ details.dropdown.site-menu > summary + ul {
 .project-timeline-bar--offTrack,
 .project-timeline-bar--overdue { background: #b83a3a; }
 .project-timeline-bar--completed { background: #3f6f57; opacity: 0.85; }
+.project-timeline-bar--ooo {
+  background: repeating-linear-gradient(
+    135deg, #5b4a8f 0, #5b4a8f 0.35rem, #7561b5 0.35rem, #7561b5 0.7rem
+  );
+}
+.project-timeline-bar--ooo-partial { border: 1px dashed #fff; }
+.project-timeline-ooo-note::before {
+  background: repeating-linear-gradient(
+    135deg, #5b4a8f 0, #5b4a8f 0.2rem, #7561b5 0.2rem, #7561b5 0.4rem
+  );
+  border-radius: 0.2rem; content: ""; display: inline-block; height: 0.65rem;
+  margin-right: 0.25rem; vertical-align: -0.04rem; width: 0.9rem;
+}
+.project-timeline-ooo-unavailable { color: #b83a3a; }

--- a/templates/partials/team_content.html
+++ b/templates/partials/team_content.html
@@ -1,7 +1,14 @@
 <h2>Projects</h2>
 <div class="project-timeline-heading">
   <h3>Timeline</h3>
-  <small>Six-week view · {{ project_timeline.date_range }} · Red line is today</small>
+  <small>
+    Six-week view · {{ project_timeline.date_range }} · Red line is today
+    {% if project_timeline.ooo_available %}
+      · <span class="project-timeline-ooo-note">OOO from Rippling · direct reports calendar</span>
+    {% elif project_timeline.ooo_configured %}
+      · <span class="project-timeline-ooo-unavailable">Rippling OOO unavailable</span>
+    {% endif %}
+  </small>
 </div>
 {% if project_timeline.unassigned_ready_projects %}
   <section class="project-ready-section" aria-label="Ready unassigned projects">
@@ -29,11 +36,16 @@
         <a class="project-timeline-developer" href="{{ url_for('team_slug', slug=developer.slug) }}">{{ developer.name|first_name }}</a>
         <div class="project-timeline-track" style="--lanes: {{ developer.lane_count }}; --today: {{ project_timeline.today_percent }}%;">
           <i class="project-timeline-today" aria-hidden="true"></i>
-          {% for project in developer.projects %}
-            <a href="{{ project.url }}" class="project-timeline-bar project-timeline-bar--{{ project.health_class }}" style="--start: {{ project.start_day }}; --span: {{ project.span_days }}; --lane: {{ project.lane }};" title="{{ project.name }}{% if project.startDate or project.targetDate %}: {{ project.startDate or 'Earlier' }} – {{ project.targetDate or 'Ongoing' }}{% endif %}">{{ project.name }}</a>
+          {% if developer.projects or developer.ooo_events %}
+            {% for project in developer.projects %}
+              <a href="{{ project.url }}" class="project-timeline-bar project-timeline-bar--{{ project.health_class }}" style="--start: {{ project.start_day }}; --span: {{ project.span_days }}; --lane: {{ project.lane }};" title="{{ project.name }}{% if project.startDate or project.targetDate %}: {{ project.startDate or 'Earlier' }} – {{ project.targetDate or 'Ongoing' }}{% endif %}">{{ project.name }}</a>
+            {% endfor %}
+            {% for event in developer.ooo_events %}
+              <span class="project-timeline-bar project-timeline-bar--ooo{% if event.is_partial_day %} project-timeline-bar--ooo-partial{% endif %}" style="--start: {{ event.start_day }}; --span: {{ event.span_days }}; --lane: {{ event.lane }};" title="{{ event.title }}" aria-label="{{ event.title }}" role="img">{% if event.span_days > 1 %}OOO{% endif %}</span>
+            {% endfor %}
           {% else %}
             <small class="project-timeline-empty">No dated projects</small>
-          {% endfor %}
+          {% endif %}
         </div>
       </div>
     {% endfor %}

--- a/tests/test_rippling_pto.py
+++ b/tests/test_rippling_pto.py
@@ -1,0 +1,274 @@
+import os
+import unittest
+from datetime import date, datetime, timezone
+from unittest.mock import Mock, patch
+
+import app as app_module
+import rippling_pto
+from rippling_pto import PTOCalendar, PTOEvent
+
+CALENDAR_WITH_ALL_DAY_AND_TIMED_EVENTS = b"""BEGIN:VCALENDAR\r
+VERSION:2.0\r
+BEGIN:VEVENT\r
+UID:all-day-1\r
+SUMMARY:Bra\r
+ ndon paid time off\r
+DESCRIPTION:Synthetic private detail\r
+DTSTART;VALUE=DATE:20260727\r
+DTEND;VALUE=DATE:20260730\r
+END:VEVENT\r
+BEGIN:VEVENT\r
+UID:timed-1\r
+SUMMARY:Dylan partial time off\r
+DTSTART;TZID=UTC;VALUE=DATE-TIME:20260731T010000Z\r
+DTEND;TZID=UTC;VALUE=DATE-TIME:20260731T030000Z\r
+END:VEVENT\r
+BEGIN:VEVENT\r
+UID:cancelled-1\r
+SUMMARY:Brandon cancelled time off\r
+DTSTART;VALUE=DATE:20260803\r
+DTEND;VALUE=DATE:20260804\r
+STATUS:CANCELLED\r
+END:VEVENT\r
+END:VCALENDAR\r
+"""
+
+
+class RipplingPTOCalendarParsingTest(unittest.TestCase):
+    def test_parses_all_day_and_timed_events_without_descriptions(self):
+        events = rippling_pto.parse_icalendar(CALENDAR_WITH_ALL_DAY_AND_TIMED_EVENTS)
+
+        self.assertEqual(
+            events,
+            (
+                PTOEvent(
+                    summary="Brandon paid time off",
+                    start=date(2026, 7, 27),
+                    end=date(2026, 7, 29),
+                    is_all_day=True,
+                ),
+                PTOEvent(
+                    summary="Dylan partial time off",
+                    start=date(2026, 7, 30),
+                    end=date(2026, 7, 30),
+                    is_all_day=False,
+                ),
+            ),
+        )
+
+    def test_rejects_non_calendar_responses(self):
+        with self.assertRaisesRegex(ValueError, "not an iCalendar"):
+            rippling_pto.parse_icalendar(b"<html>Sign in</html>")
+
+
+class RipplingPTOCalendarFetchTest(unittest.TestCase):
+    def test_missing_configuration_does_not_make_a_request(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(rippling_pto.requests, "get") as get_mock:
+                calendar = rippling_pto.get_rippling_pto_calendar()
+
+        self.assertEqual(calendar, PTOCalendar(configured=False, available=False))
+        get_mock.assert_not_called()
+
+    def test_fetches_webcal_subscription_over_https(self):
+        calendar_url = (
+            "webcal://app.rippling.com/api/feed/calendar/pto/all-reports/"
+            "calendar-id/private-token/calendar.ics?company=company-id"
+        )
+        response = Mock(status_code=200, content=CALENDAR_WITH_ALL_DAY_AND_TIMED_EVENTS)
+
+        with patch.dict(
+            os.environ,
+            {"RIPPLING_PTO_CALENDAR_URL": calendar_url},
+            clear=True,
+        ):
+            with patch.object(rippling_pto.requests, "get", return_value=response) as get_mock:
+                calendar = rippling_pto.get_rippling_pto_calendar()
+
+        self.assertTrue(calendar.configured)
+        self.assertTrue(calendar.available)
+        self.assertEqual(len(calendar.events), 2)
+        get_mock.assert_called_once_with(
+            (
+                "https://app.rippling.com/api/feed/calendar/pto/all-reports/"
+                "calendar-id/private-token/calendar.ics?company=company-id"
+            ),
+            timeout=rippling_pto.RIPPLING_PTO_TIMEOUT_SECONDS,
+            allow_redirects=False,
+        )
+
+    def test_rejects_non_rippling_calendar_urls(self):
+        with patch.dict(
+            os.environ,
+            {"RIPPLING_PTO_CALENDAR_URL": "https://example.com/private/calendar.ics"},
+            clear=True,
+        ):
+            with patch.object(rippling_pto.requests, "get") as get_mock:
+                with self.assertLogs("rippling_pto", level="WARNING"):
+                    calendar = rippling_pto.get_rippling_pto_calendar()
+
+        self.assertEqual(calendar, PTOCalendar(configured=True, available=False))
+        get_mock.assert_not_called()
+
+    def test_failure_log_does_not_expose_calendar_credentials(self):
+        calendar_url = (
+            "webcal://app.rippling.com/api/feed/calendar/pto/all-reports/"
+            "calendar-id/private-token/calendar.ics?company=private-company"
+        )
+        response = Mock(status_code=500, content=b"")
+
+        with patch.dict(
+            os.environ,
+            {"RIPPLING_PTO_CALENDAR_URL": calendar_url},
+            clear=True,
+        ):
+            with patch.object(rippling_pto.requests, "get", return_value=response):
+                with self.assertLogs("rippling_pto", level="WARNING") as logs:
+                    calendar = rippling_pto.get_rippling_pto_calendar()
+
+        self.assertEqual(calendar, PTOCalendar(configured=True, available=False))
+        combined_logs = "\n".join(logs.output)
+        self.assertNotIn("private-token", combined_logs)
+        self.assertNotIn("private-company", combined_logs)
+
+
+class ProjectTimelineOOOTest(unittest.TestCase):
+    def setUp(self):
+        app_module._build_team_context.cache_clear()
+
+    def tearDown(self):
+        app_module._build_team_context.cache_clear()
+
+    def test_ooo_shares_timeline_lanes_without_exposing_source_summary(self):
+        config = {
+            "people": {
+                "brandon": {
+                    "team": "engineering",
+                    "linear_username": "brandon",
+                }
+            },
+            "platforms": {},
+        }
+        active_project = {
+            "id": "project-1",
+            "name": "Project Alpha",
+            "url": "https://linear.example/project/alpha",
+            "health": "onTrack",
+            "status": {"name": "Active"},
+            "completedAt": None,
+            "startDate": "2026-07-20",
+            "targetDate": "2026-08-01",
+            "lead": {"displayName": "Brandon"},
+            "initiatives": {"nodes": [{"id": "initiative-1", "name": "Cycle"}]},
+            "members": [],
+        }
+        calendar = PTOCalendar(
+            configured=True,
+            available=True,
+            events=(
+                PTOEvent(
+                    summary="Brandon confidential source summary",
+                    start=date(2026, 7, 27),
+                    end=date(2026, 7, 29),
+                    is_all_day=True,
+                ),
+                PTOEvent(
+                    summary="Someone Else time off",
+                    start=date(2026, 7, 27),
+                    end=date(2026, 7, 27),
+                    is_all_day=True,
+                ),
+            ),
+        )
+
+        class FixedDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return datetime(2026, 7, 24, 12, 0, tzinfo=timezone.utc)
+
+        with (
+            patch.object(app_module, "datetime", FixedDateTime),
+            patch.object(app_module, "load_config", return_value=config),
+            patch.object(app_module, "get_projects", return_value=[active_project]),
+            patch.object(app_module, "get_rippling_pto_calendar", return_value=calendar),
+        ):
+            context = app_module._build_team_context(1)
+
+        timeline = context["project_timeline"]
+        developer = timeline["rows"][0]
+        self.assertTrue(timeline["ooo_available"])
+        self.assertEqual(developer["lane_count"], 2)
+        self.assertEqual(len(developer["ooo_events"]), 1)
+        self.assertEqual(
+            (
+                developer["ooo_events"][0]["start_day"],
+                developer["ooo_events"][0]["span_days"],
+                developer["ooo_events"][0]["lane"],
+            ),
+            (8, 3, 2),
+        )
+        self.assertNotIn(
+            "confidential source summary",
+            repr(developer["ooo_events"]),
+        )
+        with app_module.app.test_request_context():
+            rendered = app_module.render_template("partials/team_content.html", **context)
+        self.assertIn("OOO from Rippling", rendered)
+        self.assertIn("project-timeline-bar--ooo", rendered)
+        self.assertNotIn("confidential source summary", rendered)
+
+    def test_duplicate_first_names_require_a_full_name_match(self):
+        config = {
+            "people": {
+                "john_alpha": {
+                    "team": "engineering",
+                    "linear_username": "john.alpha",
+                },
+                "john_beta": {
+                    "team": "engineering",
+                    "linear_username": "john.beta",
+                },
+            },
+            "platforms": {},
+        }
+        calendar = PTOCalendar(
+            configured=True,
+            available=True,
+            events=(
+                PTOEvent(
+                    summary="John time off",
+                    start=date(2026, 7, 27),
+                    end=date(2026, 7, 27),
+                    is_all_day=True,
+                ),
+                PTOEvent(
+                    summary="John Alpha time off",
+                    start=date(2026, 7, 28),
+                    end=date(2026, 7, 28),
+                    is_all_day=True,
+                ),
+            ),
+        )
+
+        class FixedDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return datetime(2026, 7, 24, 12, 0, tzinfo=timezone.utc)
+
+        with (
+            patch.object(app_module, "datetime", FixedDateTime),
+            patch.object(app_module, "load_config", return_value=config),
+            patch.object(app_module, "get_projects", return_value=[]),
+            patch.object(app_module, "get_rippling_pto_calendar", return_value=calendar),
+        ):
+            context = app_module._build_team_context(2)
+
+        rows_by_slug = {
+            developer["slug"]: developer for developer in context["project_timeline"]["rows"]
+        }
+        self.assertEqual(len(rows_by_slug["john_alpha"]["ooo_events"]), 1)
+        self.assertEqual(rows_by_slug["john_beta"]["ooo_events"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Added a read-only Rippling iCalendar client for the private direct-reports PTO feed.
- Added striped OOO bars to the six-week project timeline, sharing lanes with overlapping projects.
- Supports full-day and timed/partial-day events, including iCalendar's exclusive `DTEND` semantics.
- Shows direct-report calendar coverage and a non-blocking unavailable state.
- Documented the required secret URL and optional display-time-zone configuration.

## Why

The project timeline needs OOO visibility, but Rippling developer API access is not available. The existing direct-reports calendar subscription provides the dates needed for this view without requiring API credentials.

## Security and privacy

- The subscription URL is environment-only and is never committed or logged.
- Requests are restricted to Rippling's HTTPS PTO calendar path, do not follow redirects, use a timeout, and cap response size.
- Calendar descriptions and leave details are ignored; the UI renders only a fixed `OOO` label and dates.
- Ambiguous first-name matches are skipped to avoid assigning one person's PTO to another row.
- The feed does not expose approval state, so published calendar events are treated as authoritative.

## Deployment

Set `RIPPLING_PTO_CALENDAR_URL` to the private Rippling calendar subscription URL. Optionally set `RIPPLING_PTO_TIMEZONE` (default: `America/New_York`) for timed entries.

## Validation

- `ruff check .`
- `ruff format --check .`
- `mypy .`
- `python -m unittest discover -s tests -p 'test_*.py'` (121 tests)
- `vulture . --config pyproject.toml`
- Headed browser render with synthetic full-day and partial-day PTO, including overlap with a project bar