### PR TITLE
Add GitHub blame candidate helpers

### DIFF
--- a/github_regressions.py
+++ b/github_regressions.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 import os
 import re
 import time
+from bisect import bisect_left, bisect_right
+from datetime import datetime, timezone
 from typing import Any
 
 import requests
 from dotenv import load_dotenv
+from gql import gql
+
+from github import _execute
 
 load_dotenv()
 
@@ -113,3 +118,122 @@ def _get_pull_request_files(owner: str, repo: str, number: int) -> list[dict[str
             break
         page += 1
     return files[:MAX_FIX_FILES]
+
+
+BLAME_QUERY = gql(
+    """
+    query RegressionBlame(
+      $owner: String!,
+      $repo: String!,
+      $oid: GitObjectID!,
+      $path: String!
+    ) {
+      repository(owner: $owner, name: $repo) {
+        object(oid: $oid) {
+          ... on Commit {
+            blame(path: $path) {
+              ranges {
+                startingLine
+                endingLine
+                commit {
+                  committedDate
+                  associatedPullRequests(first: 10) {
+                    nodes {
+                      url
+                      mergedAt
+                      author { login }
+                      reviews(first: 100, states: [APPROVED]) {
+                        nodes { author { login } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+)
+
+
+def _get_blame_ranges(owner: str, repo: str, oid: str, path: str) -> list[dict[str, Any]]:
+    data = None
+    last_error: Exception | None = None
+    for attempt in range(3):
+        try:
+            data = _execute(
+                BLAME_QUERY,
+                variable_values={"owner": owner, "repo": repo, "oid": oid, "path": path},
+            )
+            break
+        except Exception as exc:
+            last_error = exc
+            if attempt < 2:
+                time.sleep(2**attempt)
+    if data is None:
+        raise GitHubRegressionDataError(
+            f"GitHub blame failed for {owner}/{repo}:{path}"
+        ) from last_error
+
+    repository = data.get("repository") if data else None
+    commit = repository.get("object") if repository else None
+    blame = commit.get("blame") if commit else None
+    ranges = blame.get("ranges") if blame else None
+    return [item for item in ranges or [] if isinstance(item, dict)]
+
+
+def _parse_github_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def _is_bot(login: str | None) -> bool:
+    return bool(login and (login.casefold().endswith("[bot]") or login.casefold() == "dependabot"))
+
+
+def _reviewer_logins(pull_request: dict[str, Any]) -> list[str]:
+    author = ((pull_request.get("author") or {}).get("login") or "").casefold()
+    reviewers = {
+        login
+        for review in (pull_request.get("reviews") or {}).get("nodes", []) or []
+        if isinstance(review, dict)
+        for login in [((review.get("author") or {}).get("login") or "")]
+        if login and login.casefold() != author and not _is_bot(login)
+    }
+    return sorted(reviewers, key=str.casefold)
+
+
+def _original_merged_pull_request(
+    commit: dict[str, Any], fixing_merged_at: datetime
+) -> dict[str, Any] | None:
+    committed_at = _parse_github_datetime(commit.get("committedDate"))
+    pull_requests = []
+    for pull_request in (commit.get("associatedPullRequests") or {}).get("nodes", []) or []:
+        if not isinstance(pull_request, dict):
+            continue
+        merged_at = _parse_github_datetime(pull_request.get("mergedAt"))
+        if merged_at and merged_at <= fixing_merged_at:
+            pull_requests.append((pull_request, merged_at))
+    if not pull_requests:
+        return None
+    after_commit = (
+        [item for item in pull_requests if item[1] >= committed_at] if committed_at else []
+    )
+    return min(after_commit or pull_requests, key=lambda item: item[1])[0]
+
+
+def _line_overlap_count(deleted_lines: list[int], start: int, end: int) -> int:
+    return bisect_right(deleted_lines, end) - bisect_left(deleted_lines, start)
+
+
+def _candidate_score(
+    line_count: int, candidate_merged_at: datetime, fixing_merged_at: datetime
+) -> tuple[float, int]:
+    age_days = max(int((fixing_merged_at - candidate_merged_at).total_seconds() / 86400), 0)
+    return line_count / (1 + age_days / 30), age_days

--- a/github_regressions.py
+++ b/github_regressions.py
@@ -199,14 +199,14 @@ def _is_bot(login: str | None) -> bool:
 
 def _reviewer_logins(pull_request: dict[str, Any]) -> list[str]:
     author = ((pull_request.get("author") or {}).get("login") or "").casefold()
-    reviewers = {
-        login
-        for review in (pull_request.get("reviews") or {}).get("nodes", []) or []
-        if isinstance(review, dict)
-        for login in [((review.get("author") or {}).get("login") or "")]
-        if login and login.casefold() != author and not _is_bot(login)
-    }
-    return sorted(reviewers, key=str.casefold)
+    reviewers: dict[str, str] = {}
+    for review in (pull_request.get("reviews") or {}).get("nodes", []) or []:
+        if not isinstance(review, dict):
+            continue
+        login = (review.get("author") or {}).get("login") or ""
+        if login and login.casefold() != author and not _is_bot(login):
+            reviewers.setdefault(login.casefold(), login)
+    return sorted(reviewers.values(), key=str.casefold)
 
 
 def _original_merged_pull_request(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,13 @@ ignore_decorators = ["@app.route", "@app.template_filter"]
 ignore_names = [
     "breakdown",
     "deleted_line_numbers",
+    "_candidate_score",
+    "_get_blame_ranges",
     "_get_pull_request_files",
+    "_line_overlap_count",
+    "_original_merged_pull_request",
     "parse_pull_request_url",
     "post_weekly_changelog",
+    "_reviewer_logins",
 ]
 min_confidence = 60

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -36,6 +36,7 @@ class RegressionAttributionTest(unittest.TestCase):
                 "nodes": [
                     {"author": {"login": "author"}},
                     {"author": {"login": "reviewer"}},
+                    {"author": {"login": "Reviewer"}},
                     {"author": {"login": "copilot[bot]"}},
                 ]
             },

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,5 +1,8 @@
 import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
 
+import github_regressions
 from github_regressions import deleted_line_numbers, parse_pull_request_url
 
 
@@ -22,6 +25,62 @@ class RegressionAttributionTest(unittest.TestCase):
  context
 """
         self.assertEqual(deleted_line_numbers(unified_diff), [11, 13, 30])
+
+    def test_maps_blame_overlap_to_human_reviewers_and_recency_score(self):
+        fixing_merged_at = datetime(2026, 8, 10, tzinfo=timezone.utc)
+        inducing = {
+            "url": "https://github.com/example/repo/pull/9",
+            "mergedAt": "2026-07-11T00:00:00Z",
+            "author": {"login": "author"},
+            "reviews": {
+                "nodes": [
+                    {"author": {"login": "author"}},
+                    {"author": {"login": "reviewer"}},
+                    {"author": {"login": "copilot[bot]"}},
+                ]
+            },
+        }
+        mapped = github_regressions._original_merged_pull_request(
+            {
+                "committedDate": "2026-07-10T23:00:00Z",
+                "associatedPullRequests": {
+                    "nodes": [
+                        inducing,
+                        {
+                            "url": "https://github.com/example/repo/pull/11",
+                            "mergedAt": "2026-08-11T00:00:00Z",
+                        },
+                    ]
+                },
+            },
+            fixing_merged_at,
+        )
+        self.assertEqual(mapped["url"], inducing["url"])
+        self.assertEqual(github_regressions._reviewer_logins(mapped), ["reviewer"])
+        self.assertEqual(github_regressions._line_overlap_count([11, 13, 30], 10, 13), 2)
+        score, age_days = github_regressions._candidate_score(
+            2, datetime(2026, 7, 11, tzinfo=timezone.utc), fixing_merged_at
+        )
+        self.assertEqual((score, age_days), (1.0, 30))
+
+        with patch.object(
+            github_regressions,
+            "_execute",
+            return_value={
+                "repository": {
+                    "object": {
+                        "blame": {
+                            "ranges": [
+                                {"startingLine": 11, "endingLine": 13, "commit": {}},
+                                "ignored",
+                            ]
+                        }
+                    }
+                }
+            },
+        ):
+            ranges = github_regressions._get_blame_ranges("example", "repo", "abc", "src.py")
+        self.assertEqual(ranges, [{"startingLine": 11, "endingLine": 13, "commit": {}}])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- query historical GitHub blame ranges for deleted lines
- map blamed commits to merged PR authors and human approvers
- score candidates with a deterministic recency weight

## Stack

1. #448
2. #451 <-- you are here
3. #452
4. #453
5. #454
6. #455
7. #456
8. #457
9. #458

## Proof

Ran this PR's blame helpers against merged `ApollosProject/apollos-shovel#1736`:

```text
fixing=ApollosProject/apollos-shovel#1736
merged_at=2026-08-18T17:45:15Z parent=258e0ea8e904
file=dags/churches/fairhaven/wordpress_events.py deleted=19 ranges=28 overlap=19 mapped=19
file=dags/churches/ocbf/wordpress_events.py deleted=58 ranges=7 overlap=58 mapped=58
top_candidates=
  https://github.com/ApollosProject/apollos-shovel/pull/1233 author=rajuu89 reviewers=['vinnyjth'] lines=58 age_days=302 score=5.241
  https://github.com/ApollosProject/apollos-shovel/pull/1706 author=Lepozepo reviewers=['solideo-gloria'] lines=4 age_days=6 score=3.3333
  https://github.com/ApollosProject/apollos-shovel/pull/365 author=redreceipt reviewers=['vinnyjth'] lines=15 age_days=1244 score=0.3532
```

This exercises the live GraphQL blame query, overlap counting, inducing-PR mapping, human-reviewer filtering, and recency scoring.

## To Test
- `python -m unittest tests.test_regressions`
- `ruff check . && mypy .`

References #439