### PR TITLE
Make time metric standard scores direction-aware

### DIFF
--- a/person_stats.py
+++ b/person_stats.py
@@ -16,6 +16,14 @@ CARD_METRIC_KEYS = (
     "lead_completed_projects_avg_early_late",
 )
 
+LOWER_IS_BETTER_METRIC_KEYS = frozenset(
+    {
+        "priority_bug_avg_time_to_fix",
+        "avg_all_time_to_fix",
+        "lead_completed_projects_avg_early_late",
+    }
+)
+
 MetricValue = float | int | None
 
 
@@ -56,8 +64,9 @@ def format_stdev_label(z: float) -> str:
     return f"{sign}{abs(z):.1f}σ"
 
 
-def format_stdev_tooltip(values: list[float]) -> str:
-    return f"eng avg {statistics.fmean(values):.1f} · σ {statistics.pstdev(values):.1f}"
+def format_stdev_tooltip(values: list[float], *, lower_is_better: bool = False) -> str:
+    tooltip = f"eng avg {statistics.fmean(values):.1f} · σ {statistics.pstdev(values):.1f}"
+    return f"{tooltip} · lower is better" if lower_is_better else tooltip
 
 
 def metric_stdevs_for_person(
@@ -74,8 +83,11 @@ def metric_stdevs_for_person(
         z = z_score(float(person_value), values)
         if z is None:
             continue
+        lower_is_better = key in LOWER_IS_BETTER_METRIC_KEYS
+        if lower_is_better:
+            z = -z
         result[key] = {
             "label": format_stdev_label(z),
-            "tooltip": format_stdev_tooltip(values),
+            "tooltip": format_stdev_tooltip(values, lower_is_better=lower_is_better),
         }
     return result

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -26,6 +26,33 @@ class PersonStatsTest(unittest.TestCase):
         self.assertEqual(person_stats.z_score(10, [10, 2]), 1.0)
         self.assertEqual(person_stats.format_stdev_tooltip([10, 2]), "eng avg 6.0 · σ 4.0")
 
+    def test_time_metric_stdevs_reward_shorter_times(self):
+        person_metrics = {
+            "prs_merged": 10,
+            "priority_bug_avg_time_to_fix": 2,
+            "avg_all_time_to_fix": 10,
+            "lead_completed_projects_avg_early_late": -3,
+        }
+        team_metrics = [
+            person_metrics,
+            {
+                "prs_merged": 2,
+                "priority_bug_avg_time_to_fix": 10,
+                "avg_all_time_to_fix": 2,
+                "lead_completed_projects_avg_early_late": 5,
+            },
+        ]
+
+        stdevs = person_stats.metric_stdevs_for_person(person_metrics, team_metrics)
+
+        self.assertEqual(stdevs["prs_merged"]["label"], "+1.0σ")
+        self.assertEqual(stdevs["priority_bug_avg_time_to_fix"]["label"], "+1.0σ")
+        self.assertEqual(stdevs["avg_all_time_to_fix"]["label"], "−1.0σ")
+        self.assertEqual(stdevs["lead_completed_projects_avg_early_late"]["label"], "+1.0σ")
+        self.assertTrue(
+            stdevs["priority_bug_avg_time_to_fix"]["tooltip"].endswith("lower is better")
+        )
+
     def test_person_cards_include_on_page_stdev_badges(self):
         app_module._build_person_context.cache_clear()
         self.addCleanup(app_module._build_person_context.cache_clear)


### PR DESCRIPTION
## What changed

- Invert the displayed σ score for lower-is-better time metrics: priority-bug time to fix, overall time to completion, and completed-project days early/late.
- Keep count and output metrics on their existing higher-is-better direction.
- Add `lower is better` to time-metric tooltips so the sign convention is explicit.
- Add regression coverage for shorter, longer, and early-completion cases.

## Why

The shared scorer previously displayed the raw z-score for every metric. That made a longer completion time appear positive simply because it was above the engineering average, even though it represents worse performance.

## Impact

Positive σ labels now consistently represent better relative performance on the person-page cards, while the underlying engineering average and standard deviation remain unchanged.

## Checks

- `python -m unittest discover -s tests -p 'test_*.py'` (132 tests)
- `ruff check .`
- `ruff format --check .`
- `mypy .`

Closes #442