### PR TITLE
Wire date-range controls through dashboard pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,6 +45,7 @@ from project_dates import (
 )
 from rippling_pto import get_rippling_pto_calendar
 from support import get_support_slugs
+from time_window import TimeWindow
 
 
 def normalize_identity(value: str | None) -> str:
@@ -57,10 +58,27 @@ def format_display_name(linear_username: str) -> str:
     return re.sub(r"[._-]+", " ", linear_username).title()
 
 
-def github_merged_prs_url(username: str, days: int) -> str:
-    cutoff_date = (datetime.now(timezone.utc) - timedelta(days=days)).date().isoformat()
-    query = f"is:closed is:pr author:{username} archived:false merged:>={cutoff_date}"
+def github_merged_prs_url(username: str, days: int, window: TimeWindow | None = None) -> str:
+    qualifier = (
+        window or TimeWindow.from_days(days, now=datetime.now(timezone.utc))
+    ).github_merged_qualifier()
+    query = f"is:closed is:pr author:{username} archived:false {qualifier}"
     return f"https://github.com/pulls?q={quote(query, safe='')}"
+
+
+def _request_time_window() -> TimeWindow:
+    return TimeWindow.resolve(
+        days=request.args.get("days", type=int),
+        start=request.args.get("start"),
+        end=request.args.get("end"),
+        now=datetime.now(timezone.utc),
+    )
+
+
+def _window_from_parts(
+    days: int | None, start: str | None = None, end: str | None = None
+) -> TimeWindow:
+    return TimeWindow.resolve(days, start=start, end=end, now=datetime.now(timezone.utc))
 
 
 INACTIVE_PROJECT_STATUS_NAMES = {
@@ -769,16 +787,24 @@ def _build_leaderboard_entries(
 
 
 @lru_cache(maxsize=INDEX_CONTEXT_CACHE_MAXSIZE)
-def _build_priority_stats_context(days: int, _cache_epoch: int) -> dict:
+def _build_priority_stats_context(
+    days: int | None, _cache_epoch: int, start: str | None = None, end: str | None = None
+) -> dict:
+    window = _window_from_parts(days, start, end)
+    days = window.duration_days
     with ThreadPoolExecutor(max_workers=INDEX_THREADPOOL_MAX_WORKERS) as executor:
-        created_priority_future = executor.submit(get_created_issues, 2, "Bug", days)
-        completed_priority_future = executor.submit(get_completed_issues_summary, 2, "Bug", days)
-        completed_bugs_future = executor.submit(get_completed_issues_summary, 5, "Bug", days)
+        created_priority_future = executor.submit(get_created_issues, 2, "Bug", days, window)
+        completed_priority_future = executor.submit(
+            get_completed_issues_summary, 2, "Bug", days, window
+        )
+        completed_bugs_future = executor.submit(
+            get_completed_issues_summary, 5, "Bug", days, window
+        )
         completed_feature_requests_future = executor.submit(
-            get_completed_issues_summary, 5, "Feature Request", days
+            get_completed_issues_summary, 5, "Feature Request", days, window
         )
         completed_technical_changes_future = executor.submit(
-            get_completed_issues_summary, 5, "Technical Change", days
+            get_completed_issues_summary, 5, "Technical Change", days, window
         )
 
     created_priority_bugs = get_future_result_with_timeout(created_priority_future, [])
@@ -823,7 +849,7 @@ def _build_priority_stats_context(days: int, _cache_epoch: int) -> dict:
     platform_values = [len(issues_by_platform[label]) for label in platform_labels]
 
     return {
-        "days": days,
+        **window.template_vars(),
         "issue_count": len(created_priority_bugs),
         "fixes_per_day": fixes_per_day,
         "priority_percentage": priority_percentage,
@@ -835,7 +861,10 @@ def _build_priority_stats_context(days: int, _cache_epoch: int) -> dict:
 
 
 @lru_cache(maxsize=INDEX_CONTEXT_CACHE_MAXSIZE)
-def _build_open_items_context(days: int, _cache_epoch: int) -> dict:
+def _build_open_items_context(
+    days: int | None, _cache_epoch: int, start: str | None = None, end: str | None = None
+) -> dict:
+    window = _window_from_parts(days, start, end)
     with ThreadPoolExecutor(max_workers=INDEX_THREADPOOL_MAX_WORKERS) as executor:
         open_priority_future = executor.submit(get_open_issues, 2, "Bug")
         open_bugs_future = executor.submit(get_open_issues, 5, "Bug")
@@ -851,7 +880,7 @@ def _build_open_items_context(days: int, _cache_epoch: int) -> dict:
     open_work = open_bugs_result + open_feature_requests_result + open_technical_changes_result
 
     return {
-        "days": days,
+        **window.template_vars(),
         "priority_issues": sorted(open_priority_bugs, key=lambda x: x["createdAt"]),
         "open_assigned_work": sorted(
             [
@@ -865,16 +894,23 @@ def _build_open_items_context(days: int, _cache_epoch: int) -> dict:
     }
 
 
-def compute_leaderboard_context(days: int) -> dict:
+def compute_leaderboard_context(
+    days: int = DEFAULT_LEADERBOARD_DAYS, window: TimeWindow | None = None
+) -> dict:
+    window = (
+        window if window is not None else TimeWindow.from_days(days, now=datetime.now(timezone.utc))
+    )
+    days = window.duration_days
     with ThreadPoolExecutor(max_workers=INDEX_THREADPOOL_MAX_WORKERS) as executor:
         completed_work_future = executor.submit(
             get_completed_issues_summary_for_labels,
             5,
             ["Bug", "Feature Request", "Technical Change"],
             days,
+            window,
         )
-        merged_prs_future = executor.submit(get_merged_pr_activity, days)
-        cycle_points_future = executor.submit(calculate_cycle_project_points, days)
+        merged_prs_future = executor.submit(get_merged_pr_activity, days, window)
+        cycle_points_future = executor.submit(calculate_cycle_project_points, days, None, window)
 
     completed_work_result = get_future_result_with_timeout(completed_work_future, [])
     completed_work = [issue for issue in completed_work_result if not issue.get("project")]
@@ -894,22 +930,31 @@ def compute_leaderboard_context(days: int) -> dict:
     )
 
     return {
-        "days": days,
+        **window.template_vars(),
         "leaderboard_entries": leaderboard_entries,
     }
 
 
 @lru_cache(maxsize=INDEX_CONTEXT_CACHE_MAXSIZE)
-def _build_leaderboard_context(days: int, _cache_epoch: int) -> dict:
-    return compute_leaderboard_context(days)
+def _build_leaderboard_context(
+    days: int | None, _cache_epoch: int, start: str | None = None, end: str | None = None
+) -> dict:
+    window = _window_from_parts(days, start, end)
+    return compute_leaderboard_context(window.duration_days, window)
 
 
 @lru_cache(maxsize=INDEX_CONTEXT_CACHE_MAXSIZE)
-def _build_resolution_by_priority_context(days: int, _cache_epoch: int) -> dict:
+def _build_resolution_by_priority_context(
+    days: int | None, _cache_epoch: int, start: str | None = None, end: str | None = None
+) -> dict:
+    window = _window_from_parts(days, start, end)
+    days = window.duration_days
     with ThreadPoolExecutor(max_workers=INDEX_THREADPOOL_MAX_WORKERS) as executor:
-        completed_bugs_future = executor.submit(get_completed_issues_summary, 5, "Bug", days)
+        completed_bugs_future = executor.submit(
+            get_completed_issues_summary, 5, "Bug", days, window
+        )
         completed_feature_requests_future = executor.submit(
-            get_completed_issues_summary, 5, "Feature Request", days
+            get_completed_issues_summary, 5, "Feature Request", days, window
         )
 
     completed_bugs_result = get_future_result_with_timeout(completed_bugs_future, [])
@@ -926,65 +971,70 @@ def _build_resolution_by_priority_context(days: int, _cache_epoch: int) -> dict:
     resolution_stats = get_resolution_time_by_priority(completed_non_project_issues)
 
     return {
-        "days": days,
+        **window.template_vars(),
         "resolution_stats": resolution_stats,
     }
+
+
+def _cached_window_context(builder, window: TimeWindow) -> dict:
+    days, start, end = window.cache_parts()
+    cache_epoch = int(time.time() / INDEX_CACHE_TTL_SECONDS)
+    return builder(days, cache_epoch, start, end)
 
 
 # use a query string parameter for days on the index route
 @app.route("/")
 def index():
-    days = request.args.get("days", default=30, type=int)
-    return render_template("index.html", days=days)
+    window = _request_time_window()
+    return render_template("index.html", **window.template_vars())
 
 
 @app.route("/partials/index/priority-stats")
 def index_priority_stats_partial():
-    days = request.args.get("days", default=30, type=int)
-    cache_epoch = int(time.time() / INDEX_CACHE_TTL_SECONDS)
-    context = _build_priority_stats_context(days, cache_epoch)
+    context = _cached_window_context(_build_priority_stats_context, _request_time_window())
     return render_template("partials/index_priority_stats.html", **context)
 
 
 @app.route("/partials/index/resolution-by-priority")
 def index_resolution_by_priority_partial():
-    days = request.args.get("days", default=30, type=int)
-    cache_epoch = int(time.time() / INDEX_CACHE_TTL_SECONDS)
-    context = _build_resolution_by_priority_context(days, cache_epoch)
+    context = _cached_window_context(_build_resolution_by_priority_context, _request_time_window())
     return render_template("partials/index_resolution_by_priority.html", **context)
 
 
 @app.route("/partials/index/open-items")
 def index_open_items_partial():
-    days = request.args.get("days", default=30, type=int)
-    cache_epoch = int(time.time() / INDEX_CACHE_TTL_SECONDS)
-    context = _build_open_items_context(days, cache_epoch)
+    context = _cached_window_context(_build_open_items_context, _request_time_window())
     return render_template("partials/index_open_items.html", **context)
 
 
 @app.route("/partials/index/leaderboard")
 def index_leaderboard_partial():
-    days = request.args.get("days", default=30, type=int)
-    if should_use_redis_cache() and days == DEFAULT_LEADERBOARD_DAYS:
-        cached = get_cached_leaderboard(days)
+    window = _request_time_window()
+    if should_use_redis_cache() and window.preset_days == DEFAULT_LEADERBOARD_DAYS:
+        cached = get_cached_leaderboard(window.preset_days)
         if cached is not None:
-            return render_template("partials/index_leaderboard.html", **cached)
-        logging.info("Leaderboard cache miss while REDIS_URL is configured (days=%s)", days)
+            return render_template(
+                "partials/index_leaderboard.html",
+                **{**window.template_vars(), **cached},
+            )
+        logging.info(
+            "Leaderboard cache miss while REDIS_URL is configured (days=%s)",
+            window.preset_days,
+        )
         return render_template(
             "partials/index_leaderboard.html",
-            days=days,
+            **window.template_vars(),
             leaderboard_entries=[],
             leaderboard_unavailable=True,
         )
-    cache_epoch = int(time.time() / INDEX_CACHE_TTL_SECONDS)
-    context = _build_leaderboard_context(days, cache_epoch)
+    context = _cached_window_context(_build_leaderboard_context, window)
     return render_template("partials/index_leaderboard.html", **context)
 
 
 @app.route("/team/<slug>")
 def team_slug(slug):
     """Display open and completed work for a team member."""
-    days = request.args.get("days", default=30, type=int)
+    window = _request_time_window()
     config = load_config()
     person_cfg = config.get("people", {}).get(slug)
     if not person_cfg:
@@ -995,7 +1045,7 @@ def team_slug(slug):
         "person.html",
         person_slug=slug,
         person_name=person_name,
-        days=days,
+        **window.template_vars(),
     )
 
 
@@ -1015,13 +1065,14 @@ def projects_content_partial():
 
 @app.route("/partials/team/<slug>/content")
 def team_person_content_partial(slug):
-    days = request.args.get("days", default=30, type=int)
+    window = _request_time_window()
     config = load_config()
     person_cfg = config.get("people", {}).get(slug)
     if not person_cfg:
         abort(404)
+    days, start, end = window.cache_parts()
     cache_epoch = int(time.time() / INDEX_CACHE_TTL_SECONDS)
-    context = _build_person_context(slug, days, cache_epoch)
+    context = _build_person_context(slug, days or window.duration_days, cache_epoch, start, end)
     return render_template("partials/person_content.html", **context)
 
 
@@ -1278,7 +1329,15 @@ def _build_team_context(_cache_epoch: int) -> dict:
 
 
 @lru_cache(maxsize=INDEX_CONTEXT_CACHE_MAXSIZE)
-def _build_person_context(slug: str, days: int, _cache_epoch: int) -> dict:
+def _build_person_context(
+    slug: str,
+    days: int,
+    _cache_epoch: int,
+    start: str | None = None,
+    end: str | None = None,
+) -> dict:
+    window = _window_from_parts(days, start, end)
+    days = window.duration_days
     config = load_config()
     person_cfg = config.get("people", {}).get(slug) or {}
     login = person_cfg.get("linear_username", slug)
@@ -1291,7 +1350,7 @@ def _build_person_context(slug: str, days: int, _cache_epoch: int) -> dict:
     )
     with ThreadPoolExecutor(max_workers=TEAM_THREADPOOL_MAX_WORKERS) as executor:
         open_future = executor.submit(get_open_issues_for_person, login)
-        completed_future = executor.submit(get_completed_issues_for_person, login, days)
+        completed_future = executor.submit(get_completed_issues_for_person, login, days, window)
         projects_future = executor.submit(get_projects)
         github_future = None
         if github_username:
@@ -1299,6 +1358,7 @@ def _build_person_context(slug: str, days: int, _cache_epoch: int) -> dict:
                 get_merged_pr_counts_for_user,
                 github_username,
                 days,
+                window,
             )
         open_items = sorted(
             open_future.result(timeout=EXECUTOR_TIMEOUT_SECONDS),
@@ -1427,9 +1487,9 @@ def _build_person_context(slug: str, days: int, _cache_epoch: int) -> dict:
         "linear_username": login,
         "github_username": github_username,
         "github_merged_prs_url": (
-            github_merged_prs_url(github_username, days) if github_username else None
+            github_merged_prs_url(github_username, days, window) if github_username else None
         ),
-        "days": days,
+        **window.template_vars(),
         "open_current_cycle": open_current_cycle,
         "open_other": open_other,
         "completed_by_project": completed_by_project,

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,15 +17,10 @@
 {% block header_nav %}{% endblock %}
 
 {% block content %}
+    {% set presets = [7, 30, 90] %}
+    {% include "partials/time_window_controls.html" %}
     {#
     <h2>Priority Bug Stats</h2>
-    <form method="get" style="display:inline-block; margin-bottom: 0.5em;">
-      <select name="days" onchange="this.form.submit()">
-        <option value="7"  {{ 'selected' if days == 7 else '' }}>7d</option>
-        <option value="30" {{ 'selected' if days == 30 else '' }}>30d</option>
-        <option value="90" {{ 'selected' if days == 90 else '' }}>90d</option>
-      </select>
-    </form>
     <div id="priority-stats" aria-busy="true"></div>
     #}
     <section id="resolution-by-priority" aria-busy="true"></section>
@@ -35,7 +30,8 @@
 
 {% block extra_scripts %}
 <script>
-  const days = {{ days }};
+  const windowQuery = {{ window_query | tojson }};
+  const windowQs = new URLSearchParams(windowQuery).toString();
   let chartLibraryPromise;
 
   function ensureChartLibrary() {
@@ -114,14 +110,14 @@
   // Priority bug stats section intentionally disabled while we evaluate alternatives.
   // loadSection(
   //   'priority-stats',
-  //   `/partials/index/priority-stats?days=${days}`,
+  //   `/partials/index/priority-stats?${windowQs}`,
   //   renderPlatformChart
   // );
   loadSection(
     'resolution-by-priority',
-    `/partials/index/resolution-by-priority?days=${days}`
+    `/partials/index/resolution-by-priority?${windowQs}`
   );
-  loadSection('open-items', `/partials/index/open-items?days=${days}`);
-  loadSection('leaderboard', `/partials/index/leaderboard?days=${days}`);
+  loadSection('open-items', `/partials/index/open-items?${windowQs}`);
+  loadSection('leaderboard', `/partials/index/leaderboard?${windowQs}`);
 </script>
 {% endblock %}

--- a/templates/partials/index_leaderboard.html
+++ b/templates/partials/index_leaderboard.html
@@ -8,7 +8,7 @@
   "Completed project lead: 30 pts/week",
   "Completed project member: 15 pts/week"
 ] | join('\n') %}
-<h2>Leaderboard ({{ days }}d)</h2>
+<h2>Leaderboard ({{ window_label or (days ~ 'd') }})</h2>
 <h4>
   Scores
   <small
@@ -34,7 +34,7 @@
       <tr>
         <td>
           {% if entry.slug %}
-            <a href="{{ url_for('team_slug', slug=entry.slug, days=days) }}">
+            <a href="{{ url_for('team_slug', slug=entry.slug, **(window_query or {'days': days})) }}">
               {{ entry.display_name|first_name }}
             </a>
           {% else %}

--- a/templates/partials/person_content.html
+++ b/templates/partials/person_content.html
@@ -33,13 +33,8 @@
 {% endfor %}
 {% endif %}
 <hr />
-<form method="get" style="display:inline-block; margin-bottom: 0.5em;">
-  <select name="days" onchange="this.form.submit()">
-    <option value="1"  {{ 'selected' if days == 1 else '' }}>1d</option>
-    <option value="7"  {{ 'selected' if days == 7 else '' }}>7d</option>
-    <option value="30" {{ 'selected' if days == 30 else '' }}>30d</option>
-  </select>
-</form>
+{% set presets = [1, 7, 30] %}
+{% include "partials/time_window_controls.html" %}
 <div class="grid">
   <div>
     <article>

--- a/templates/partials/time_window_controls.html
+++ b/templates/partials/time_window_controls.html
@@ -1,0 +1,18 @@
+{% set presets = presets if presets is defined else [7, 30, 90] %}
+<div class="grid" style="align-items:end">
+  <form method="get">
+    <label>Period
+      <select name="days" onchange="this.form.submit()" aria-label="Lookback period">
+        {% if preset_days is none %}<option value="" selected disabled>Custom</option>{% endif %}
+        {% for n in presets %}
+        <option value="{{ n }}" {{ 'selected' if preset_days == n else '' }}>{{ n }}d</option>
+        {% endfor %}
+      </select>
+    </label>
+  </form>
+  <form method="get" class="grid">
+    <label>From <input type="date" name="start" value="{{ start or '' }}" required></label>
+    <label>To <input type="date" name="end" value="{{ end or '' }}" required></label>
+    <button type="submit">Apply</button>
+  </form>
+</div>

--- a/templates/person.html
+++ b/templates/person.html
@@ -24,7 +24,8 @@
 
 {% block extra_scripts %}
 <script>
-  const days = {{ days }};
+  const windowQuery = {{ window_query | tojson }};
+  const windowQs = new URLSearchParams(windowQuery).toString();
   const slug = "{{ person_slug }}";
   let chartLibraryPromise;
 
@@ -106,6 +107,6 @@
     }
   }
 
-  loadSection('person-content', `/partials/team/${slug}/content?days=${days}`, renderPlatformChart);
+  loadSection('person-content', `/partials/team/${slug}/content?${windowQs}`, renderPlatformChart);
 </script>
 {% endblock %}

--- a/tests/test_leaderboard_cache.py
+++ b/tests/test_leaderboard_cache.py
@@ -48,5 +48,6 @@ class LeaderboardCacheTest(unittest.TestCase):
 
         self.assertIn("Michael", hit.get_data(as_text=True))
         self.assertIn("Leaderboard is refreshing.", miss.get_data(as_text=True))
-        compute.assert_called_once_with(7)
+        compute.assert_called_once()
+        self.assertEqual(compute.call_args.args[0], 7)
         self.assertEqual(other.status_code, 200)

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -96,8 +96,34 @@ class NavigationTest(unittest.TestCase):
             body = app_module.render_template("partials/person_content.html", **context)
         self.assertIn("merged%3A%3E%3D2026-07-01", body)
         fetch.assert_called_once_with()
-        counts.assert_called_once_with("bkraeling", 30)
+        counts.assert_called_once_with("bkraeling", 30, counts.call_args.args[2])
         support.assert_called_once_with(config=config, projects=projects)
+
+    def test_index_and_person_pages_accept_date_ranges(self):
+        index = self.client.get("/?start=2026-01-01&end=2026-01-31&days=7")
+        index_body = index.get_data(as_text=True)
+        self.assertEqual(index.status_code, 200)
+        self.assertIn('name="start"', index_body)
+        self.assertIn('value="2026-01-01"', index_body)
+        self.assertIn('value="2026-01-31"', index_body)
+
+        config = {
+            "people": {
+                "brandon": {
+                    "linear_username": "brandon",
+                    "github_username": "bkraeling",
+                }
+            }
+        }
+        app_module._build_person_context.cache_clear()
+        self.addCleanup(app_module._build_person_context.cache_clear)
+        with patch.object(app_module, "load_config", return_value=config):
+            person = self.client.get("/team/brandon?start=2026-01-01&end=2026-01-31")
+        person_body = person.get_data(as_text=True)
+        self.assertEqual(person.status_code, 200)
+        self.assertIn('"start": "2026-01-01"', person_body)
+        self.assertIn('"end": "2026-01-31"', person_body)
+        self.assertIn("`/partials/team/${slug}/content?${windowQs}`", person_body)
 
     def test_projects_page_and_timeline_use_project_labels(self):
         context = {

--- a/time_window.py
+++ b/time_window.py
@@ -68,6 +68,12 @@ class TimeWindow:
     def inclusive_end_date(self) -> date:
         return (self.end - timedelta(microseconds=1)).date()
 
+    @property
+    def duration_days(self) -> int:
+        if self.preset_days is not None:
+            return self.preset_days
+        return max((self.end - self.start).days, 1)
+
     def linear_bounds(self) -> dict[str, str]:
         return {"after": _to_linear_datetime(self.start), "before": _to_linear_datetime(self.end)}
 
@@ -76,3 +82,25 @@ class TimeWindow:
         if self.preset_days is not None:
             return f"merged:>={start}"
         return f"merged:>={start} merged:<={self.inclusive_end_date.isoformat()}"
+
+    def query_args(self) -> dict[str, str | int]:
+        if self.preset_days is not None:
+            return {"days": self.preset_days}
+        return {"start": self.start.date().isoformat(), "end": self.inclusive_end_date.isoformat()}
+
+    def cache_parts(self) -> tuple[int | None, str | None, str | None]:
+        query = self.query_args()
+        return query.get("days"), query.get("start"), query.get("end")  # type: ignore[return-value]
+
+    def template_vars(self) -> dict[str, object]:
+        query = self.query_args()
+        start, end = query.get("start"), query.get("end")
+        label = f"{self.preset_days}d" if self.preset_days is not None else f"{start} – {end}"
+        return {
+            "days": self.duration_days,
+            "preset_days": self.preset_days,
+            "start": start,
+            "end": end,
+            "window_label": label,
+            "window_query": query,
+        }


### PR DESCRIPTION
## Issue
Finishes #428: homepage and person pages that already take `days` now also take an inclusive `start`/`end` date range.

Depends on merged #435.

Closes #428

## Solution
Parse `start`/`end` query params (both dates required), keep day-preset shortcuts, add From/To controls, and preserve the current window on leaderboard person links.

## To Test
- [ ] `/` and `/team/<slug>` still switch day presets.
- [ ] Applying From/To writes `start`/`end` into the URL and keeps that window on reload.
- [ ] Leaderboard person links preserve the current window.

## Proof
Local gunicorn at `http://127.0.0.1:8000` on `date-range-ui`.

Homepage still defaults to 30d, with From/To available:

![Homepage 30d presets plus From/To](https://files.catbox.moe/so5r50.png)

Applying From=`2026-01-01` To=`2026-01-31` navigates to `/?start=2026-01-01&end=2026-01-31`, selects Period=Custom, and the resolution partial uses that window:

![Homepage custom date range](https://files.catbox.moe/hen2f6.png)

Person page `/team/brandon?start=2026-01-01&end=2026-01-31` keeps the same controls. The merged-PR link uses `merged:>=2026-01-01 merged:<=2026-01-31`:

![Person page custom date range](https://files.catbox.moe/3mu4hc.png)

Leaderboard heading and person links preserve the range:

```
<h2>Leaderboard (2026-01-01 – 2026-01-31)</h2>
<a href="/team/michael?start=2026-01-01&end=2026-01-31">
```