### PR TITLE
Filter person PR links by date

### DIFF
--- a/app.py
+++ b/app.py
@@ -59,6 +59,15 @@ def format_display_name(linear_username: str) -> str:
     return re.sub(r"[._-]+", " ", linear_username).title()
 
 
+def github_merged_prs_url(username: str, days: int) -> str:
+    cutoff_date = (datetime.now(timezone.utc) - timedelta(days=days)).date().isoformat()
+    query = (
+        f"is:closed is:pr author:{username} archived:false "
+        f"merged:>={cutoff_date}"
+    )
+    return f"https://github.com/pulls?q={quote(query, safe='')}"
+
+
 INACTIVE_PROJECT_STATUS_NAMES = {
     "completed",
     "incomplete",
@@ -1423,6 +1432,9 @@ def _build_person_context(slug: str, days: int, _cache_epoch: int) -> dict:
         "person_name": person_name,
         "linear_username": login,
         "github_username": github_username,
+        "github_merged_prs_url": (
+            github_merged_prs_url(github_username, days) if github_username else None
+        ),
         "days": days,
         "open_current_cycle": open_current_cycle,
         "open_other": open_other,

--- a/app.py
+++ b/app.py
@@ -61,10 +61,7 @@ def format_display_name(linear_username: str) -> str:
 
 def github_merged_prs_url(username: str, days: int) -> str:
     cutoff_date = (datetime.now(timezone.utc) - timedelta(days=days)).date().isoformat()
-    query = (
-        f"is:closed is:pr author:{username} archived:false "
-        f"merged:>={cutoff_date}"
-    )
+    query = f"is:closed is:pr author:{username} archived:false merged:>={cutoff_date}"
     return f"https://github.com/pulls?q={quote(query, safe='')}"
 
 

--- a/templates/partials/person_content.html
+++ b/templates/partials/person_content.html
@@ -44,8 +44,8 @@
   <div>
     <article>
       <header>
-        {% if github_username %}
-        <a href="https://github.com/pulls?q=is%3Aclosed+is%3Apr+author%3A{{ github_username | urlencode }}+archived%3Afalse">PRs Merged</a>
+        {% if github_merged_prs_url %}
+        <a href="{{ github_merged_prs_url }}">PRs Merged</a>
         {% else %}
         PRs Merged
         {% endif %}

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -89,9 +89,7 @@ class NavigationTest(unittest.TestCase):
             context = app_module._build_person_context("brandon", 30, 1)
 
         self.assertEqual((context["prs_merged"], context["prs_reviewed"]), (60, 53))
-        merged_pr_query = parse_qs(
-            urlparse(context["github_merged_prs_url"]).query
-        )["q"][0]
+        merged_pr_query = parse_qs(urlparse(context["github_merged_prs_url"]).query)["q"][0]
         self.assertIn("author:bkraeling", merged_pr_query)
         self.assertIn("merged:>=2026-07-01", merged_pr_query)
         with app_module.app.test_request_context():

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,7 +1,15 @@
 import unittest
+from datetime import datetime
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 import app as app_module
+
+
+class FixedDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2026, 7, 31, 12, tzinfo=tz)
 
 
 class NavigationTest(unittest.TestCase):
@@ -68,6 +76,7 @@ class NavigationTest(unittest.TestCase):
         self.addCleanup(app_module._build_person_context.cache_clear)
 
         with (
+            patch.object(app_module, "datetime", FixedDateTime),
             patch.object(app_module, "load_config", return_value=config),
             patch.object(app_module, "get_open_issues_for_person", return_value=[]),
             patch.object(app_module, "get_completed_issues_for_person", return_value=[]),
@@ -80,6 +89,14 @@ class NavigationTest(unittest.TestCase):
             context = app_module._build_person_context("brandon", 30, 1)
 
         self.assertEqual((context["prs_merged"], context["prs_reviewed"]), (60, 53))
+        merged_pr_query = parse_qs(
+            urlparse(context["github_merged_prs_url"]).query
+        )["q"][0]
+        self.assertIn("author:bkraeling", merged_pr_query)
+        self.assertIn("merged:>=2026-07-01", merged_pr_query)
+        with app_module.app.test_request_context():
+            body = app_module.render_template("partials/person_content.html", **context)
+        self.assertIn("merged%3A%3E%3D2026-07-01", body)
         fetch.assert_called_once_with()
         counts.assert_called_once_with("bkraeling", 30)
         support.assert_called_once_with(config=config, projects=projects)


### PR DESCRIPTION
## Summary

- build the person-page GitHub PR URL on the server
- include the selected page range as a `merged:>=YYYY-MM-DD` GitHub search qualifier
- cover both the generated query and rendered link with a regression test

## Why

The PRs Merged count uses the selected 1, 7, or 30-day range, but its link previously opened an unbounded GitHub search. This made the linked results inconsistent with the number shown on the page.

## Impact

Clicking PRs Merged now opens results constrained to the same UTC cutoff date as the selected person-page range.

## Validation

- `python -m unittest discover -s tests -p 'test_*.py'` (121 tests)
- `ruff check .`
- `mypy .`