### PR TITLE
Speed up homepage leaderboard load

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ python -m unittest discover -s tests -p 'test_*.py'
 - `AIRFLOW_API_BASE_URL` – Base URL for Airflow REST API (for example: `https://airflow.example.com`)
 - `AIRFLOW_API_TOKEN` – Bearer token for Airflow API
 - `AIRFLOW_FLEET_HEARTBEAT_URL` – Optional Better Stack heartbeat URL for worker-reported Airflow fleet health
-- `REDIS_URL` – Optional Redis connection string for cached Airflow fleet-health responses
+- `REDIS_URL` – Optional Redis connection string for cached Airflow fleet-health and leaderboard responses
 - `REDIS_SSL_CERT_REQS` – Optional TLS cert verification mode for `rediss://` (`none`, `optional`, `required`; default for `rediss://` is `none` unless `REDIS_URL` already sets `ssl_cert_reqs`)
 - `AIRFLOW_FLEET_HEALTH_REFRESH_SECONDS` – Optional worker refresh interval for cached fleet health (default: `60`)
 - `AIRFLOW_FLEET_HEALTH_MAX_STALE_SECONDS` – Optional max age accepted by the web endpoint when reading cached data (default: `180`)
 - `AIRFLOW_FLEET_HEALTH_REDIS_TTL_SECONDS` – Optional Redis TTL for cached fleet health record (default: `900`)
+- `LEADERBOARD_REFRESH_SECONDS` – Optional worker refresh interval for the cached homepage leaderboard (default: `60`)
+- `LEADERBOARD_MAX_STALE_SECONDS` – Optional max age accepted when serving a cached leaderboard (default: `600`)
+- `LEADERBOARD_REDIS_TTL_SECONDS` – Optional Redis TTL for the cached leaderboard (default: `900`)
 - `BIGQUERY_ANALYTICS_PROJECT_ID` – Optional Google Cloud project that contains the Segment BigQuery export (default: `apollos-project`)
 - `BIGQUERY_ANALYTICS_DATASETS` – Optional comma-separated BigQuery datasets containing Segment export tables (default: `apollos,apollos_tv,apollos_roku`)
 - `BIGQUERY_ANALYTICS_TABLES` – Optional comma-separated Segment tables to inspect for app runtime versions (default: `identifies,screens,app_became_active,app_became_backgrounded,app_became_inactive`)

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
 from datetime import datetime, timedelta, timezone
@@ -21,13 +22,10 @@ from fleet_health_cache import (
 )
 from github import (
     get_merged_pr_counts_for_user,
-    merged_prs_by_author,
-    merged_prs_by_reviewer,
+    merged_prs_for_leaderboard,
 )
-from leaderboard import (
-    calculate_cycle_project_lead_points,
-    calculate_cycle_project_member_points,
-)
+from leaderboard import calculate_cycle_project_points
+from leaderboard_cache import get_cached_leaderboard, store_cached_leaderboard
 from linear.issues import (
     by_platform,
     by_project,
@@ -419,6 +417,8 @@ INDEX_THREADPOOL_MAX_WORKERS = 12
 TEAM_THREADPOOL_MAX_WORKERS = 4
 # Cache time-to-live in seconds for the index page
 INDEX_CACHE_TTL_SECONDS = 60
+LEADERBOARD_CACHE_TTL_SECONDS = 60
+LEADERBOARD_MAX_STALE_SECONDS = 600
 
 
 class BreakdownCategory(TypedDict):
@@ -500,7 +500,9 @@ ResultType = TypeVar("ResultType")
 
 
 def get_future_result_with_timeout(
-    future: Future[ResultType], default_value: ResultType, timeout: int = INDEX_FUTURE_TIMEOUT
+    future: Future[ResultType],
+    default_value: ResultType,
+    timeout: float = INDEX_FUTURE_TIMEOUT,
 ) -> ResultType:
     """
     Get result from a future with a timeout, returning a default value on timeout.
@@ -526,6 +528,8 @@ def _build_leaderboard_entries(
     completed_technical_changes: list,
     merged_reviews: dict,
     merged_authored_prs: dict,
+    cycle_lead_points: dict[str, int] | None = None,
+    cycle_member_points: dict[str, int] | None = None,
 ) -> list[LeaderboardEntry]:
     config_data = load_config()
     people_config = config_data.get("people", {})
@@ -677,7 +681,13 @@ def _build_leaderboard_entries(
                 pr_points,
             )
 
-    cycle_lead_points = calculate_cycle_project_lead_points(days)
+    if cycle_lead_points is None or cycle_member_points is None:
+        computed_lead_points, computed_member_points = calculate_cycle_project_points(days)
+        if cycle_lead_points is None:
+            cycle_lead_points = computed_lead_points
+        if cycle_member_points is None:
+            cycle_member_points = computed_member_points
+
     for lead_name, points in cycle_lead_points.items():
         slug = resolve_slug(lead_name, format_display_name(lead_name))
         if slug:
@@ -706,7 +716,6 @@ def _build_leaderboard_entries(
                 points,
             )
 
-    cycle_member_points = calculate_cycle_project_member_points(days)
     for member_name, points in cycle_member_points.items():
         slug = resolve_slug(member_name, format_display_name(member_name))
         if slug:
@@ -872,9 +881,28 @@ def _build_open_items_context(days: int, _cache_epoch: int) -> dict:
     }
 
 
-@lru_cache(maxsize=INDEX_CONTEXT_CACHE_MAXSIZE)
-def _build_leaderboard_context(days: int, _cache_epoch: int) -> dict:
-    with ThreadPoolExecutor(max_workers=INDEX_THREADPOOL_MAX_WORKERS) as executor:
+LEADERBOARD_GITHUB_WAIT_SECONDS = 2
+
+
+def compute_leaderboard_context(days: int, wait_for_github: bool = False) -> dict:
+    deadline = time.monotonic() + INDEX_FUTURE_TIMEOUT
+
+    def take_future(
+        future: Future[ResultType],
+        default_value: ResultType,
+        timeout: float | None = None,
+    ) -> ResultType:
+        remaining = deadline - time.monotonic() if timeout is None else timeout
+        remaining = max(0.0, remaining)
+        try:
+            return future.result(timeout=remaining)
+        except Exception:
+            logging.exception("Leaderboard source failed; continuing with partial data")
+            return default_value
+
+    executor = ThreadPoolExecutor(max_workers=INDEX_THREADPOOL_MAX_WORKERS)
+    github_complete = False
+    try:
         completed_bugs_future = executor.submit(get_completed_issues_summary, 5, "Bug", days)
         completed_feature_requests_future = executor.submit(
             get_completed_issues_summary, 5, "Feature Request", days
@@ -882,26 +910,34 @@ def _build_leaderboard_context(days: int, _cache_epoch: int) -> dict:
         completed_technical_changes_future = executor.submit(
             get_completed_issues_summary, 5, "Technical Change", days
         )
-        reviews_future = executor.submit(merged_prs_by_reviewer, days)
-        authored_prs_future = executor.submit(merged_prs_by_author, days)
+        github_future = executor.submit(merged_prs_for_leaderboard, days)
+        cycle_points_future = executor.submit(calculate_cycle_project_points, days)
 
-    completed_bugs_result = get_future_result_with_timeout(completed_bugs_future, [])
-    completed_bugs = [issue for issue in completed_bugs_result if not issue.get("project")]
-    completed_feature_requests_result = get_future_result_with_timeout(
-        completed_feature_requests_future, []
-    )
-    completed_feature_requests = [
-        issue for issue in completed_feature_requests_result if not issue.get("project")
-    ]
-    completed_technical_changes_result = get_future_result_with_timeout(
-        completed_technical_changes_future, []
-    )
-    completed_technical_changes = [
-        issue for issue in completed_technical_changes_result if not issue.get("project")
-    ]
+        completed_bugs_result = take_future(completed_bugs_future, [])
+        completed_bugs = [issue for issue in completed_bugs_result if not issue.get("project")]
+        completed_feature_requests_result = take_future(completed_feature_requests_future, [])
+        completed_feature_requests = [
+            issue for issue in completed_feature_requests_result if not issue.get("project")
+        ]
+        completed_technical_changes_result = take_future(completed_technical_changes_future, [])
+        completed_technical_changes = [
+            issue for issue in completed_technical_changes_result if not issue.get("project")
+        ]
+        cycle_lead_points, cycle_member_points = take_future(cycle_points_future, ({}, {}))
 
-    merged_reviews = get_future_result_with_timeout(reviews_future, {})
-    merged_authored_prs = get_future_result_with_timeout(authored_prs_future, {})
+        remaining = max(0.0, deadline - time.monotonic())
+        github_wait = 30.0 if wait_for_github else min(LEADERBOARD_GITHUB_WAIT_SECONDS, remaining)
+        try:
+            merged_authored_prs, merged_reviews = github_future.result(timeout=github_wait)
+            github_complete = True
+        except TimeoutError:
+            logging.warning("Leaderboard GitHub scores not ready yet; showing Linear scores first")
+            merged_authored_prs, merged_reviews = {}, {}
+        except Exception:
+            logging.exception("Leaderboard GitHub source failed; continuing without PR scores")
+            merged_authored_prs, merged_reviews = {}, {}
+    finally:
+        executor.shutdown(wait=False, cancel_futures=False)
 
     leaderboard_entries = _build_leaderboard_entries(
         days=days,
@@ -910,12 +946,161 @@ def _build_leaderboard_context(days: int, _cache_epoch: int) -> dict:
         completed_technical_changes=completed_technical_changes,
         merged_reviews=merged_reviews,
         merged_authored_prs=merged_authored_prs,
+        cycle_lead_points=cycle_lead_points,
+        cycle_member_points=cycle_member_points,
     )
 
     return {
         "days": days,
         "leaderboard_entries": leaderboard_entries,
+        "complete": github_complete,
     }
+
+
+_leaderboard_state_lock = threading.Lock()
+_leaderboard_memory_cache: dict[int, tuple[float, dict]] = {}
+_leaderboard_inflight: dict[int, Future[dict]] = {}
+_leaderboard_refresh_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="leaderboard")
+
+
+def _empty_leaderboard_context(days: int) -> dict:
+    return {"days": days, "leaderboard_entries": []}
+
+
+def _public_leaderboard_context(context: dict, days: int) -> dict:
+    return {
+        "days": days,
+        "leaderboard_entries": context.get("leaderboard_entries") or [],
+    }
+
+
+def _store_leaderboard_memory_cache(
+    days: int, context: dict, cached_at: float | None = None
+) -> None:
+    public_context = _public_leaderboard_context(context, days)
+    with _leaderboard_state_lock:
+        _leaderboard_memory_cache[days] = (
+            time.time() if cached_at is None else cached_at,
+            public_context,
+        )
+
+
+def _read_leaderboard_memory_cache(days: int) -> tuple[dict | None, bool]:
+    now = time.time()
+    with _leaderboard_state_lock:
+        cached = _leaderboard_memory_cache.get(days)
+    if not cached:
+        return None, False
+    cached_at, context = cached
+    age = now - cached_at
+    if age <= LEADERBOARD_CACHE_TTL_SECONDS:
+        return context, True
+    if age <= LEADERBOARD_MAX_STALE_SECONDS:
+        return context, False
+    return None, False
+
+
+def _read_leaderboard_redis_cache(days: int) -> tuple[dict | None, bool]:
+    cached = get_cached_leaderboard(days)
+    if cached is None:
+        return None, False
+    cached_at = float(cached.get("cached_at_epoch") or 0)
+    context = _public_leaderboard_context(cached, days)
+    _store_leaderboard_memory_cache(days, context, cached_at=cached_at)
+    age = time.time() - cached_at
+    return context, age <= LEADERBOARD_CACHE_TTL_SECONDS
+
+
+def _compute_and_store_leaderboard_context(days: int, wait_for_github: bool = False) -> dict:
+    try:
+        context = compute_leaderboard_context(days, wait_for_github=wait_for_github)
+    except Exception:
+        logging.exception("Failed to compute leaderboard context for days=%s", days)
+        cached, _fresh = _read_leaderboard_memory_cache(days)
+        return cached or _empty_leaderboard_context(days)
+
+    public_context = _public_leaderboard_context(context, days)
+    complete = bool(context.get("complete", True))
+    cached_at = time.time() if complete else time.time() - LEADERBOARD_CACHE_TTL_SECONDS - 1
+    _store_leaderboard_memory_cache(days, public_context, cached_at=cached_at)
+    if complete:
+        try:
+            store_cached_leaderboard(days, public_context)
+        except Exception:
+            logging.exception("Failed to persist leaderboard cache for days=%s", days)
+    public_context = dict(public_context)
+    public_context["complete"] = complete
+    return public_context
+
+
+def _start_leaderboard_refresh(days: int, wait_for_github: bool = False) -> Future[dict]:
+    with _leaderboard_state_lock:
+        inflight = _leaderboard_inflight.get(days)
+        if inflight is not None and not inflight.done():
+            return inflight
+
+        holder: dict[str, Future[dict]] = {}
+
+        def refresh() -> dict:
+            context = _empty_leaderboard_context(days)
+            try:
+                context = _compute_and_store_leaderboard_context(
+                    days, wait_for_github=wait_for_github
+                )
+                return context
+            finally:
+                with _leaderboard_state_lock:
+                    if _leaderboard_inflight.get(days) is holder.get("future"):
+                        _leaderboard_inflight.pop(days, None)
+                if not context.get("complete") and not wait_for_github:
+                    _start_leaderboard_refresh(days, wait_for_github=True)
+
+        future = _leaderboard_refresh_executor.submit(refresh)
+        holder["future"] = future
+        _leaderboard_inflight[days] = future
+        return future
+
+
+def peek_leaderboard_context(days: int) -> dict | None:
+    """Return a cached leaderboard without starting a live rebuild."""
+    context, _fresh = _read_leaderboard_memory_cache(days)
+    if context is not None:
+        return context
+    context, _fresh = _read_leaderboard_redis_cache(days)
+    return context
+
+
+def prefetch_leaderboard_context(days: int) -> None:
+    context, fresh = _read_leaderboard_memory_cache(days)
+    if context is None:
+        context, fresh = _read_leaderboard_redis_cache(days)
+    if fresh:
+        return
+    _start_leaderboard_refresh(days)
+
+
+def get_leaderboard_context(days: int) -> dict:
+    context, fresh = _read_leaderboard_memory_cache(days)
+    if context is None:
+        context, fresh = _read_leaderboard_redis_cache(days)
+    if fresh and context is not None:
+        return context
+
+    refresh_future = _start_leaderboard_refresh(days)
+    if context is not None:
+        return context
+
+    try:
+        return refresh_future.result(timeout=INDEX_FUTURE_TIMEOUT + 2)
+    except Exception:
+        logging.exception("Timed out waiting for leaderboard context for days=%s", days)
+        return _empty_leaderboard_context(days)
+
+
+def reset_leaderboard_runtime_cache() -> None:
+    with _leaderboard_state_lock:
+        _leaderboard_memory_cache.clear()
+        _leaderboard_inflight.clear()
 
 
 @lru_cache(maxsize=INDEX_CONTEXT_CACHE_MAXSIZE)
@@ -949,7 +1134,18 @@ def _build_resolution_by_priority_context(days: int, _cache_epoch: int) -> dict:
 @app.route("/")
 def index():
     days = request.args.get("days", default=30, type=int)
-    return render_template("index.html", days=days)
+    cached_leaderboard = peek_leaderboard_context(days)
+    prefetch_leaderboard_context(days)
+    leaderboard_html = (
+        render_template("partials/index_leaderboard.html", **cached_leaderboard)
+        if cached_leaderboard is not None
+        else None
+    )
+    return render_template(
+        "index.html",
+        days=days,
+        leaderboard_html=leaderboard_html,
+    )
 
 
 @app.route("/partials/index/priority-stats")
@@ -979,8 +1175,7 @@ def index_open_items_partial():
 @app.route("/partials/index/leaderboard")
 def index_leaderboard_partial():
     days = request.args.get("days", default=30, type=int)
-    cache_epoch = int(time.time() / INDEX_CACHE_TTL_SECONDS)
-    context = _build_leaderboard_context(days, cache_epoch)
+    context = get_leaderboard_context(days)
     return render_template("partials/index_leaderboard.html", **context)
 
 

--- a/github.py
+++ b/github.py
@@ -1,7 +1,8 @@
 import logging
 import os
 import threading
-from concurrent.futures import ThreadPoolExecutor
+import time
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from functools import lru_cache
 from typing import Any, Dict, List
@@ -335,7 +336,20 @@ def prs_by_approver():
     return prs_by_approver
 
 
-def _get_merged_prs(days: int = 30):
+_merged_prs_lock = threading.Lock()
+_merged_prs_cache: dict[int, tuple[float, List[Dict[str, Any]]]] = {}
+_merged_prs_inflight: dict[int, Future[List[Dict[str, Any]]]] = {}
+_merged_prs_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="github-prs")
+MERGED_PRS_CACHE_TTL_SECONDS = 60
+
+
+def _reset_merged_prs_cache() -> None:
+    with _merged_prs_lock:
+        _merged_prs_cache.clear()
+        _merged_prs_inflight.clear()
+
+
+def _fetch_merged_prs(days: int) -> List[Dict[str, Any]]:
     """Return merged PRs within the last ``days`` days using GitHub search."""
     if not token:
         return []
@@ -390,6 +404,30 @@ def _get_merged_prs(days: int = 30):
         pages += 1
         if pages >= max_pages:
             break
+    return prs
+
+
+def _get_merged_prs(days: int = 30) -> List[Dict[str, Any]]:
+    now = time.time()
+    with _merged_prs_lock:
+        cached = _merged_prs_cache.get(days)
+        if cached and now - cached[0] < MERGED_PRS_CACHE_TTL_SECONDS:
+            return cached[1]
+        inflight = _merged_prs_inflight.get(days)
+        if inflight is None:
+            inflight = _merged_prs_executor.submit(_fetch_merged_prs, days)
+            _merged_prs_inflight[days] = inflight
+
+    try:
+        prs = inflight.result()
+    except Exception:
+        logging.exception("Failed to fetch merged GitHub PRs for days=%s", days)
+        prs = []
+    finally:
+        with _merged_prs_lock:
+            if _merged_prs_inflight.get(days) is inflight:
+                _merged_prs_inflight.pop(days, None)
+            _merged_prs_cache[days] = (time.time(), prs)
     return prs
 
 
@@ -464,21 +502,21 @@ def get_merged_pr_counts_for_user(username: str, days: int = 30) -> tuple[int, i
     return authored_count, reviewed_count
 
 
-def merged_prs_by_author(days: int = 30) -> Dict[str, List[Dict[str, Any]]]:
-    """Return merged PRs grouped by author within the given timeframe."""
-    prs = _get_merged_prs(days)
+def _group_merged_prs_by_author(
+    prs: List[Dict[str, Any]],
+) -> Dict[str, List[Dict[str, Any]]]:
     prs_by_author: Dict[str, List[Dict[str, Any]]] = {}
     for pr in prs:
-        author = pr.get("author", {}).get("login")
+        author = (pr.get("author") or {}).get("login")
         if not author:
             continue
         prs_by_author.setdefault(author, []).append(pr)
     return prs_by_author
 
 
-def merged_prs_by_reviewer(days: int = 30) -> Dict[str, List[Dict[str, Any]]]:
-    """Return merged PRs grouped by reviewer within the given timeframe."""
-    prs = _get_merged_prs(days)
+def _group_merged_prs_by_reviewer(
+    prs: List[Dict[str, Any]],
+) -> Dict[str, List[Dict[str, Any]]]:
     prs_by_reviewer: Dict[str, List[Dict[str, Any]]] = {}
     for pr in prs:
         for review in pr.get("reviews", {}).get("nodes", []):
@@ -486,6 +524,24 @@ def merged_prs_by_reviewer(days: int = 30) -> Dict[str, List[Dict[str, Any]]]:
                 reviewer = review["author"]["login"]
                 prs_by_reviewer.setdefault(reviewer, []).append(pr)
     return prs_by_reviewer
+
+
+def merged_prs_for_leaderboard(
+    days: int = 30,
+) -> tuple[Dict[str, List[Dict[str, Any]]], Dict[str, List[Dict[str, Any]]]]:
+    """Return merged PRs grouped by author and reviewer from a single GitHub search."""
+    prs = _get_merged_prs(days)
+    return _group_merged_prs_by_author(prs), _group_merged_prs_by_reviewer(prs)
+
+
+def merged_prs_by_author(days: int = 30) -> Dict[str, List[Dict[str, Any]]]:
+    """Return merged PRs grouped by author within the given timeframe."""
+    return _group_merged_prs_by_author(_get_merged_prs(days))
+
+
+def merged_prs_by_reviewer(days: int = 30) -> Dict[str, List[Dict[str, Any]]]:
+    """Return merged PRs grouped by reviewer within the given timeframe."""
+    return _group_merged_prs_by_reviewer(_get_merged_prs(days))
 
 
 def get_prs_waiting_for_review_by_reviewer():

--- a/jobs.py
+++ b/jobs.py
@@ -17,14 +17,11 @@ from github import (
     GitHubDataError,
     get_pr_diff,
     get_prs_waiting_for_review_by_reviewer,
-    merged_prs_by_author,
-    merged_prs_by_reviewer,
+    merged_prs_for_leaderboard,
 )
 from issue_timing import format_issue_sla_text, parse_linear_dt
-from leaderboard import (
-    calculate_cycle_project_lead_points,
-    calculate_cycle_project_member_points,
-)
+from leaderboard import calculate_cycle_project_points
+from leaderboard_cache import DEFAULT_LEADERBOARD_DAYS, DEFAULT_REFRESH_SECONDS
 from linear.issues import (
     get_completed_issues,
     get_completed_issues_for_person,
@@ -174,6 +171,17 @@ def refresh_airflow_fleet_health_cache_job():
         payload.get("status"),
         status,
         payload.get("evaluated_dags"),
+    )
+
+
+def refresh_leaderboard_cache_job():
+    from leaderboard_cache import refresh_leaderboard_cache
+
+    context = refresh_leaderboard_cache(DEFAULT_LEADERBOARD_DAYS)
+    logging.info(
+        "Refreshed leaderboard cache (days=%s, entries=%s)",
+        DEFAULT_LEADERBOARD_DAYS,
+        len(context.get("leaderboard_entries") or []),
     )
 
 
@@ -550,26 +558,26 @@ def post_leaderboard():
         score = priority_to_score.get(item["priority"], 0)
         leaderboard[slack_markdown] += score
 
-    for reviewer, prs in merged_prs_by_reviewer(days).items():
+    merged_authored_prs, merged_reviews = merged_prs_for_leaderboard(days)
+    for reviewer, prs in merged_reviews.items():
         slack_markdown = get_slack_markdown_by_github_username(reviewer)
         if slack_markdown not in leaderboard:
             leaderboard[slack_markdown] = 0
         leaderboard[slack_markdown] += len(prs)
 
-    for author, prs in merged_prs_by_author(days).items():
+    for author, prs in merged_authored_prs.items():
         slack_markdown = get_slack_markdown_by_github_username(author)
         if slack_markdown not in leaderboard:
             leaderboard[slack_markdown] = 0
         leaderboard[slack_markdown] += len(prs)
 
-    cycle_points = calculate_cycle_project_lead_points(days)
-    for lead_name, points in cycle_points.items():
+    cycle_lead_points, cycle_member_points = calculate_cycle_project_points(days)
+    for lead_name, points in cycle_lead_points.items():
         slack_markdown = get_slack_markdown_by_linear_username(lead_name)
         key = slack_markdown if slack_markdown != "No Assignee" else lead_name
         leaderboard[key] = leaderboard.get(key, 0) + points
 
-    member_points = calculate_cycle_project_member_points(days)
-    for member_name, points in member_points.items():
+    for member_name, points in cycle_member_points.items():
         slack_markdown = get_slack_markdown_by_linear_username(member_name)
         key = slack_markdown if slack_markdown != "No Assignee" else member_name
         leaderboard[key] = leaderboard.get(key, 0) + points
@@ -938,6 +946,7 @@ def post_weekly_changelog():
 def run_debug_jobs() -> None:
     if should_use_redis_cache():
         refresh_airflow_fleet_health_cache_job()
+        refresh_leaderboard_cache_job()
     post_inactive_engineers()
     post_priority_bugs()
     post_leaderboard()
@@ -958,8 +967,19 @@ def configure_scheduled_jobs() -> None:
             "Scheduled airflow fleet health cache refresh every %s seconds",
             refresh_interval_seconds,
         )
+        leaderboard_refresh_seconds = _read_positive_int_env(
+            "LEADERBOARD_REFRESH_SECONDS",
+            DEFAULT_REFRESH_SECONDS,
+        )
+        schedule.every(leaderboard_refresh_seconds).seconds.do(refresh_leaderboard_cache_job)
+        refresh_leaderboard_cache_job()
+        logging.info(
+            "Scheduled leaderboard cache refresh every %s seconds",
+            leaderboard_refresh_seconds,
+        )
     else:
         logging.info("REDIS_URL not set; airflow fleet health cache refresh is disabled")
+        logging.info("REDIS_URL not set; leaderboard cache refresh is disabled")
 
     schedule.every().friday.at("13:00").do(post_inactive_engineers)
     schedule.every().day.at("12:00").do(post_priority_bugs)

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from functools import lru_cache
 
 from constants import (
     CYCLE_PROJECT_LEAD_POINTS_PER_WEEK,
     CYCLE_PROJECT_MEMBER_POINTS_PER_WEEK,
 )
-from linear.projects import get_completed_project_issue_assignees, get_projects
+from linear.projects import get_completed_project_issue_assignees_by_project, get_projects
 
 
 def _parse_date(value: str | None) -> datetime | None:
@@ -51,8 +52,7 @@ def _calculate_cycle_project_points(
     projects = get_projects()
     timeframe_start = now - timedelta(days=days)
     week_segments = _build_week_segments(timeframe_start, now)
-    points_by_lead: dict[str, int] = {}
-    points_by_member: dict[str, int] = {}
+    scoring_projects: list[tuple[str | None, str, int]] = []
     for project in projects:
         if not _is_completed_project(project):
             continue
@@ -71,39 +71,58 @@ def _calculate_cycle_project_points(
         window_start = max(start_at, timeframe_start)
         if window_end <= window_start:
             continue
-        scoring_segments = [
-            (segment_start, segment_end)
+        scoring_weeks = sum(
+            1
             for segment_start, segment_end in week_segments
             if min(window_end, segment_end) > max(window_start, segment_start)
-        ]
-        if not scoring_segments:
-            continue
-        project_id = project.get("id")
-        contributors = (
-            {
-                contributor
-                for contributor in get_completed_project_issue_assignees(project_id)
-                if contributor and contributor != lead_name
-            }
-            if project_id
-            else set()
         )
-        for _ in scoring_segments:
-            points_by_lead[lead_name] = (
-                points_by_lead.get(lead_name, 0) + CYCLE_PROJECT_LEAD_POINTS_PER_WEEK
+        if not scoring_weeks:
+            continue
+        scoring_projects.append((project.get("id"), lead_name, scoring_weeks))
+
+    project_ids = [project_id for project_id, _, _ in scoring_projects if project_id]
+    assignees_by_project = (
+        get_completed_project_issue_assignees_by_project(project_ids) if project_ids else {}
+    )
+
+    points_by_lead: dict[str, int] = {}
+    points_by_member: dict[str, int] = {}
+    for project_id, lead_name, scoring_weeks in scoring_projects:
+        points_by_lead[lead_name] = (
+            points_by_lead.get(lead_name, 0) + CYCLE_PROJECT_LEAD_POINTS_PER_WEEK * scoring_weeks
+        )
+        if not project_id:
+            continue
+        for contributor in assignees_by_project.get(project_id, []):
+            if not contributor or contributor == lead_name:
+                continue
+            points_by_member[contributor] = (
+                points_by_member.get(contributor, 0)
+                + CYCLE_PROJECT_MEMBER_POINTS_PER_WEEK * scoring_weeks
             )
-            for contributor in contributors:
-                points_by_member[contributor] = (
-                    points_by_member.get(contributor, 0) + CYCLE_PROJECT_MEMBER_POINTS_PER_WEEK
-                )
     return points_by_lead, points_by_member
 
 
+@lru_cache(maxsize=16)
+def _calculate_cycle_project_points_cached(
+    days: int, now_key: str
+) -> tuple[dict[str, int], dict[str, int]]:
+    return _calculate_cycle_project_points(days, datetime.fromisoformat(now_key))
+
+
+def calculate_cycle_project_points(
+    days: int, now: datetime | None = None
+) -> tuple[dict[str, int], dict[str, int]]:
+    if now is None:
+        return _calculate_cycle_project_points(days, None)
+    return _calculate_cycle_project_points_cached(days, now.isoformat())
+
+
 def calculate_cycle_project_lead_points(days: int, now: datetime | None = None) -> dict[str, int]:
-    lead_points, _ = _calculate_cycle_project_points(days, now)
+    lead_points, _ = calculate_cycle_project_points(days, now)
     return lead_points
 
 
 def calculate_cycle_project_member_points(days: int, now: datetime | None = None) -> dict[str, int]:
-    _, member_points = _calculate_cycle_project_points(days, now)
+    _, member_points = calculate_cycle_project_points(days, now)
     return member_points

--- a/leaderboard_cache.py
+++ b/leaderboard_cache.py
@@ -1,0 +1,122 @@
+import json
+import logging
+import os
+import time
+from typing import Any
+
+from fleet_health_cache import should_use_redis_cache
+
+LEADERBOARD_CACHE_KEY_PREFIX = "leaderboard:v1:"
+DEFAULT_MAX_STALE_SECONDS = 600
+DEFAULT_REDIS_TTL_SECONDS = 900
+DEFAULT_REFRESH_SECONDS = 60
+DEFAULT_LEADERBOARD_DAYS = 30
+
+
+def leaderboard_cache_key(days: int) -> str:
+    return f"{LEADERBOARD_CACHE_KEY_PREFIX}{days}"
+
+
+def get_cached_leaderboard(days: int) -> dict[str, Any] | None:
+    client = _get_redis_client()
+    if client is None:
+        return None
+
+    try:
+        raw = client.get(leaderboard_cache_key(days))
+    except Exception:
+        logging.exception("Failed to read leaderboard cache from Redis")
+        return None
+
+    if not raw:
+        return None
+
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        logging.warning("Leaderboard cache payload is not valid JSON")
+        return None
+
+    entries = parsed.get("leaderboard_entries")
+    cached_at_epoch = parsed.get("cached_at_epoch")
+    cached_days = parsed.get("days", days)
+
+    if not isinstance(entries, list) or not isinstance(cached_at_epoch, (int, float)):
+        logging.warning("Leaderboard cache payload has invalid shape")
+        return None
+    if not isinstance(cached_days, int):
+        return None
+
+    max_stale_seconds = _read_non_negative_int_env(
+        "LEADERBOARD_MAX_STALE_SECONDS",
+        DEFAULT_MAX_STALE_SECONDS,
+    )
+    if max_stale_seconds > 0 and time.time() - float(cached_at_epoch) > max_stale_seconds:
+        return None
+
+    return {
+        "days": cached_days,
+        "leaderboard_entries": entries,
+        "cached_at_epoch": float(cached_at_epoch),
+    }
+
+
+def store_cached_leaderboard(days: int, context: dict[str, Any]) -> bool:
+    client = _get_redis_client()
+    if client is None:
+        return False
+
+    ttl_seconds = _read_non_negative_int_env(
+        "LEADERBOARD_REDIS_TTL_SECONDS",
+        DEFAULT_REDIS_TTL_SECONDS,
+    )
+    record = {
+        "cached_at_epoch": time.time(),
+        "days": days,
+        "leaderboard_entries": context.get("leaderboard_entries", []),
+    }
+    serialized = json.dumps(record, separators=(",", ":"))
+
+    try:
+        if ttl_seconds > 0:
+            client.setex(leaderboard_cache_key(days), ttl_seconds, serialized)
+        else:
+            client.set(leaderboard_cache_key(days), serialized)
+    except Exception:
+        logging.exception("Failed to write leaderboard cache to Redis")
+        return False
+
+    return True
+
+
+def refresh_leaderboard_cache(days: int = DEFAULT_LEADERBOARD_DAYS) -> dict[str, Any]:
+    from app import compute_leaderboard_context
+
+    context = compute_leaderboard_context(days)
+    store_cached_leaderboard(days, context)
+    return context
+
+
+def _get_redis_client() -> Any | None:
+    if not should_use_redis_cache():
+        return None
+    try:
+        from fleet_health_cache import _get_redis_client as get_shared_redis_client
+    except Exception:
+        return None
+    try:
+        return get_shared_redis_client()
+    except Exception:
+        logging.exception("Failed to initialize Redis client for leaderboard cache")
+        return None
+
+
+def _read_non_negative_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return default
+    return max(0, parsed)

--- a/linear/issues.py
+++ b/linear/issues.py
@@ -241,7 +241,7 @@ def get_completed_issues_summary(priority, label, days=30):
             $cursor: String
         ) {
           issues(
-            first: 50
+            first: 250
             after: $cursor
             filter: {
               team: { key: { eq: $team_key } }

--- a/linear/projects.py
+++ b/linear/projects.py
@@ -4,23 +4,45 @@ from config import get_linear_team_key
 
 from .client import _execute
 
+PROJECT_ID_FILTER_CHUNK_SIZE = 50
+
 
 def get_completed_project_issue_assignees(project_id: str) -> list[str]:
     """Return sorted unique assignee display names for a project's completed issues."""
+    return get_completed_project_issue_assignees_by_project([project_id]).get(project_id, [])
+
+
+def get_completed_project_issue_assignees_by_project(
+    project_ids: list[str],
+) -> dict[str, list[str]]:
+    """Return completed-issue assignees grouped by project id."""
+    unique_project_ids = []
+    seen_ids = set()
+    for project_id in project_ids:
+        if not project_id or project_id in seen_ids:
+            continue
+        seen_ids.add(project_id)
+        unique_project_ids.append(project_id)
+    if not unique_project_ids:
+        return {}
+
     query = gql(
         """
-        query CompletedProjectIssueAssignees($project_id: ID!, $after: String) {
+        query CompletedProjectIssueAssignees($project_ids: [ID!], $after: String) {
           issues(
-            first: 50
+            first: 250
             after: $after
             filter: {
-              project: { id: { eq: $project_id } }
+              project: { id: { in: $project_ids } }
               state: { type: { in: ["completed"] } }
             }
           ) {
             nodes {
               assignee {
                 displayName
+              }
+              project {
+                id
               }
             }
             pageInfo {
@@ -32,23 +54,32 @@ def get_completed_project_issue_assignees(project_id: str) -> list[str]:
         """
     )
 
-    assignees: set[str] = set()
-    after = None
-    while True:
-        data = _execute(query, variable_values={"project_id": project_id, "after": after})
-        issue_connection = data.get("issues", {}) or {}
-        for issue in issue_connection.get("nodes", []) or []:
-            assignee = issue.get("assignee") or {}
-            display_name = assignee.get("displayName")
-            if display_name:
-                assignees.add(display_name)
-        page_info = issue_connection.get("pageInfo", {}) or {}
-        if not page_info.get("hasNextPage"):
-            break
-        after = page_info.get("endCursor")
-        if not after:
-            break
-    return sorted(assignees)
+    assignees_by_project: dict[str, set[str]] = {
+        project_id: set() for project_id in unique_project_ids
+    }
+    for index in range(0, len(unique_project_ids), PROJECT_ID_FILTER_CHUNK_SIZE):
+        chunk = unique_project_ids[index : index + PROJECT_ID_FILTER_CHUNK_SIZE]
+        after = None
+        while True:
+            data = _execute(query, variable_values={"project_ids": chunk, "after": after})
+            issue_connection = data.get("issues", {}) or {}
+            for issue in issue_connection.get("nodes", []) or []:
+                project = issue.get("project") or {}
+                issue_project_id = project.get("id")
+                if issue_project_id not in assignees_by_project:
+                    continue
+                assignee = issue.get("assignee") or {}
+                display_name = assignee.get("displayName")
+                if display_name:
+                    assignees_by_project[issue_project_id].add(display_name)
+            page_info = issue_connection.get("pageInfo", {}) or {}
+            if not page_info.get("hasNextPage"):
+                break
+            after = page_info.get("endCursor")
+            if not after:
+                break
+
+    return {project_id: sorted(assignees) for project_id, assignees in assignees_by_project.items()}
 
 
 def _normalize_project_members(projects: list[dict]) -> list[dict]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,15 @@ select = ["E", "F", "I", "W"]
 [tool.vulture]
 exclude = ["venv", ".venv", "env", ".env", "__pycache__", ".git", "static", "templates", ".tox", "build", "dist", "*.egg-info", "tests"]
 ignore_decorators = ["@app.route", "@app.template_filter"]
-ignore_names = ["breakdown", "post_weekly_changelog"]
+ignore_names = [
+    "breakdown",
+    "post_weekly_changelog",
+    "reset_leaderboard_runtime_cache",
+    "merged_prs_by_author",
+    "merged_prs_by_reviewer",
+    "calculate_cycle_project_lead_points",
+    "calculate_cycle_project_member_points",
+    "get_completed_project_issue_assignees",
+    "_reset_merged_prs_cache",
+]
 min_confidence = 60

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,7 +30,9 @@
     #}
     <section id="resolution-by-priority" aria-busy="true"></section>
     <section id="open-items" aria-busy="true"></section>
-    <section id="leaderboard" aria-busy="true"></section>
+    <section id="leaderboard"{% if not leaderboard_html %} aria-busy="true"{% endif %}>
+      {{ leaderboard_html|safe if leaderboard_html else '' }}
+    </section>
 {% endblock %}
 
 {% block extra_scripts %}
@@ -122,6 +124,8 @@
     `/partials/index/resolution-by-priority?days=${days}`
   );
   loadSection('open-items', `/partials/index/open-items?days=${days}`);
+  {% if not leaderboard_html %}
   loadSection('leaderboard', `/partials/index/leaderboard?days=${days}`);
+  {% endif %}
 </script>
 {% endblock %}

--- a/tests/test_gql_client_requests.py
+++ b/tests/test_gql_client_requests.py
@@ -42,6 +42,31 @@ class GraphQLClientRequestTests(unittest.TestCase):
         self.assertIn("author:bkraeling", variables["authored"])
         self.assertIn("reviewed-by:bkraeling", variables["reviewed"])
 
+    def test_merged_prs_for_leaderboard_uses_a_single_search(self):
+        response = {
+            "search": {
+                "nodes": [
+                    {
+                        "author": {"login": "alice"},
+                        "reviews": {"nodes": [{"author": {"login": "bob"}, "state": "APPROVED"}]},
+                    }
+                ],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+            }
+        }
+
+        github._reset_merged_prs_cache()
+        with (
+            patch.object(github, "token", "token"),
+            patch.object(github, "get_github_orgs", return_value=["apollosproject"]),
+            patch.object(github, "_execute", return_value=response) as execute,
+        ):
+            by_author, by_reviewer = github.merged_prs_for_leaderboard(30)
+
+        self.assertEqual(execute.call_count, 1)
+        self.assertEqual(list(by_author), ["alice"])
+        self.assertEqual(list(by_reviewer), ["bob"])
+
     def test_github_client_allows_slow_repository_queries(self):
         previous_client = getattr(github._thread_local, "client", None)
         if hasattr(github._thread_local, "client"):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -48,12 +48,23 @@ def _install_import_shims() -> None:
     github_module.get_prs_waiting_for_review_by_reviewer = lambda *args, **kwargs: {}
     github_module.merged_prs_by_author = lambda *args, **kwargs: {}
     github_module.merged_prs_by_reviewer = lambda *args, **kwargs: {}
+    github_module.merged_prs_for_leaderboard = lambda *args, **kwargs: ({}, {})
     sys.modules.setdefault("github", github_module)
 
     leaderboard_module = cast(Any, types.ModuleType("leaderboard"))
     leaderboard_module.calculate_cycle_project_lead_points = lambda *args, **kwargs: 0
     leaderboard_module.calculate_cycle_project_member_points = lambda *args, **kwargs: 0
+    leaderboard_module.calculate_cycle_project_points = lambda *args, **kwargs: ({}, {})
     sys.modules.setdefault("leaderboard", leaderboard_module)
+
+    leaderboard_cache_module = cast(Any, types.ModuleType("leaderboard_cache"))
+    leaderboard_cache_module.DEFAULT_LEADERBOARD_DAYS = 30
+    leaderboard_cache_module.DEFAULT_REFRESH_SECONDS = 60
+    leaderboard_cache_module.refresh_leaderboard_cache = lambda *args, **kwargs: {
+        "days": 30,
+        "leaderboard_entries": [],
+    }
+    sys.modules.setdefault("leaderboard_cache", leaderboard_cache_module)
 
     linear_package = cast(Any, types.ModuleType("linear"))
     linear_package.__path__ = []
@@ -91,6 +102,7 @@ for module_name in [
     "fleet_health_cache",
     "github",
     "leaderboard",
+    "leaderboard_cache",
     "linear",
     "linear.issues",
     "linear.projects",

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -18,9 +18,15 @@ def _import_leaderboard_with_stub():
     def _get_completed_project_issue_assignees(_project_id):
         return []
 
+    def _get_completed_project_issue_assignees_by_project(_project_ids):
+        return {}
+
     linear_projects_module.get_projects = _get_projects
     linear_projects_module.get_completed_project_issue_assignees = (
         _get_completed_project_issue_assignees
+    )
+    linear_projects_module.get_completed_project_issue_assignees_by_project = (
+        _get_completed_project_issue_assignees_by_project
     )
 
     original_leaderboard = sys.modules.pop("leaderboard", None)
@@ -58,13 +64,14 @@ class CycleProjectPointsTest(TestCase):
         with patch.object(leaderboard_module, "get_projects", return_value=projects):
             with patch.object(
                 leaderboard_module,
-                "get_completed_project_issue_assignees",
-                return_value=["Austin"],
+                "get_completed_project_issue_assignees_by_project",
+                return_value={"project-1": ["Austin"]},
             ) as assignees_mock:
-                lead_points = leaderboard_module.calculate_cycle_project_lead_points(30, now)
-                member_points = leaderboard_module.calculate_cycle_project_member_points(30, now)
+                lead_points, member_points = leaderboard_module.calculate_cycle_project_points(
+                    30, now
+                )
 
-        assignees_mock.assert_called_with("project-1")
+        assignees_mock.assert_called_once_with(["project-1"])
         self.assertEqual(lead_points, {"nick": 120})
         self.assertEqual(member_points, {"Austin": 60})
 
@@ -110,8 +117,8 @@ class CycleProjectPointsTest(TestCase):
         with patch.object(leaderboard_module, "get_projects", return_value=projects):
             with patch.object(
                 leaderboard_module,
-                "get_completed_project_issue_assignees",
-                return_value=["Contributor"],
+                "get_completed_project_issue_assignees_by_project",
+                return_value={"project-1": ["Contributor"]},
             ):
                 member_points = leaderboard_module.calculate_cycle_project_member_points(30, now)
 
@@ -136,8 +143,8 @@ class CycleProjectPointsTest(TestCase):
         with patch.object(leaderboard_module, "get_projects", return_value=projects):
             with patch.object(
                 leaderboard_module,
-                "get_completed_project_issue_assignees",
-                return_value=["Austin"],
+                "get_completed_project_issue_assignees_by_project",
+                return_value={"old-project": ["Austin"]},
             ) as assignees_mock:
                 lead_points = leaderboard_module.calculate_cycle_project_lead_points(30, now)
                 member_points = leaderboard_module.calculate_cycle_project_member_points(30, now)

--- a/tests/test_leaderboard_cache.py
+++ b/tests/test_leaderboard_cache.py
@@ -1,0 +1,59 @@
+import json
+import unittest
+from unittest.mock import patch
+
+import leaderboard_cache
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def setex(self, key, _ttl, value):
+        self.store[key] = value
+
+    def set(self, key, value):
+        self.store[key] = value
+
+
+class LeaderboardCacheTest(unittest.TestCase):
+    def test_round_trips_leaderboard_payload(self):
+        fake_redis = _FakeRedis()
+        context = {
+            "days": 30,
+            "leaderboard_entries": [
+                {"slug": "nick", "display_name": "Nick", "score": 20, "breakdown": None}
+            ],
+        }
+
+        with patch.object(leaderboard_cache, "_get_redis_client", return_value=fake_redis):
+            self.assertTrue(leaderboard_cache.store_cached_leaderboard(30, context))
+            cached = leaderboard_cache.get_cached_leaderboard(30)
+
+        self.assertIsNotNone(cached)
+        assert cached is not None
+        self.assertEqual(cached["days"], 30)
+        self.assertEqual(cached["leaderboard_entries"], context["leaderboard_entries"])
+        self.assertIn("cached_at_epoch", cached)
+
+    def test_rejects_stale_payload(self):
+        fake_redis = _FakeRedis()
+        fake_redis.set(
+            leaderboard_cache.leaderboard_cache_key(30),
+            json.dumps(
+                {
+                    "cached_at_epoch": 1,
+                    "days": 30,
+                    "leaderboard_entries": [],
+                }
+            ),
+        )
+
+        with patch.object(leaderboard_cache, "_get_redis_client", return_value=fake_redis):
+            with patch.object(leaderboard_cache, "_read_non_negative_int_env", return_value=60):
+                cached = leaderboard_cache.get_cached_leaderboard(30)
+
+        self.assertIsNone(cached)

--- a/tests/test_leaderboard_page.py
+++ b/tests/test_leaderboard_page.py
@@ -1,0 +1,99 @@
+import unittest
+from unittest.mock import patch
+
+import app as app_module
+
+
+class LeaderboardPageTest(unittest.TestCase):
+    def setUp(self):
+        app_module.reset_leaderboard_runtime_cache()
+        self.addCleanup(app_module.reset_leaderboard_runtime_cache)
+        self.client = app_module.app.test_client()
+
+    def test_index_embeds_cached_leaderboard_without_a_followup_fetch(self):
+        context = {
+            "days": 30,
+            "leaderboard_entries": [
+                {
+                    "slug": "nick",
+                    "display_name": "Nick",
+                    "score": 40,
+                    "breakdown": "Urgent issues: 40 pts",
+                }
+            ],
+        }
+
+        with patch.object(app_module, "peek_leaderboard_context", return_value=context):
+            with patch.object(app_module, "prefetch_leaderboard_context") as prefetch:
+                response = self.client.get("/")
+
+        body = response.get_data(as_text=True)
+        self.assertEqual(response.status_code, 200)
+        prefetch.assert_called_once_with(30)
+        self.assertIn("Leaderboard (30d)", body)
+        self.assertIn("Nick", body)
+        self.assertIn(">40<", body)
+        self.assertNotIn("loadSection('leaderboard'", body)
+
+    def test_index_prefetches_when_leaderboard_is_not_cached(self):
+        with patch.object(app_module, "peek_leaderboard_context", return_value=None):
+            with patch.object(app_module, "prefetch_leaderboard_context") as prefetch:
+                response = self.client.get("/")
+
+        body = response.get_data(as_text=True)
+        self.assertEqual(response.status_code, 200)
+        prefetch.assert_called_once_with(30)
+        self.assertIn('id="leaderboard"', body)
+        self.assertIn('aria-busy="true"', body)
+        self.assertIn("loadSection('leaderboard'", body)
+
+    def test_leaderboard_partial_serves_stale_cache_without_recomputing(self):
+        stale_context = {
+            "days": 30,
+            "leaderboard_entries": [
+                {
+                    "slug": "austin",
+                    "display_name": "Austin",
+                    "score": 15,
+                    "breakdown": None,
+                }
+            ],
+        }
+
+        with patch.object(
+            app_module,
+            "_read_leaderboard_memory_cache",
+            return_value=(stale_context, False),
+        ):
+            with patch.object(
+                app_module, "_read_leaderboard_redis_cache", return_value=(None, False)
+            ):
+                with patch.object(app_module, "_start_leaderboard_refresh") as refresh:
+                    refresh.return_value.result.side_effect = AssertionError(
+                        "stale cache should not wait for a rebuild"
+                    )
+                    response = self.client.get("/partials/index/leaderboard?days=30")
+
+        self.assertEqual(response.status_code, 200)
+        refresh.assert_called_once_with(30)
+        body = response.get_data(as_text=True)
+        self.assertIn("Austin", body)
+        self.assertIn(">15<", body)
+
+    def test_compute_leaderboard_context_fetches_github_and_cycle_points_once(self):
+        with (
+            patch.object(app_module, "get_completed_issues_summary", return_value=[]),
+            patch.object(
+                app_module, "merged_prs_for_leaderboard", return_value=({}, {})
+            ) as github_fetch,
+            patch.object(
+                app_module, "calculate_cycle_project_points", return_value=({}, {})
+            ) as cycle_fetch,
+            patch.object(app_module, "load_config", return_value={"people": {}}),
+        ):
+            context = app_module.compute_leaderboard_context(30)
+
+        github_fetch.assert_called_once_with(30)
+        cycle_fetch.assert_called_once_with(30)
+        self.assertEqual(context["days"], 30)
+        self.assertEqual(context["leaderboard_entries"], [])

--- a/tests/test_linear_projects.py
+++ b/tests/test_linear_projects.py
@@ -93,8 +93,11 @@ class GetCompletedProjectIssueAssigneesTest(unittest.TestCase):
                         "endCursor": "issue-cursor-1",
                     },
                     "nodes": [
-                        {"assignee": {"displayName": "Austin Witherow"}},
-                        {"assignee": None},
+                        {
+                            "assignee": {"displayName": "Austin Witherow"},
+                            "project": {"id": "project-2"},
+                        },
+                        {"assignee": None, "project": {"id": "project-2"}},
                     ],
                 }
             },
@@ -102,8 +105,14 @@ class GetCompletedProjectIssueAssigneesTest(unittest.TestCase):
                 "issues": {
                     "pageInfo": {"hasNextPage": False, "endCursor": None},
                     "nodes": [
-                        {"assignee": {"displayName": "Later Page Contributor"}},
-                        {"assignee": {"displayName": "Austin Witherow"}},
+                        {
+                            "assignee": {"displayName": "Later Page Contributor"},
+                            "project": {"id": "project-2"},
+                        },
+                        {
+                            "assignee": {"displayName": "Austin Witherow"},
+                            "project": {"id": "project-2"},
+                        },
                     ],
                 }
             },
@@ -122,12 +131,44 @@ class GetCompletedProjectIssueAssigneesTest(unittest.TestCase):
         self.assertEqual(
             calls,
             [
-                {"project_id": "project-2", "after": None},
-                {"project_id": "project-2", "after": "issue-cursor-1"},
+                {"project_ids": ["project-2"], "after": None},
+                {"project_ids": ["project-2"], "after": "issue-cursor-1"},
             ],
         )
-        self.assertIn("$project_id: ID!", queries[0])
+        self.assertIn("$project_ids: [ID!]", queries[0])
         self.assertEqual(assignees, ["Austin Witherow", "Later Page Contributor"])
+
+    def test_batches_assignees_for_multiple_projects_in_one_query(self):
+        def fake_execute(_query, variable_values=None):
+            self.assertEqual(variable_values["project_ids"], ["project-1", "project-2"])
+            return {
+                "issues": {
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    "nodes": [
+                        {
+                            "assignee": {"displayName": "Austin"},
+                            "project": {"id": "project-1"},
+                        },
+                        {
+                            "assignee": {"displayName": "Nick"},
+                            "project": {"id": "project-2"},
+                        },
+                        {
+                            "assignee": {"displayName": "Austin"},
+                            "project": {"id": "project-2"},
+                        },
+                    ],
+                }
+            }
+
+        with patch.object(project_module, "_execute", side_effect=fake_execute) as execute:
+            assignees = project_module.get_completed_project_issue_assignees_by_project(
+                ["project-1", "project-2", "project-1"]
+            )
+
+        execute.assert_called_once()
+        self.assertEqual(assignees["project-1"], ["Austin"])
+        self.assertEqual(assignees["project-2"], ["Austin", "Nick"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Rebuild the homepage leaderboard from one GitHub search and one batched Linear assignee query, instead of fetching PRs twice and scoring cycle projects twice with an N+1 Linear call.
- Serve a cached table in the first homepage HTML when memory or Redis has a result, and start the rebuild as soon as `/` is requested so the spinner path overlaps with page load.
- Keep showing stale scores while a refresh runs. GitHub PR points can arrive on a follow-up refresh so Linear and project scores are not blocked by the slow search.
- When `REDIS_URL` is set, the worker precomputes the default 30-day board on the same cadence as fleet-health cache refresh.

## Test plan
- [x] `ruff check .`
- [x] `python -m unittest discover -s tests -p 'test_*.py'`
- [x] Cold `/` returns 200 quickly and starts a leaderboard rebuild
- [x] First `/partials/index/leaderboard` returns real Linear/project scores
- [x] Warm `/` embeds the leaderboard and skips the extra fetch
- [x] A later request includes GitHub PR/review points after the background refresh