### PR TITLE
Add Time to Completion tooltip

### DIFF
--- a/templates/partials/person_content.html
+++ b/templates/partials/person_content.html
@@ -102,7 +102,17 @@
   </div>
   <div>
     <article>
-      <header>Time to Completion</header>
+      {% set time_to_completion_tooltip = "Average days from the most recent assignment to this person until the issue was completed. Only issues completed in the selected time window with assignment history are included." %}
+      <header>
+        Time to Completion
+        <small
+          id="time-to-completion-tooltip"
+          data-tooltip="{{ time_to_completion_tooltip }}"
+          data-placement="bottom"
+          tabindex="0"
+          aria-label="{{ time_to_completion_tooltip }}"
+        >ⓘ</small>
+      </header>
       {% if avg_all_time_to_fix is not none %}
       <h1>{{ avg_all_time_to_fix }}d</h1>
       {% else %}

--- a/templates/person.html
+++ b/templates/person.html
@@ -7,6 +7,16 @@
   #work-done-tooltip[data-tooltip]::before {
     font-size: 0.7em;
   }
+  #time-to-completion-tooltip {
+    cursor: help;
+    font-size: 0.8em;
+    opacity: 0.6;
+  }
+  #time-to-completion-tooltip[data-tooltip]::before {
+    font-size: 0.7em;
+    max-width: min(22rem, calc(100vw - 2rem));
+    white-space: normal;
+  }
   h1.low {
     color: #b33;
   }

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -98,6 +98,18 @@ class PersonStatsTest(unittest.TestCase):
         with app_module.app.test_request_context():
             body = app_module.render_template("partials/person_content.html", **context)
         self.assertIn('data-placement="bottom"', body)
+        self.assertIn('id="time-to-completion-tooltip"', body)
+        self.assertIn(
+            "Average days from the most recent assignment to this person until the issue was "
+            "completed. Only issues completed in the selected time window with assignment history "
+            "are included.",
+            body,
+        )
+        self.assertIn('tabindex="0"', body)
         styles = Path(__file__).resolve().parents[1].joinpath("static/styles.css").read_text()
         self.assertIn("max-width: min(12rem, calc(100vw - 2rem));", styles)
         self.assertIn("white-space: normal;", styles)
+        person_template = (
+            Path(__file__).resolve().parents[1].joinpath("templates/person.html").read_text()
+        )
+        self.assertIn("max-width: min(22rem, calc(100vw - 2rem));", person_template)


### PR DESCRIPTION
## Summary

- add an info tooltip beside **Time to Completion**
- explain that the metric averages days from the most recent assignment to completion for eligible issues in the selected time window
- make the tooltip keyboard-focusable and responsive on narrow screens
- add rendering-test coverage for the tooltip copy and presentation

## Why

The metric label did not explain what interval was measured or which completed issues were included, so the value was difficult to interpret.

## Impact

People viewing an engineer's dashboard can now understand the metric in place without leaving the page.

## Validation

- `python -m unittest discover -s tests -p 'test_*.py'` — 132 tests passed
- `ruff check .`
- `mypy .`
- `vulture . --config pyproject.toml`

Closes #440