### PR TITLE
Tighten the date-range toolbar on dashboard pages

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -60,10 +60,12 @@ details.dropdown.site-menu > summary + ul {
 .time-window form {
   align-items: center;
   display: flex;
-  flex: 0 0 auto;
+  flex: 0 1 auto;
   flex-wrap: wrap;
   gap: 0.4rem;
   margin: 0;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .time-window label {

--- a/static/styles.css
+++ b/static/styles.css
@@ -47,6 +47,88 @@ details.dropdown.site-menu > summary + ul {
   width: 100%;
 }
 
+.time-window {
+  --pico-form-element-spacing-vertical: 0.3rem;
+  --pico-form-element-spacing-horizontal: 0.55rem;
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem 1rem;
+  margin: 0 0 1rem;
+}
+
+.time-window form {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0;
+}
+
+.time-window label {
+  align-items: center;
+  color: var(--pico-muted-color);
+  display: inline-flex;
+  font-size: 0.75rem;
+  font-weight: 600;
+  gap: 0.35rem;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.time-window input,
+.time-window button {
+  height: 2.25rem;
+  margin: 0;
+  min-height: 2.25rem;
+  width: auto;
+}
+
+.time-window input[type="date"] {
+  font-size: 0.85rem;
+  font-weight: 400;
+  padding: 0 0.5rem;
+  text-transform: none;
+  width: 10.5rem;
+}
+
+.time-window-presets {
+  border: 1px solid var(--pico-muted-border-color);
+  border-radius: 0.35rem;
+  overflow: hidden;
+}
+
+.time-window-presets button {
+  --pico-background-color: transparent;
+  --pico-border-color: transparent;
+  --pico-box-shadow: none;
+  --pico-color: var(--pico-muted-color);
+  border-radius: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0 0.75rem;
+}
+
+.time-window-presets button:not(:last-child) {
+  border-right: 1px solid var(--pico-muted-border-color);
+}
+
+.time-window-presets button[aria-pressed="true"] {
+  --pico-background-color: var(--pico-primary-background);
+  --pico-color: var(--pico-primary-inverse);
+}
+
+.time-window-custom button {
+  --pico-background-color: transparent;
+  --pico-border-color: var(--pico-muted-border-color);
+  --pico-box-shadow: none;
+  --pico-color: var(--pico-color);
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0 0.75rem;
+}
+
 @keyframes busy-spinner {
   to {
     transform: rotate(360deg);

--- a/templates/partials/time_window_controls.html
+++ b/templates/partials/time_window_controls.html
@@ -1,18 +1,24 @@
 {% set presets = presets if presets is defined else [7, 30, 90] %}
-<div class="grid" style="align-items:end">
-  <form method="get">
-    <label>Period
-      <select name="days" onchange="this.form.submit()" aria-label="Lookback period">
-        {% if preset_days is none %}<option value="" selected disabled>Custom</option>{% endif %}
-        {% for n in presets %}
-        <option value="{{ n }}" {{ 'selected' if preset_days == n else '' }}>{{ n }}d</option>
-        {% endfor %}
-      </select>
-    </label>
+<div class="time-window">
+  <form method="get" class="time-window-presets">
+    {% for n in presets %}
+    <button
+      type="submit"
+      name="days"
+      value="{{ n }}"
+      aria-pressed="{{ 'true' if preset_days == n else 'false' }}"
+    >{{ n }}d</button>
+    {% endfor %}
   </form>
-  <form method="get" class="grid">
-    <label>From <input type="date" name="start" value="{{ start or '' }}" required></label>
-    <label>To <input type="date" name="end" value="{{ end or '' }}" required></label>
+  <form method="get" class="time-window-custom">
+    <label>
+      <span>From</span>
+      <input type="date" name="start" value="{{ start or '' }}" required aria-label="Start date">
+    </label>
+    <label>
+      <span>To</span>
+      <input type="date" name="end" value="{{ end or '' }}" required aria-label="End date">
+    </label>
     <button type="submit">Apply</button>
   </form>
 </div>

--- a/templates/partials/time_window_controls.html
+++ b/templates/partials/time_window_controls.html
@@ -1,6 +1,6 @@
 {% set presets = presets if presets is defined else [7, 30, 90] %}
 <div class="time-window">
-  <form method="get" class="time-window-presets">
+  <form method="get" class="time-window-presets" aria-label="Lookback period">
     {% for n in presets %}
     <button
       type="submit"

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -48,6 +48,18 @@ class NavigationTest(unittest.TestCase):
         self.assertIn("right: 0;", site_menu_rule)
         self.assertIn("max-width: calc(100vw - 2rem);", site_menu_rule)
 
+    def test_time_window_controls_stay_compact(self):
+        with open("static/styles.css") as styles_file:
+            styles = styles_file.read()
+
+        toolbar = styles.split(".time-window {", 1)[1].split("}", 1)[0]
+        self.assertIn("display: flex;", toolbar)
+        self.assertIn("flex-wrap: wrap;", toolbar)
+
+        inputs = styles.split(".time-window input,", 1)[1].split("}", 1)[0]
+        self.assertIn("width: auto;", inputs)
+        self.assertIn("min-height: 2.25rem;", inputs)
+
     def test_busy_indicators_use_a_css_rotation_animation(self):
         with open("static/styles.css") as styles_file:
             styles = styles_file.read()
@@ -103,6 +115,9 @@ class NavigationTest(unittest.TestCase):
         index = self.client.get("/?start=2026-01-01&end=2026-01-31&days=7")
         index_body = index.get_data(as_text=True)
         self.assertEqual(index.status_code, 200)
+        self.assertIn('class="time-window"', index_body)
+        self.assertIn('class="time-window-presets"', index_body)
+        self.assertIn('class="time-window-custom"', index_body)
         self.assertIn('name="start"', index_body)
         self.assertIn('value="2026-01-01"', index_body)
         self.assertIn('value="2026-01-31"', index_body)

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -23,3 +23,13 @@ class TimeWindowTest(unittest.TestCase):
             TimeWindow.resolve(days=7, start="bad", end="2026-02-01", now=now).preset_days,
             7,
         )
+        self.assertEqual(
+            preset.template_vars()["window_query"],
+            {"days": 30},
+        )
+        self.assertEqual(preset.template_vars()["start"], "2026-07-01")
+        self.assertEqual(preset.template_vars()["end"], "2026-07-31")
+        self.assertEqual(
+            custom.template_vars()["window_query"],
+            {"start": "2026-01-01", "end": "2026-01-31"},
+        )

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -27,8 +27,8 @@ class TimeWindowTest(unittest.TestCase):
             preset.template_vars()["window_query"],
             {"days": 30},
         )
-        self.assertEqual(preset.template_vars()["start"], "2026-07-01")
-        self.assertEqual(preset.template_vars()["end"], "2026-07-31")
+        self.assertIsNone(preset.template_vars()["start"])
+        self.assertIsNone(preset.template_vars()["end"])
         self.assertEqual(
             custom.template_vars()["window_query"],
             {"start": "2026-01-01", "end": "2026-01-31"},

--- a/time_window.py
+++ b/time_window.py
@@ -94,8 +94,7 @@ class TimeWindow:
 
     def template_vars(self) -> dict[str, object]:
         query = self.query_args()
-        start = self.start.date().isoformat()
-        end = self.inclusive_end_date.isoformat()
+        start, end = query.get("start"), query.get("end")
         label = f"{self.preset_days}d" if self.preset_days is not None else f"{start} – {end}"
         return {
             "days": self.duration_days,

--- a/time_window.py
+++ b/time_window.py
@@ -94,7 +94,8 @@ class TimeWindow:
 
     def template_vars(self) -> dict[str, object]:
         query = self.query_args()
-        start, end = query.get("start"), query.get("end")
+        start = self.start.date().isoformat()
+        end = self.inclusive_end_date.isoformat()
         label = f"{self.preset_days}d" if self.preset_days is not None else f"{start} – {end}"
         return {
             "days": self.duration_days,


### PR DESCRIPTION
## Issue
The date-range control from #436 used Pico’s full-width form grid, so homepage and person pages opened with a bulky From/To form instead of the old compact period control.

## Solution
Replace that form with a compact toolbar: preset pills plus inline From/To/Apply. Preset pills submit `days`; Apply submits `start`/`end`. Date fields stay empty on a preset so Apply cannot silently widen a rolling window.

## To Test
- Open `/` and confirm 7d/30d/90d sit on one row with From/To/Apply.
- Switch a preset and confirm the URL uses `?days=` with empty date fields.
- Apply a custom range and confirm the URL uses `start`/`end` with no pill selected.
- Open a person page and confirm the 1d/7d/30d toolbar above the stats cards is the same compact row.

## Proof
Homepage default 30d toolbar:

![Homepage time-window toolbar](https://github.com/user-attachments/assets/6f69021b-4c30-411c-b263-9df90dca8a7c)

Custom Jan 1–31 range, no preset selected:

![Custom date-range toolbar](https://github.com/user-attachments/assets/f69d60e8-e3e8-4073-a9da-a49fa7ccaed3)

Person page 1d/7d/30d toolbar:

![Person page time-window toolbar](https://github.com/user-attachments/assets/7ff20030-f668-4768-aed8-73a1e04ea676)