### PR TITLE
Show person-page stdevs versus the engineering group

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,7 +38,7 @@ from linear.issues import (
     get_time_data,
 )
 from linear.projects import get_projects
-from person_stats import metric_stdevs_for_person, person_card_metrics
+from person_stats import issue_card_values, metric_stdevs_for_person
 from project_dates import (
     format_project_start_status,
     format_project_target_status,
@@ -178,69 +178,6 @@ def format_average_project_schedule_variance(
 
     direction = "late" if average_variance_days > 0 else "early"
     return f"{display}d {direction}"
-
-
-def _normalize_person_name(value: str | None) -> str:
-    if not value:
-        return ""
-    cleaned = value.replace(".", " ").replace("-", " ").strip()
-    return re.sub(r"\s+", " ", cleaned).lower()
-
-
-def _person_display_name(person_cfg: dict[str, Any], slug: str) -> str:
-    login = person_cfg.get("linear_username", slug)
-    return str(login).replace(".", " ").replace("-", " ").title()
-
-
-def _engineering_people(config: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    people = config.get("people", {})
-    return {
-        slug: info for slug, info in people.items() if info.get("team") == ENGINEERING_TEAM_SLUG
-    }
-
-
-def _configured_github_username(person_cfg: dict[str, Any]) -> str | None:
-    raw_github_username = person_cfg.get("github_username")
-    if isinstance(raw_github_username, str) and raw_github_username:
-        return raw_github_username
-    return None
-
-
-def _led_projects_for_person(
-    cycle_projects: list[dict[str, Any]], person_cfg: dict[str, Any], slug: str
-) -> list[dict[str, Any]]:
-    person_name = _person_display_name(person_cfg, slug)
-    normalized_person_name = _normalize_person_name(
-        person_cfg.get("linear_display_name") or person_name
-    )
-    return [
-        project
-        for project in cycle_projects
-        if _normalize_person_name((project.get("lead") or {}).get("displayName"))
-        == normalized_person_name
-    ]
-
-
-def _lead_project_metrics(
-    led_projects: list[dict[str, Any]],
-) -> tuple[int, int, int, float | None]:
-    lead_completed_projects = sum(1 for project in led_projects if is_completed_project(project))
-    lead_incomplete_projects = sum(1 for project in led_projects if is_incomplete_project(project))
-    lead_current_projects = sum(1 for project in led_projects if not project.get("is_inactive"))
-    variances = [
-        variance_days
-        for project in led_projects
-        if is_completed_project(project)
-        for variance_days in [get_project_schedule_variance_days(project)]
-        if variance_days is not None
-    ]
-    average_variance = sum(variances) / len(variances) if variances else None
-    return (
-        lead_current_projects,
-        lead_completed_projects,
-        lead_incomplete_projects,
-        average_variance,
-    )
 
 
 app = Flask(__name__)
@@ -1392,31 +1329,6 @@ def _build_team_context(_cache_epoch: int) -> dict:
     }
 
 
-def _card_metrics_for_config_person(
-    slug: str,
-    person_cfg: dict[str, Any],
-    completed_items: list[dict[str, Any]],
-    cycle_projects: list[dict[str, Any]],
-    prs_merged: int,
-    prs_reviewed: int,
-) -> dict[str, float | int | None]:
-    (
-        lead_current_projects,
-        lead_completed_projects,
-        lead_incomplete_projects,
-        average_completed_project_variance,
-    ) = _lead_project_metrics(_led_projects_for_person(cycle_projects, person_cfg, slug))
-    return person_card_metrics(
-        prs_merged=prs_merged,
-        prs_reviewed=prs_reviewed,
-        completed_items=completed_items,
-        lead_current_projects=lead_current_projects,
-        lead_completed_projects=lead_completed_projects,
-        lead_incomplete_projects=lead_incomplete_projects,
-        average_completed_project_variance=average_completed_project_variance,
-    )
-
-
 @lru_cache(maxsize=INDEX_CONTEXT_CACHE_MAXSIZE)
 def _build_person_context(
     slug: str,
@@ -1430,16 +1342,31 @@ def _build_person_context(
     config = load_config()
     person_cfg = config.get("people", {}).get(slug) or {}
     login = person_cfg.get("linear_username", slug)
-    person_name = _person_display_name(person_cfg, slug)
-    github_username = _configured_github_username(person_cfg)
-    engineering_people = _engineering_people(config)
+    person_name = login.replace(".", " ").replace("-", " ").title()
+    raw_github_username = person_cfg.get("github_username")
+    github_username = (
+        raw_github_username
+        if isinstance(raw_github_username, str) and raw_github_username
+        else None
+    )
+    engineering_people = {
+        key: info
+        for key, info in config.get("people", {}).items()
+        if info.get("team") == ENGINEERING_TEAM_SLUG
+    }
     other_engineers = {key: info for key, info in engineering_people.items() if key != slug}
     extra_workers = 0
     if len(engineering_people) >= 2:
         extra_workers = len(other_engineers) + sum(
-            1 for info in other_engineers.values() if _configured_github_username(info)
+            1
+            for info in other_engineers.values()
+            if isinstance(info.get("github_username"), str) and info.get("github_username")
         )
-    with ThreadPoolExecutor(max_workers=TEAM_THREADPOOL_MAX_WORKERS + extra_workers) as executor:
+    other_completed_futures: dict[str, Future[list[dict[str, Any]]]] = {}
+    other_github_futures: dict[str, Future[tuple[int, int]]] = {}
+    with ThreadPoolExecutor(
+        max_workers=min(INDEX_THREADPOOL_MAX_WORKERS, TEAM_THREADPOOL_MAX_WORKERS + extra_workers)
+    ) as executor:
         open_future = executor.submit(get_open_issues_for_person, login)
         completed_future = executor.submit(get_completed_issues_for_person, login, days, window)
         projects_future = executor.submit(get_projects)
@@ -1451,19 +1378,16 @@ def _build_person_context(
                 days,
                 window,
             )
-        other_completed_futures: dict[str, Future[list[dict[str, Any]]]] = {}
-        other_github_futures: dict[str, Future[tuple[int, int]]] = {}
         if len(engineering_people) >= 2:
             for other_slug, info in other_engineers.items():
-                other_login = info.get("linear_username", other_slug)
                 other_completed_futures[other_slug] = executor.submit(
                     get_completed_issues_for_person,
-                    other_login,
+                    info.get("linear_username", other_slug),
                     days,
                     window,
                 )
-                other_github_username = _configured_github_username(info)
-                if other_github_username:
+                other_github_username = info.get("github_username")
+                if isinstance(other_github_username, str) and other_github_username:
                     other_github_futures[other_slug] = executor.submit(
                         get_merged_pr_counts_for_user,
                         other_github_username,
@@ -1486,61 +1410,35 @@ def _build_person_context(
         else:
             prs_merged = prs_reviewed = 0
 
-        _annotate_project_schedule_fields(cycle_projects)
-        for proj in cycle_projects:
-            proj["is_inactive"] = is_inactive_project(proj)
+    priority_fix_times = []
+    priority_bugs_fixed = 0
+    for issue in completed_items:
+        is_priority_bug = issue.get("priority", 5) <= 2 and any(
+            lbl.get("name") == "Bug" for lbl in issue.get("labels", {}).get("nodes", [])
+        )
+        if not is_priority_bug:
+            continue
+        priority_bugs_fixed += 1
+        if issue.get("assignee_time_to_fix") is not None:
+            fix_time = issue["assignee_time_to_fix"]
+            priority_fix_times.append(fix_time)
 
-        team_metrics = []
-        for other_slug, info in other_engineers.items():
-            completed_future_for_other = other_completed_futures.get(other_slug)
-            if completed_future_for_other is None:
-                continue
-            try:
-                other_completed = completed_future_for_other.result(
-                    timeout=EXECUTOR_TIMEOUT_SECONDS
-                )
-            except Exception:
-                logging.exception(
-                    "Failed to load completed issues for %s while computing person stdevs",
-                    other_slug,
-                )
-                continue
-            other_github_future = other_github_futures.get(other_slug)
-            if other_github_future is not None:
-                try:
-                    other_prs_merged, other_prs_reviewed = other_github_future.result(
-                        timeout=EXECUTOR_TIMEOUT_SECONDS
-                    )
-                except Exception:
-                    logging.exception(
-                        "Failed to load GitHub counts for %s while computing person stdevs",
-                        other_slug,
-                    )
-                    other_prs_merged = other_prs_reviewed = 0
-            else:
-                other_prs_merged = other_prs_reviewed = 0
-            team_metrics.append(
-                _card_metrics_for_config_person(
-                    other_slug,
-                    info,
-                    other_completed,
-                    cycle_projects,
-                    other_prs_merged,
-                    other_prs_reviewed,
-                )
-            )
+    if priority_fix_times:
+        avg_priority_bug_fix = int(sum(priority_fix_times) / len(priority_fix_times))
+    else:
+        avg_priority_bug_fix = None
 
-    current_metrics = _card_metrics_for_config_person(
-        slug,
-        person_cfg,
-        completed_items,
-        cycle_projects,
-        prs_merged,
-        prs_reviewed,
-    )
-    if slug in engineering_people:
-        team_metrics.append(current_metrics)
-    metric_stdevs = metric_stdevs_for_person(current_metrics, team_metrics)
+    # Compute metrics for all completed work
+    all_work_done = len(completed_items)
+    all_fix_times = [
+        issue["assignee_time_to_fix"]
+        for issue in completed_items
+        if issue.get("assignee_time_to_fix") is not None
+    ]
+    if all_fix_times:
+        avg_all_time_to_fix = int(sum(all_fix_times) / len(all_fix_times))
+    else:
+        avg_all_time_to_fix = None
 
     # Group open and completed items by project
     open_by_project = by_project(open_items)
@@ -1550,6 +1448,107 @@ def _build_person_context(
         issues.sort(key=lambda x: x["updatedAt"], reverse=True)
     for issues in completed_by_project.values():
         issues.sort(key=lambda x: x["completedAt"], reverse=True)
+
+    # Annotate the projects fetched alongside issue and GitHub data.
+    _annotate_project_schedule_fields(cycle_projects)
+    for proj in cycle_projects:
+        proj["is_inactive"] = is_inactive_project(proj)
+
+    def _normalize_text(value: str | None) -> str:
+        if not value:
+            return ""
+        cleaned = value.replace(".", " ").replace("-", " ").strip()
+        return re.sub(r"\s+", " ", cleaned).lower()
+
+    def normalize_display_name(value: str | None) -> str:
+        return _normalize_text(value)
+
+    normalized_person_name = normalize_display_name(
+        person_cfg.get("linear_display_name") or person_name
+    )
+    led_projects = [
+        project
+        for project in cycle_projects
+        if normalize_display_name((project.get("lead") or {}).get("displayName"))
+        == normalized_person_name
+    ]
+    lead_completed_projects = sum(1 for project in led_projects if is_completed_project(project))
+    lead_incomplete_projects = sum(1 for project in led_projects if is_incomplete_project(project))
+    lead_current_projects = sum(1 for project in led_projects if not project.get("is_inactive"))
+    lead_completed_project_variances = [
+        variance_days
+        for project in led_projects
+        if is_completed_project(project)
+        for variance_days in [get_project_schedule_variance_days(project)]
+        if variance_days is not None
+    ]
+    if lead_completed_project_variances:
+        average_completed_project_variance = sum(lead_completed_project_variances) / len(
+            lead_completed_project_variances
+        )
+    else:
+        average_completed_project_variance = None
+
+    current_metrics = {
+        "prs_merged": prs_merged,
+        "prs_reviewed": prs_reviewed,
+        **issue_card_values(completed_items),
+        "lead_current_projects": lead_current_projects,
+        "lead_completed_projects": lead_completed_projects,
+        "lead_incomplete_projects": lead_incomplete_projects,
+        "lead_completed_projects_avg_early_late": average_completed_project_variance,
+    }
+    team_metrics = [current_metrics] if slug in engineering_people else []
+    for other_slug, info in other_engineers.items():
+        completed_future_for_other = other_completed_futures.get(other_slug)
+        if completed_future_for_other is None:
+            continue
+        try:
+            other_completed = completed_future_for_other.result(timeout=EXECUTOR_TIMEOUT_SECONDS)
+        except TimeoutError:
+            continue
+        other_github_future = other_github_futures.get(other_slug)
+        other_prs_merged, other_prs_reviewed = (
+            get_future_result_with_timeout(other_github_future, (0, 0), EXECUTOR_TIMEOUT_SECONDS)
+            if other_github_future is not None
+            else (0, 0)
+        )
+        other_name = (
+            str(info.get("linear_username", other_slug)).replace(".", " ").replace("-", " ").title()
+        )
+        other_led = [
+            project
+            for project in cycle_projects
+            if normalize_display_name((project.get("lead") or {}).get("displayName"))
+            == normalize_display_name(info.get("linear_display_name") or other_name)
+        ]
+        other_variances = [
+            variance_days
+            for project in other_led
+            if is_completed_project(project)
+            for variance_days in [get_project_schedule_variance_days(project)]
+            if variance_days is not None
+        ]
+        team_metrics.append(
+            {
+                "prs_merged": other_prs_merged,
+                "prs_reviewed": other_prs_reviewed,
+                **issue_card_values(other_completed),
+                "lead_current_projects": sum(
+                    1 for project in other_led if not project.get("is_inactive")
+                ),
+                "lead_completed_projects": sum(
+                    1 for project in other_led if is_completed_project(project)
+                ),
+                "lead_incomplete_projects": sum(
+                    1 for project in other_led if is_incomplete_project(project)
+                ),
+                "lead_completed_projects_avg_early_late": (
+                    sum(other_variances) / len(other_variances) if other_variances else None
+                ),
+            }
+        )
+    metric_stdevs = metric_stdevs_for_person(current_metrics, team_metrics)
 
     project_names = {proj.get("name") for proj in cycle_projects if proj.get("name")}
 
@@ -1591,17 +1590,17 @@ def _build_person_context(
         "completed_by_project": completed_by_project,
         "on_call_support": on_support,
         "work_by_platform": work_by_platform,
-        "prs_merged": current_metrics["prs_merged"],
-        "prs_reviewed": current_metrics["prs_reviewed"],
-        "priority_bug_avg_time_to_fix": current_metrics["priority_bug_avg_time_to_fix"],
-        "priority_bugs_fixed": current_metrics["priority_bugs_fixed"],
-        "all_work_done": current_metrics["all_work_done"],
-        "avg_all_time_to_fix": current_metrics["avg_all_time_to_fix"],
-        "lead_completed_projects": current_metrics["lead_completed_projects"],
-        "lead_current_projects": current_metrics["lead_current_projects"],
-        "lead_incomplete_projects": current_metrics["lead_incomplete_projects"],
+        "prs_merged": prs_merged,
+        "prs_reviewed": prs_reviewed,
+        "priority_bug_avg_time_to_fix": avg_priority_bug_fix,
+        "priority_bugs_fixed": priority_bugs_fixed,
+        "all_work_done": all_work_done,
+        "avg_all_time_to_fix": avg_all_time_to_fix,
+        "lead_completed_projects": lead_completed_projects,
+        "lead_current_projects": lead_current_projects,
+        "lead_incomplete_projects": lead_incomplete_projects,
         "lead_completed_projects_avg_early_late": format_average_project_schedule_variance(
-            current_metrics["lead_completed_projects_avg_early_late"]
+            average_completed_project_variance
         ),
         "metric_stdevs": metric_stdevs,
         "platform_labels": platform_labels,

--- a/app.py
+++ b/app.py
@@ -38,6 +38,7 @@ from linear.issues import (
     get_time_data,
 )
 from linear.projects import get_projects
+from person_stats import metric_stdevs_for_person, person_card_metrics
 from project_dates import (
     format_project_start_status,
     format_project_target_status,
@@ -177,6 +178,69 @@ def format_average_project_schedule_variance(
 
     direction = "late" if average_variance_days > 0 else "early"
     return f"{display}d {direction}"
+
+
+def _normalize_person_name(value: str | None) -> str:
+    if not value:
+        return ""
+    cleaned = value.replace(".", " ").replace("-", " ").strip()
+    return re.sub(r"\s+", " ", cleaned).lower()
+
+
+def _person_display_name(person_cfg: dict[str, Any], slug: str) -> str:
+    login = person_cfg.get("linear_username", slug)
+    return str(login).replace(".", " ").replace("-", " ").title()
+
+
+def _engineering_people(config: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    people = config.get("people", {})
+    return {
+        slug: info for slug, info in people.items() if info.get("team") == ENGINEERING_TEAM_SLUG
+    }
+
+
+def _configured_github_username(person_cfg: dict[str, Any]) -> str | None:
+    raw_github_username = person_cfg.get("github_username")
+    if isinstance(raw_github_username, str) and raw_github_username:
+        return raw_github_username
+    return None
+
+
+def _led_projects_for_person(
+    cycle_projects: list[dict[str, Any]], person_cfg: dict[str, Any], slug: str
+) -> list[dict[str, Any]]:
+    person_name = _person_display_name(person_cfg, slug)
+    normalized_person_name = _normalize_person_name(
+        person_cfg.get("linear_display_name") or person_name
+    )
+    return [
+        project
+        for project in cycle_projects
+        if _normalize_person_name((project.get("lead") or {}).get("displayName"))
+        == normalized_person_name
+    ]
+
+
+def _lead_project_metrics(
+    led_projects: list[dict[str, Any]],
+) -> tuple[int, int, int, float | None]:
+    lead_completed_projects = sum(1 for project in led_projects if is_completed_project(project))
+    lead_incomplete_projects = sum(1 for project in led_projects if is_incomplete_project(project))
+    lead_current_projects = sum(1 for project in led_projects if not project.get("is_inactive"))
+    variances = [
+        variance_days
+        for project in led_projects
+        if is_completed_project(project)
+        for variance_days in [get_project_schedule_variance_days(project)]
+        if variance_days is not None
+    ]
+    average_variance = sum(variances) / len(variances) if variances else None
+    return (
+        lead_current_projects,
+        lead_completed_projects,
+        lead_incomplete_projects,
+        average_variance,
+    )
 
 
 app = Flask(__name__)
@@ -1328,6 +1392,31 @@ def _build_team_context(_cache_epoch: int) -> dict:
     }
 
 
+def _card_metrics_for_config_person(
+    slug: str,
+    person_cfg: dict[str, Any],
+    completed_items: list[dict[str, Any]],
+    cycle_projects: list[dict[str, Any]],
+    prs_merged: int,
+    prs_reviewed: int,
+) -> dict[str, float | int | None]:
+    (
+        lead_current_projects,
+        lead_completed_projects,
+        lead_incomplete_projects,
+        average_completed_project_variance,
+    ) = _lead_project_metrics(_led_projects_for_person(cycle_projects, person_cfg, slug))
+    return person_card_metrics(
+        prs_merged=prs_merged,
+        prs_reviewed=prs_reviewed,
+        completed_items=completed_items,
+        lead_current_projects=lead_current_projects,
+        lead_completed_projects=lead_completed_projects,
+        lead_incomplete_projects=lead_incomplete_projects,
+        average_completed_project_variance=average_completed_project_variance,
+    )
+
+
 @lru_cache(maxsize=INDEX_CONTEXT_CACHE_MAXSIZE)
 def _build_person_context(
     slug: str,
@@ -1341,14 +1430,16 @@ def _build_person_context(
     config = load_config()
     person_cfg = config.get("people", {}).get(slug) or {}
     login = person_cfg.get("linear_username", slug)
-    person_name = login.replace(".", " ").replace("-", " ").title()
-    raw_github_username = person_cfg.get("github_username")
-    github_username = (
-        raw_github_username
-        if isinstance(raw_github_username, str) and raw_github_username
-        else None
-    )
-    with ThreadPoolExecutor(max_workers=TEAM_THREADPOOL_MAX_WORKERS) as executor:
+    person_name = _person_display_name(person_cfg, slug)
+    github_username = _configured_github_username(person_cfg)
+    engineering_people = _engineering_people(config)
+    other_engineers = {key: info for key, info in engineering_people.items() if key != slug}
+    extra_workers = 0
+    if len(engineering_people) >= 2:
+        extra_workers = len(other_engineers) + sum(
+            1 for info in other_engineers.values() if _configured_github_username(info)
+        )
+    with ThreadPoolExecutor(max_workers=TEAM_THREADPOOL_MAX_WORKERS + extra_workers) as executor:
         open_future = executor.submit(get_open_issues_for_person, login)
         completed_future = executor.submit(get_completed_issues_for_person, login, days, window)
         projects_future = executor.submit(get_projects)
@@ -1360,6 +1451,25 @@ def _build_person_context(
                 days,
                 window,
             )
+        other_completed_futures: dict[str, Future[list[dict[str, Any]]]] = {}
+        other_github_futures: dict[str, Future[tuple[int, int]]] = {}
+        if len(engineering_people) >= 2:
+            for other_slug, info in other_engineers.items():
+                other_login = info.get("linear_username", other_slug)
+                other_completed_futures[other_slug] = executor.submit(
+                    get_completed_issues_for_person,
+                    other_login,
+                    days,
+                    window,
+                )
+                other_github_username = _configured_github_username(info)
+                if other_github_username:
+                    other_github_futures[other_slug] = executor.submit(
+                        get_merged_pr_counts_for_user,
+                        other_github_username,
+                        days,
+                        window,
+                    )
         open_items = sorted(
             open_future.result(timeout=EXECUTOR_TIMEOUT_SECONDS),
             key=lambda x: x["updatedAt"],
@@ -1376,35 +1486,61 @@ def _build_person_context(
         else:
             prs_merged = prs_reviewed = 0
 
-    priority_fix_times = []
-    priority_bugs_fixed = 0
-    for issue in completed_items:
-        is_priority_bug = issue.get("priority", 5) <= 2 and any(
-            lbl.get("name") == "Bug" for lbl in issue.get("labels", {}).get("nodes", [])
-        )
-        if not is_priority_bug:
-            continue
-        priority_bugs_fixed += 1
-        if issue.get("assignee_time_to_fix") is not None:
-            fix_time = issue["assignee_time_to_fix"]
-            priority_fix_times.append(fix_time)
+        _annotate_project_schedule_fields(cycle_projects)
+        for proj in cycle_projects:
+            proj["is_inactive"] = is_inactive_project(proj)
 
-    if priority_fix_times:
-        avg_priority_bug_fix = int(sum(priority_fix_times) / len(priority_fix_times))
-    else:
-        avg_priority_bug_fix = None
+        team_metrics = []
+        for other_slug, info in other_engineers.items():
+            completed_future_for_other = other_completed_futures.get(other_slug)
+            if completed_future_for_other is None:
+                continue
+            try:
+                other_completed = completed_future_for_other.result(
+                    timeout=EXECUTOR_TIMEOUT_SECONDS
+                )
+            except Exception:
+                logging.exception(
+                    "Failed to load completed issues for %s while computing person stdevs",
+                    other_slug,
+                )
+                continue
+            other_github_future = other_github_futures.get(other_slug)
+            if other_github_future is not None:
+                try:
+                    other_prs_merged, other_prs_reviewed = other_github_future.result(
+                        timeout=EXECUTOR_TIMEOUT_SECONDS
+                    )
+                except Exception:
+                    logging.exception(
+                        "Failed to load GitHub counts for %s while computing person stdevs",
+                        other_slug,
+                    )
+                    other_prs_merged = other_prs_reviewed = 0
+            else:
+                other_prs_merged = other_prs_reviewed = 0
+            team_metrics.append(
+                _card_metrics_for_config_person(
+                    other_slug,
+                    info,
+                    other_completed,
+                    cycle_projects,
+                    other_prs_merged,
+                    other_prs_reviewed,
+                )
+            )
 
-    # Compute metrics for all completed work
-    all_work_done = len(completed_items)
-    all_fix_times = [
-        issue["assignee_time_to_fix"]
-        for issue in completed_items
-        if issue.get("assignee_time_to_fix") is not None
-    ]
-    if all_fix_times:
-        avg_all_time_to_fix = int(sum(all_fix_times) / len(all_fix_times))
-    else:
-        avg_all_time_to_fix = None
+    current_metrics = _card_metrics_for_config_person(
+        slug,
+        person_cfg,
+        completed_items,
+        cycle_projects,
+        prs_merged,
+        prs_reviewed,
+    )
+    if slug in engineering_people:
+        team_metrics.append(current_metrics)
+    metric_stdevs = metric_stdevs_for_person(current_metrics, team_metrics)
 
     # Group open and completed items by project
     open_by_project = by_project(open_items)
@@ -1414,46 +1550,6 @@ def _build_person_context(
         issues.sort(key=lambda x: x["updatedAt"], reverse=True)
     for issues in completed_by_project.values():
         issues.sort(key=lambda x: x["completedAt"], reverse=True)
-
-    # Annotate the projects fetched alongside issue and GitHub data.
-    _annotate_project_schedule_fields(cycle_projects)
-    for proj in cycle_projects:
-        proj["is_inactive"] = is_inactive_project(proj)
-
-    def _normalize_text(value: str | None) -> str:
-        if not value:
-            return ""
-        cleaned = value.replace(".", " ").replace("-", " ").strip()
-        return re.sub(r"\s+", " ", cleaned).lower()
-
-    def normalize_display_name(value: str | None) -> str:
-        return _normalize_text(value)
-
-    normalized_person_name = normalize_display_name(
-        person_cfg.get("linear_display_name") or person_name
-    )
-    led_projects = [
-        project
-        for project in cycle_projects
-        if normalize_display_name((project.get("lead") or {}).get("displayName"))
-        == normalized_person_name
-    ]
-    lead_completed_projects = sum(1 for project in led_projects if is_completed_project(project))
-    lead_incomplete_projects = sum(1 for project in led_projects if is_incomplete_project(project))
-    lead_current_projects = sum(1 for project in led_projects if not project.get("is_inactive"))
-    lead_completed_project_variances = [
-        variance_days
-        for project in led_projects
-        if is_completed_project(project)
-        for variance_days in [get_project_schedule_variance_days(project)]
-        if variance_days is not None
-    ]
-    if lead_completed_project_variances:
-        average_completed_project_variance = sum(lead_completed_project_variances) / len(
-            lead_completed_project_variances
-        )
-    else:
-        average_completed_project_variance = None
 
     project_names = {proj.get("name") for proj in cycle_projects if proj.get("name")}
 
@@ -1495,18 +1591,19 @@ def _build_person_context(
         "completed_by_project": completed_by_project,
         "on_call_support": on_support,
         "work_by_platform": work_by_platform,
-        "prs_merged": prs_merged,
-        "prs_reviewed": prs_reviewed,
-        "priority_bug_avg_time_to_fix": avg_priority_bug_fix,
-        "priority_bugs_fixed": priority_bugs_fixed,
-        "all_work_done": all_work_done,
-        "avg_all_time_to_fix": avg_all_time_to_fix,
-        "lead_completed_projects": lead_completed_projects,
-        "lead_current_projects": lead_current_projects,
-        "lead_incomplete_projects": lead_incomplete_projects,
+        "prs_merged": current_metrics["prs_merged"],
+        "prs_reviewed": current_metrics["prs_reviewed"],
+        "priority_bug_avg_time_to_fix": current_metrics["priority_bug_avg_time_to_fix"],
+        "priority_bugs_fixed": current_metrics["priority_bugs_fixed"],
+        "all_work_done": current_metrics["all_work_done"],
+        "avg_all_time_to_fix": current_metrics["avg_all_time_to_fix"],
+        "lead_completed_projects": current_metrics["lead_completed_projects"],
+        "lead_current_projects": current_metrics["lead_current_projects"],
+        "lead_incomplete_projects": current_metrics["lead_incomplete_projects"],
         "lead_completed_projects_avg_early_late": format_average_project_schedule_variance(
-            average_completed_project_variance
+            current_metrics["lead_completed_projects_avg_early_late"]
         ),
+        "metric_stdevs": metric_stdevs,
         "platform_labels": platform_labels,
         "platform_values": platform_values,
     }

--- a/person_stats.py
+++ b/person_stats.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import statistics
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+CARD_METRIC_KEYS = (
+    "prs_merged",
+    "prs_reviewed",
+    "priority_bugs_fixed",
+    "priority_bug_avg_time_to_fix",
+    "all_work_done",
+    "avg_all_time_to_fix",
+    "lead_current_projects",
+    "lead_completed_projects",
+    "lead_incomplete_projects",
+    "lead_completed_projects_avg_early_late",
+)
+
+MetricValue = float | int | None
+PersonCardMetrics = dict[str, MetricValue]
+
+
+def _is_priority_bug(issue: dict[str, Any]) -> bool:
+    if issue.get("priority", 5) > 2:
+        return False
+    return any(lbl.get("name") == "Bug" for lbl in issue.get("labels", {}).get("nodes", []))
+
+
+def completed_work_metrics(completed_items: list[dict[str, Any]]) -> PersonCardMetrics:
+    priority_fix_times: list[Any] = []
+    priority_bugs_fixed = 0
+    for issue in completed_items:
+        if not _is_priority_bug(issue):
+            continue
+        priority_bugs_fixed += 1
+        if issue.get("assignee_time_to_fix") is not None:
+            priority_fix_times.append(issue["assignee_time_to_fix"])
+
+    all_fix_times = [
+        issue["assignee_time_to_fix"]
+        for issue in completed_items
+        if issue.get("assignee_time_to_fix") is not None
+    ]
+    return {
+        "priority_bugs_fixed": priority_bugs_fixed,
+        "priority_bug_avg_time_to_fix": (
+            int(sum(priority_fix_times) / len(priority_fix_times)) if priority_fix_times else None
+        ),
+        "all_work_done": len(completed_items),
+        "avg_all_time_to_fix": (
+            int(sum(all_fix_times) / len(all_fix_times)) if all_fix_times else None
+        ),
+    }
+
+
+def person_card_metrics(
+    *,
+    prs_merged: int,
+    prs_reviewed: int,
+    completed_items: list[dict[str, Any]],
+    lead_current_projects: int,
+    lead_completed_projects: int,
+    lead_incomplete_projects: int,
+    average_completed_project_variance: float | None,
+) -> PersonCardMetrics:
+    return {
+        "prs_merged": prs_merged,
+        "prs_reviewed": prs_reviewed,
+        **completed_work_metrics(completed_items),
+        "lead_current_projects": lead_current_projects,
+        "lead_completed_projects": lead_completed_projects,
+        "lead_incomplete_projects": lead_incomplete_projects,
+        "lead_completed_projects_avg_early_late": average_completed_project_variance,
+    }
+
+
+def z_score(value: float, values: list[float]) -> float | None:
+    if len(values) < 2:
+        return None
+    stdev = statistics.pstdev(values)
+    if stdev == 0:
+        return 0.0
+    return (value - statistics.fmean(values)) / stdev
+
+
+def format_stdev_label(z: float) -> str:
+    if abs(z) < 0.05:
+        return "0.0σ"
+    sign = "+" if z > 0 else "−"
+    return f"{sign}{abs(z):.1f}σ"
+
+
+def format_stdev_tooltip(z: float, values: list[float]) -> str:
+    mean = statistics.fmean(values)
+    stdev = statistics.pstdev(values)
+    summary = f"mean {mean:.1f}, σ {stdev:.1f}"
+    if abs(z) < 0.05:
+        return f"0.0σ from the engineering group average ({summary})"
+    direction = "above" if z > 0 else "below"
+    return f"{abs(z):.1f}σ {direction} the engineering group average ({summary})"
+
+
+def metric_stdevs_for_person(
+    person_metrics: Mapping[str, MetricValue],
+    team_metrics: Iterable[Mapping[str, MetricValue]],
+) -> dict[str, dict[str, str]]:
+    team_list = list(team_metrics)
+    result: dict[str, dict[str, str]] = {}
+    for key in CARD_METRIC_KEYS:
+        person_value = person_metrics.get(key)
+        if person_value is None:
+            continue
+        values = [float(value) for metrics in team_list if (value := metrics.get(key)) is not None]
+        z = z_score(float(person_value), values)
+        if z is None:
+            continue
+        result[key] = {
+            "label": format_stdev_label(z),
+            "tooltip": format_stdev_tooltip(z, values),
+        }
+    return result

--- a/person_stats.py
+++ b/person_stats.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import statistics
 from collections.abc import Iterable, Mapping
-from typing import Any
 
 CARD_METRIC_KEYS = (
     "prs_merged",
@@ -18,60 +17,26 @@ CARD_METRIC_KEYS = (
 )
 
 MetricValue = float | int | None
-PersonCardMetrics = dict[str, MetricValue]
 
 
-def _is_priority_bug(issue: dict[str, Any]) -> bool:
-    if issue.get("priority", 5) > 2:
-        return False
-    return any(lbl.get("name") == "Bug" for lbl in issue.get("labels", {}).get("nodes", []))
-
-
-def completed_work_metrics(completed_items: list[dict[str, Any]]) -> PersonCardMetrics:
-    priority_fix_times: list[Any] = []
-    priority_bugs_fixed = 0
-    for issue in completed_items:
-        if not _is_priority_bug(issue):
-            continue
-        priority_bugs_fixed += 1
-        if issue.get("assignee_time_to_fix") is not None:
-            priority_fix_times.append(issue["assignee_time_to_fix"])
-
-    all_fix_times = [
-        issue["assignee_time_to_fix"]
-        for issue in completed_items
-        if issue.get("assignee_time_to_fix") is not None
+def issue_card_values(items: list[dict]) -> dict[str, MetricValue]:
+    bugs = [
+        issue
+        for issue in items
+        if issue.get("priority", 5) <= 2
+        and any(lbl.get("name") == "Bug" for lbl in issue.get("labels", {}).get("nodes", []))
     ]
+    bug_times = [
+        i["assignee_time_to_fix"] for i in bugs if i.get("assignee_time_to_fix") is not None
+    ]
+    times = [i["assignee_time_to_fix"] for i in items if i.get("assignee_time_to_fix") is not None]
     return {
-        "priority_bugs_fixed": priority_bugs_fixed,
+        "priority_bugs_fixed": len(bugs),
         "priority_bug_avg_time_to_fix": (
-            int(sum(priority_fix_times) / len(priority_fix_times)) if priority_fix_times else None
+            int(sum(bug_times) / len(bug_times)) if bug_times else None
         ),
-        "all_work_done": len(completed_items),
-        "avg_all_time_to_fix": (
-            int(sum(all_fix_times) / len(all_fix_times)) if all_fix_times else None
-        ),
-    }
-
-
-def person_card_metrics(
-    *,
-    prs_merged: int,
-    prs_reviewed: int,
-    completed_items: list[dict[str, Any]],
-    lead_current_projects: int,
-    lead_completed_projects: int,
-    lead_incomplete_projects: int,
-    average_completed_project_variance: float | None,
-) -> PersonCardMetrics:
-    return {
-        "prs_merged": prs_merged,
-        "prs_reviewed": prs_reviewed,
-        **completed_work_metrics(completed_items),
-        "lead_current_projects": lead_current_projects,
-        "lead_completed_projects": lead_completed_projects,
-        "lead_incomplete_projects": lead_incomplete_projects,
-        "lead_completed_projects_avg_early_late": average_completed_project_variance,
+        "all_work_done": len(items),
+        "avg_all_time_to_fix": int(sum(times) / len(times)) if times else None,
     }
 
 
@@ -80,7 +45,7 @@ def z_score(value: float, values: list[float]) -> float | None:
         return None
     stdev = statistics.pstdev(values)
     if stdev == 0:
-        return 0.0
+        return None
     return (value - statistics.fmean(values)) / stdev
 
 
@@ -91,14 +56,8 @@ def format_stdev_label(z: float) -> str:
     return f"{sign}{abs(z):.1f}σ"
 
 
-def format_stdev_tooltip(z: float, values: list[float]) -> str:
-    mean = statistics.fmean(values)
-    stdev = statistics.pstdev(values)
-    summary = f"mean {mean:.1f}, σ {stdev:.1f}"
-    if abs(z) < 0.05:
-        return f"0.0σ from the engineering group average ({summary})"
-    direction = "above" if z > 0 else "below"
-    return f"{abs(z):.1f}σ {direction} the engineering group average ({summary})"
+def format_stdev_tooltip(values: list[float]) -> str:
+    return f"eng avg {statistics.fmean(values):.1f} · σ {statistics.pstdev(values):.1f}"
 
 
 def metric_stdevs_for_person(
@@ -117,6 +76,6 @@ def metric_stdevs_for_person(
             continue
         result[key] = {
             "label": format_stdev_label(z),
-            "tooltip": format_stdev_tooltip(z, values),
+            "tooltip": format_stdev_tooltip(values),
         }
     return result

--- a/static/styles.css
+++ b/static/styles.css
@@ -245,3 +245,13 @@ details.dropdown.site-menu > summary + ul {
   margin-right: 0.25rem; vertical-align: -0.04rem; width: 0.9rem;
 }
 .project-timeline-ooo-unavailable { color: #b83a3a; }
+
+.metric-stdev {
+  color: var(--pico-muted-color);
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  margin-top: 0.15rem;
+  opacity: 0.7;
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -255,3 +255,10 @@ details.dropdown.site-menu > summary + ul {
   margin-top: 0.15rem;
   opacity: 0.7;
 }
+
+.metric-stdev[data-tooltip]::before {
+  max-width: min(12rem, calc(100vw - 2rem));
+  overflow: hidden;
+  text-align: left;
+  white-space: normal;
+}

--- a/templates/partials/person_content.html
+++ b/templates/partials/person_content.html
@@ -1,7 +1,7 @@
 {% macro stdev_badge(key) -%}
   {%- set stat = (metric_stdevs or {}).get(key) -%}
   {%- if stat -%}
-  <small class="metric-stdev" data-tooltip="{{ stat.tooltip }}">{{ stat.label }}</small>
+  <small class="metric-stdev" data-tooltip="{{ stat.tooltip }}" data-placement="bottom">{{ stat.label }}</small>
   {%- endif -%}
 {%- endmacro %}
 <h2>{{ 'Current Support Work' if on_call_support else 'Current Project Work' }}</h2>

--- a/templates/partials/person_content.html
+++ b/templates/partials/person_content.html
@@ -1,3 +1,9 @@
+{% macro stdev_badge(key) -%}
+  {%- set stat = (metric_stdevs or {}).get(key) -%}
+  {%- if stat -%}
+  <small class="metric-stdev" data-tooltip="{{ stat.tooltip }}">{{ stat.label }}</small>
+  {%- endif -%}
+{%- endmacro %}
 <h2>{{ 'Current Support Work' if on_call_support else 'Current Project Work' }}</h2>
 {% if open_current_cycle %}
 {% for project, issues in open_current_cycle.items() %}
@@ -46,12 +52,14 @@
         {% endif %}
       </header>
       <h1>{{ prs_merged }}</h1>
+      {{ stdev_badge('prs_merged') }}
     </article>
   </div>
   <div>
     <article>
       <header>PRs Reviewed</header>
       <h1>{{ prs_reviewed }}</h1>
+      {{ stdev_badge('prs_reviewed') }}
     </article>
   </div>
 </div>
@@ -60,6 +68,7 @@
     <article>
       <header><a href="https://linear.app/differential/view/sla-issues-7e2098ebf79e">Priority Bugs Fixed</a></header>
       <h1>{{ priority_bugs_fixed }}</h1>
+      {{ stdev_badge('priority_bugs_fixed') }}
     </article>
   </div>
   <div>
@@ -70,6 +79,7 @@
       {% else %}
       <h1>n/a</h1>
       {% endif %}
+      {{ stdev_badge('priority_bug_avg_time_to_fix') }}
     </article>
   </div>
 </div>
@@ -87,6 +97,7 @@
       <h1{% if days >= 7 and rate < 2 %} class="low"{% elif days >= 7 and rate >= 5 %} class="high"{% endif %}>
         {{ all_work_done }}
       </h1>
+      {{ stdev_badge('all_work_done') }}
     </article>
   </div>
   <div>
@@ -97,6 +108,7 @@
       {% else %}
       <h1>n/a</h1>
       {% endif %}
+      {{ stdev_badge('avg_all_time_to_fix') }}
     </article>
   </div>
 </div>
@@ -105,18 +117,21 @@
     <article>
       <header><a href="https://linear.app/differential/projects/all">Current Projects</a></header>
       <h1>{{ lead_current_projects }}</h1>
+      {{ stdev_badge('lead_current_projects') }}
     </article>
   </div>
   <div>
     <article>
       <header><a href="https://linear.app/differential/projects/all">Completed Projects</a></header>
       <h1>{{ lead_completed_projects }}</h1>
+      {{ stdev_badge('lead_completed_projects') }}
     </article>
   </div>
   <div>
     <article>
       <header><a href="https://linear.app/differential/projects/all">Incomplete Projects</a></header>
       <h1>{{ lead_incomplete_projects }}</h1>
+      {{ stdev_badge('lead_incomplete_projects') }}
     </article>
   </div>
   <div>
@@ -127,6 +142,7 @@
       {% else %}
       <h1>n/a</h1>
       {% endif %}
+      {{ stdev_badge('lead_completed_projects_avg_early_late') }}
     </article>
   </div>
 </div>

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -1,16 +1,16 @@
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 import app as app_module
 import person_stats
 
 
-def _issue(*, priority=4, bug=False, time_to_fix=1):
-    labels = [{"name": "Bug"}] if bug else []
+def _issue(*, priority=4, bug=False):
     return {
         "priority": priority,
-        "labels": {"nodes": labels},
-        "assignee_time_to_fix": time_to_fix,
+        "labels": {"nodes": [{"name": "Bug"}] if bug else []},
+        "assignee_time_to_fix": 1,
         "updatedAt": "2026-01-02T00:00:00.000Z",
         "completedAt": "2026-01-02T00:00:00.000Z",
         "title": "Issue",
@@ -21,71 +21,14 @@ def _issue(*, priority=4, bug=False, time_to_fix=1):
 
 
 class PersonStatsTest(unittest.TestCase):
-    def test_completed_work_metrics_match_person_page_averages(self):
-        issues = [
-            _issue(priority=2, bug=True, time_to_fix=2),
-            _issue(priority=1, bug=True, time_to_fix=4),
-            _issue(priority=4, time_to_fix=9),
-        ]
-
-        metrics = person_stats.completed_work_metrics(issues)
-
-        self.assertEqual(metrics["priority_bugs_fixed"], 2)
-        self.assertEqual(metrics["priority_bug_avg_time_to_fix"], 3)
-        self.assertEqual(metrics["all_work_done"], 3)
-        self.assertEqual(metrics["avg_all_time_to_fix"], 5)
-
-    def test_z_score_uses_population_stdev_and_skips_thin_samples(self):
-        self.assertIsNone(person_stats.z_score(4, [4]))
-        self.assertEqual(person_stats.z_score(4, [4, 4]), 0.0)
+    def test_z_scores_skip_zero_variance_and_keep_copy_short(self):
+        self.assertIsNone(person_stats.z_score(9, [4, 4]))
         self.assertEqual(person_stats.z_score(10, [10, 2]), 1.0)
-        self.assertEqual(person_stats.z_score(2, [10, 2]), -1.0)
+        self.assertEqual(person_stats.format_stdev_tooltip([10, 2]), "eng avg 6.0 · σ 4.0")
 
-    def test_stdev_labels_are_compact(self):
-        self.assertEqual(person_stats.format_stdev_label(1.0), "+1.0σ")
-        self.assertEqual(person_stats.format_stdev_label(-1.04), "−1.0σ")
-        self.assertEqual(person_stats.format_stdev_label(0.01), "0.0σ")
-
-    def test_metric_stdevs_omit_missing_and_single_values(self):
-        person = {
-            "prs_merged": 10,
-            "prs_reviewed": 4,
-            "priority_bugs_fixed": 2,
-            "priority_bug_avg_time_to_fix": 3,
-            "all_work_done": 8,
-            "avg_all_time_to_fix": 5,
-            "lead_current_projects": 0,
-            "lead_completed_projects": 2,
-            "lead_incomplete_projects": 0,
-            "lead_completed_projects_avg_early_late": 0.0,
-        }
-        teammate = {
-            **person,
-            "prs_merged": 2,
-            "prs_reviewed": 0,
-            "priority_bugs_fixed": 0,
-            "priority_bug_avg_time_to_fix": None,
-            "all_work_done": 2,
-            "avg_all_time_to_fix": 1,
-            "lead_completed_projects": 0,
-            "lead_completed_projects_avg_early_late": None,
-        }
-
-        stdevs = person_stats.metric_stdevs_for_person(person, [person, teammate])
-
-        self.assertEqual(stdevs["prs_merged"]["label"], "+1.0σ")
-        self.assertIn("above the engineering group average", stdevs["prs_merged"]["tooltip"])
-        self.assertEqual(stdevs["all_work_done"]["label"], "+1.0σ")
-        self.assertNotIn("priority_bug_avg_time_to_fix", stdevs)
-        self.assertNotIn("lead_completed_projects_avg_early_late", stdevs)
-
-
-class PersonContextStdevsTest(unittest.TestCase):
-    def setUp(self):
+    def test_person_cards_include_on_page_stdev_badges(self):
         app_module._build_person_context.cache_clear()
         self.addCleanup(app_module._build_person_context.cache_clear)
-
-    def test_person_cards_include_engineering_group_stdevs(self):
         config = {
             "people": {
                 "alice": {
@@ -98,121 +41,36 @@ class PersonContextStdevsTest(unittest.TestCase):
                     "linear_username": "bob",
                     "github_username": "bob-gh",
                 },
-                "vinny": {
-                    "team": "unassigned",
-                    "linear_username": "vincent",
-                    "github_username": "vinnyjth",
-                },
             }
         }
-        projects = [
-            {
-                "id": "proj-1",
-                "name": "Shipped",
-                "status": {"name": "Released"},
-                "completedAt": "2026-01-10T00:00:00.000Z",
-                "startDate": "2026-01-01",
-                "targetDate": "2026-01-12",
-                "lead": {"displayName": "Alice"},
-            },
-            {
-                "id": "proj-2",
-                "name": "Also Shipped",
-                "status": {"name": "Completed"},
-                "completedAt": "2026-01-10T00:00:00.000Z",
-                "startDate": "2026-01-01",
-                "targetDate": "2026-01-08",
-                "lead": {"displayName": "Alice"},
-            },
-        ]
-        completed_logins = []
-        github_usernames = []
 
         def fake_completed(login, days=30, window=None):
-            completed_logins.append(login)
-            if login == "alice":
-                return [
-                    _issue(priority=2, bug=True, time_to_fix=2),
-                    _issue(priority=2, bug=True, time_to_fix=4),
-                    *[_issue() for _ in range(6)],
-                ]
-            if login == "bob":
-                return [_issue(), _issue()]
-            raise AssertionError(f"unexpected completed-issues login {login}")
-
-        def fake_pr_counts(username, days=30, window=None):
-            github_usernames.append(username)
-            if username == "alice-gh":
-                return (10, 4)
-            if username == "bob-gh":
-                return (2, 0)
-            raise AssertionError(f"unexpected github username {username}")
+            return (
+                [_issue(priority=2, bug=True), *[_issue() for _ in range(7)]]
+                if login == "alice"
+                else [_issue(), _issue()]
+            )
 
         with (
             patch.object(app_module, "load_config", return_value=config),
             patch.object(app_module, "get_open_issues_for_person", return_value=[]),
             patch.object(app_module, "get_completed_issues_for_person", side_effect=fake_completed),
-            patch.object(app_module, "get_projects", return_value=projects),
-            patch.object(app_module, "get_merged_pr_counts_for_user", side_effect=fake_pr_counts),
-            patch.object(app_module, "get_support_slugs", return_value=set()),
-        ):
-            context = app_module._build_person_context("alice", 30, 1)
-
-        self.assertEqual(sorted(completed_logins), ["alice", "bob"])
-        self.assertEqual(sorted(github_usernames), ["alice-gh", "bob-gh"])
-        self.assertEqual(context["prs_merged"], 10)
-        self.assertEqual(context["all_work_done"], 8)
-        self.assertEqual(context["lead_completed_projects"], 2)
-        self.assertEqual(context["metric_stdevs"]["prs_merged"]["label"], "+1.0σ")
-        self.assertEqual(context["metric_stdevs"]["all_work_done"]["label"], "+1.0σ")
-        self.assertEqual(context["metric_stdevs"]["lead_completed_projects"]["label"], "+1.0σ")
-        self.assertIn(
-            "engineering group average",
-            context["metric_stdevs"]["prs_merged"]["tooltip"],
-        )
-
-        with app_module.app.test_request_context():
-            body = app_module.render_template("partials/person_content.html", **context)
-
-        self.assertIn('class="metric-stdev"', body)
-        self.assertIn("+1.0σ", body)
-        self.assertIn("above the engineering group average", body)
-
-    def test_single_engineer_has_no_stdev_badges(self):
-        config = {
-            "people": {
-                "alice": {
-                    "team": "engineering",
-                    "linear_username": "alice",
-                    "github_username": "alice-gh",
-                }
-            }
-        }
-
-        with (
-            patch.object(app_module, "load_config", return_value=config),
-            patch.object(app_module, "get_open_issues_for_person", return_value=[]),
-            patch.object(app_module, "get_completed_issues_for_person", return_value=[]),
             patch.object(app_module, "get_projects", return_value=[]),
-            patch.object(app_module, "get_merged_pr_counts_for_user", return_value=(3, 1)),
+            patch.object(
+                app_module,
+                "get_merged_pr_counts_for_user",
+                side_effect=lambda username, days=30, window=None: (
+                    (10, 4) if username == "alice-gh" else (2, 0)
+                ),
+            ),
             patch.object(app_module, "get_support_slugs", return_value=set()),
         ):
             context = app_module._build_person_context("alice", 30, 1)
 
-        self.assertEqual(context["metric_stdevs"], {})
+        self.assertEqual(context["metric_stdevs"]["prs_merged"]["tooltip"], "eng avg 6.0 · σ 4.0")
         with app_module.app.test_request_context():
             body = app_module.render_template("partials/person_content.html", **context)
-        self.assertNotIn("metric-stdev", body)
-
-    def test_metric_stdev_styles_stay_subtle(self):
-        with open("static/styles.css") as styles_file:
-            styles = styles_file.read()
-
-        rule = styles.split(".metric-stdev {", 1)[1].split("}", 1)[0]
-        self.assertIn("font-size: 0.7rem;", rule)
-        self.assertIn("opacity: 0.7;", rule)
-        self.assertIn("color: var(--pico-muted-color);", rule)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        self.assertIn('data-placement="bottom"', body)
+        styles = Path(__file__).resolve().parents[1].joinpath("static/styles.css").read_text()
+        self.assertIn("max-width: min(12rem, calc(100vw - 2rem));", styles)
+        self.assertIn("white-space: normal;", styles)

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -1,0 +1,218 @@
+import unittest
+from unittest.mock import patch
+
+import app as app_module
+import person_stats
+
+
+def _issue(*, priority=4, bug=False, time_to_fix=1):
+    labels = [{"name": "Bug"}] if bug else []
+    return {
+        "priority": priority,
+        "labels": {"nodes": labels},
+        "assignee_time_to_fix": time_to_fix,
+        "updatedAt": "2026-01-02T00:00:00.000Z",
+        "completedAt": "2026-01-02T00:00:00.000Z",
+        "title": "Issue",
+        "url": "https://linear.example/issue",
+        "project": None,
+        "platform": None,
+    }
+
+
+class PersonStatsTest(unittest.TestCase):
+    def test_completed_work_metrics_match_person_page_averages(self):
+        issues = [
+            _issue(priority=2, bug=True, time_to_fix=2),
+            _issue(priority=1, bug=True, time_to_fix=4),
+            _issue(priority=4, time_to_fix=9),
+        ]
+
+        metrics = person_stats.completed_work_metrics(issues)
+
+        self.assertEqual(metrics["priority_bugs_fixed"], 2)
+        self.assertEqual(metrics["priority_bug_avg_time_to_fix"], 3)
+        self.assertEqual(metrics["all_work_done"], 3)
+        self.assertEqual(metrics["avg_all_time_to_fix"], 5)
+
+    def test_z_score_uses_population_stdev_and_skips_thin_samples(self):
+        self.assertIsNone(person_stats.z_score(4, [4]))
+        self.assertEqual(person_stats.z_score(4, [4, 4]), 0.0)
+        self.assertEqual(person_stats.z_score(10, [10, 2]), 1.0)
+        self.assertEqual(person_stats.z_score(2, [10, 2]), -1.0)
+
+    def test_stdev_labels_are_compact(self):
+        self.assertEqual(person_stats.format_stdev_label(1.0), "+1.0σ")
+        self.assertEqual(person_stats.format_stdev_label(-1.04), "−1.0σ")
+        self.assertEqual(person_stats.format_stdev_label(0.01), "0.0σ")
+
+    def test_metric_stdevs_omit_missing_and_single_values(self):
+        person = {
+            "prs_merged": 10,
+            "prs_reviewed": 4,
+            "priority_bugs_fixed": 2,
+            "priority_bug_avg_time_to_fix": 3,
+            "all_work_done": 8,
+            "avg_all_time_to_fix": 5,
+            "lead_current_projects": 0,
+            "lead_completed_projects": 2,
+            "lead_incomplete_projects": 0,
+            "lead_completed_projects_avg_early_late": 0.0,
+        }
+        teammate = {
+            **person,
+            "prs_merged": 2,
+            "prs_reviewed": 0,
+            "priority_bugs_fixed": 0,
+            "priority_bug_avg_time_to_fix": None,
+            "all_work_done": 2,
+            "avg_all_time_to_fix": 1,
+            "lead_completed_projects": 0,
+            "lead_completed_projects_avg_early_late": None,
+        }
+
+        stdevs = person_stats.metric_stdevs_for_person(person, [person, teammate])
+
+        self.assertEqual(stdevs["prs_merged"]["label"], "+1.0σ")
+        self.assertIn("above the engineering group average", stdevs["prs_merged"]["tooltip"])
+        self.assertEqual(stdevs["all_work_done"]["label"], "+1.0σ")
+        self.assertNotIn("priority_bug_avg_time_to_fix", stdevs)
+        self.assertNotIn("lead_completed_projects_avg_early_late", stdevs)
+
+
+class PersonContextStdevsTest(unittest.TestCase):
+    def setUp(self):
+        app_module._build_person_context.cache_clear()
+        self.addCleanup(app_module._build_person_context.cache_clear)
+
+    def test_person_cards_include_engineering_group_stdevs(self):
+        config = {
+            "people": {
+                "alice": {
+                    "team": "engineering",
+                    "linear_username": "alice",
+                    "github_username": "alice-gh",
+                },
+                "bob": {
+                    "team": "engineering",
+                    "linear_username": "bob",
+                    "github_username": "bob-gh",
+                },
+                "vinny": {
+                    "team": "unassigned",
+                    "linear_username": "vincent",
+                    "github_username": "vinnyjth",
+                },
+            }
+        }
+        projects = [
+            {
+                "id": "proj-1",
+                "name": "Shipped",
+                "status": {"name": "Released"},
+                "completedAt": "2026-01-10T00:00:00.000Z",
+                "startDate": "2026-01-01",
+                "targetDate": "2026-01-12",
+                "lead": {"displayName": "Alice"},
+            },
+            {
+                "id": "proj-2",
+                "name": "Also Shipped",
+                "status": {"name": "Completed"},
+                "completedAt": "2026-01-10T00:00:00.000Z",
+                "startDate": "2026-01-01",
+                "targetDate": "2026-01-08",
+                "lead": {"displayName": "Alice"},
+            },
+        ]
+        completed_logins = []
+        github_usernames = []
+
+        def fake_completed(login, days=30, window=None):
+            completed_logins.append(login)
+            if login == "alice":
+                return [
+                    _issue(priority=2, bug=True, time_to_fix=2),
+                    _issue(priority=2, bug=True, time_to_fix=4),
+                    *[_issue() for _ in range(6)],
+                ]
+            if login == "bob":
+                return [_issue(), _issue()]
+            raise AssertionError(f"unexpected completed-issues login {login}")
+
+        def fake_pr_counts(username, days=30, window=None):
+            github_usernames.append(username)
+            if username == "alice-gh":
+                return (10, 4)
+            if username == "bob-gh":
+                return (2, 0)
+            raise AssertionError(f"unexpected github username {username}")
+
+        with (
+            patch.object(app_module, "load_config", return_value=config),
+            patch.object(app_module, "get_open_issues_for_person", return_value=[]),
+            patch.object(app_module, "get_completed_issues_for_person", side_effect=fake_completed),
+            patch.object(app_module, "get_projects", return_value=projects),
+            patch.object(app_module, "get_merged_pr_counts_for_user", side_effect=fake_pr_counts),
+            patch.object(app_module, "get_support_slugs", return_value=set()),
+        ):
+            context = app_module._build_person_context("alice", 30, 1)
+
+        self.assertEqual(sorted(completed_logins), ["alice", "bob"])
+        self.assertEqual(sorted(github_usernames), ["alice-gh", "bob-gh"])
+        self.assertEqual(context["prs_merged"], 10)
+        self.assertEqual(context["all_work_done"], 8)
+        self.assertEqual(context["lead_completed_projects"], 2)
+        self.assertEqual(context["metric_stdevs"]["prs_merged"]["label"], "+1.0σ")
+        self.assertEqual(context["metric_stdevs"]["all_work_done"]["label"], "+1.0σ")
+        self.assertEqual(context["metric_stdevs"]["lead_completed_projects"]["label"], "+1.0σ")
+        self.assertIn(
+            "engineering group average",
+            context["metric_stdevs"]["prs_merged"]["tooltip"],
+        )
+
+        with app_module.app.test_request_context():
+            body = app_module.render_template("partials/person_content.html", **context)
+
+        self.assertIn('class="metric-stdev"', body)
+        self.assertIn("+1.0σ", body)
+        self.assertIn("above the engineering group average", body)
+
+    def test_single_engineer_has_no_stdev_badges(self):
+        config = {
+            "people": {
+                "alice": {
+                    "team": "engineering",
+                    "linear_username": "alice",
+                    "github_username": "alice-gh",
+                }
+            }
+        }
+
+        with (
+            patch.object(app_module, "load_config", return_value=config),
+            patch.object(app_module, "get_open_issues_for_person", return_value=[]),
+            patch.object(app_module, "get_completed_issues_for_person", return_value=[]),
+            patch.object(app_module, "get_projects", return_value=[]),
+            patch.object(app_module, "get_merged_pr_counts_for_user", return_value=(3, 1)),
+            patch.object(app_module, "get_support_slugs", return_value=set()),
+        ):
+            context = app_module._build_person_context("alice", 30, 1)
+
+        self.assertEqual(context["metric_stdevs"], {})
+        with app_module.app.test_request_context():
+            body = app_module.render_template("partials/person_content.html", **context)
+        self.assertNotIn("metric-stdev", body)
+
+    def test_metric_stdev_styles_stay_subtle(self):
+        with open("static/styles.css") as styles_file:
+            styles = styles_file.read()
+
+        rule = styles.split(".metric-stdev {", 1)[1].split("}", 1)[0]
+        self.assertIn("font-size: 0.7rem;", rule)
+        self.assertIn("opacity: 0.7;", rule)
+        self.assertIn("color: var(--pico-muted-color);", rule)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issue
Person-page metric cards had no engineering-group comparison (#429). The first pass also used Pico’s default nowrap tooltips, so the copy ran off the page.

## Solution
Compare each card to the engineering group and show a muted `+1.2σ` label. Tooltips are short (`eng avg 71.8 · σ 100.5`), placed below the badge, and wrapped so they stay on screen. Team fetches reuse the existing person-page APIs with a capped worker pool. Zero-variance metrics omit the badge.

Closes #429

## To Test
- Open `/team/<engineer>` and confirm each metric card shows a muted σ label
- Hover left- and right-edge labels and confirm the tooltip stays on the page
- Change the date window and confirm the σ values update

## Proof
After, cards on `/team/michael?days=30`:

![Person-page metric cards with σ labels](https://github.com/ApollosProject/bug-board/releases/download/proof-438/cards.png)

After, left-card tooltip stays on the page:

![PRs Merged tooltip](https://github.com/ApollosProject/bug-board/releases/download/proof-438/tooltip-left.png)

After, right-edge tooltip stays on the page:

![Avg Days Early/Late tooltip](https://github.com/ApollosProject/bug-board/releases/download/proof-438/tooltip-right.png)