### PR TITLE
Remove Andy from engineering group

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,7 +10,7 @@ people:
     linear_username: michael.neeley
     github_username: redreceipt
   andy:
-    team: engineering
+    team: unassigned
     slack_id: U080E70RQ4U
     linear_username: andy.smith
     github_username: AndySmith1965


### PR DESCRIPTION
## Summary

- move Andy from the `engineering` group to `unassigned`
- preserve Andy’s identity, Roku lead assignment, and Roku notification whitelist

## Why

Andy remained marked as an engineering team member in `config.yml`, so engineering-group views and metrics still included him. Reassigning the existing person record removes him from that group without deleting the configuration used by other features.

## Validation

- `ruff check .`
- `python -m unittest discover -s tests -p 'test_*.py'` (132 tests)
- parsed `config.yml` with PyYAML and verified Andy’s team is `unassigned`

Closes #445