### PR TITLE
Identify regression fix candidates

### DIFF
--- a/linear/issues.py
+++ b/linear/issues.py
@@ -235,6 +235,70 @@ def get_completed_issues(priority, label, days=30, window: TimeWindow | None = N
     return issues
 
 
+def get_completed_regression_candidates(
+    days: int = 30, window: TimeWindow | None = None
+) -> list[dict]:
+    """Return completed priority bugs and their linked GitHub pull requests."""
+
+    team_key = get_linear_team_key()
+    query = gql(
+        """
+        query CompletedRegressionCandidates(
+          $team_key: String!,
+          $after: DateTimeOrDuration,
+          $before: DateTimeOrDuration,
+          $cursor: String
+        ) {
+          issues(
+            first: 100
+            after: $cursor
+            filter: {
+              team: { key: { eq: $team_key } }
+              labels: { name: { eq: "Bug" } }
+              priority: { lte: 2, gte: 1 }
+              state: { type: { in: ["completed"] } }
+              completedAt: { gte: $after, lt: $before }
+            }
+            orderBy: updatedAt
+          ) {
+            nodes {
+              id
+              identifier
+              attachments {
+                nodes {
+                  metadata
+                }
+              }
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+        """
+    )
+
+    issues: list[dict] = []
+    cursor = None
+    while True:
+        data = _execute(
+            query,
+            variable_values={
+                "team_key": team_key,
+                "cursor": cursor,
+                **_datetime_bounds(days, window),
+            },
+        )
+        payload = data["issues"]
+        issues.extend(payload["nodes"])
+        page_info = payload["pageInfo"]
+        if not page_info["hasNextPage"]:
+            break
+        cursor = page_info["endCursor"]
+    return issues
+
+
 def get_completed_issues_summary(priority, label, days=30, window: TimeWindow | None = None):
     return get_completed_issues_summary_for_labels(priority, [label], days, window)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,16 +24,11 @@ exclude = ["venv", ".venv", "env", ".env", "__pycache__", ".git", "static", "tem
 ignore_decorators = ["@app.route", "@app.template_filter"]
 ignore_names = [
     "breakdown",
-    "deleted_line_numbers",
+    "extract_fixing_pr_urls",
     "get_fixing_pr_attribution",
+    "get_completed_regression_candidates",
     "get_pull_request_attribution_metadata",
-    "_candidate_score",
-    "_get_blame_ranges",
-    "_get_pull_request_files",
-    "_line_overlap_count",
-    "_original_merged_pull_request",
-    "parse_pull_request_url",
+    "load_regression_overrides",
     "post_weekly_changelog",
-    "_reviewer_logins",
 ]
 min_confidence = 60

--- a/regression_overrides.yml
+++ b/regression_overrides.yml
@@ -1,0 +1,8 @@
+# Version-controlled corrections to automated SZZ attribution.
+#
+# APO-123:
+#   inducing_pr: https://github.com/ApollosProject/example/pull/456
+#
+# APO-789:
+#   ignored: true
+overrides: {}

--- a/regressions.py
+++ b/regressions.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from github_regressions import parse_pull_request_url
+
+REGRESSION_OVERRIDES_PATH = "regression_overrides.yml"
+FIXING_LINK_KINDS = {"closes", "contributes"}
+
+
+def extract_fixing_pr_urls(issue: dict[str, Any]) -> list[str]:
+    urls = set()
+    for attachment in (issue.get("attachments") or {}).get("nodes", []) or []:
+        metadata = attachment.get("metadata") if isinstance(attachment, dict) else None
+        url = metadata.get("url") if isinstance(metadata, dict) else None
+        if (
+            metadata
+            and metadata.get("status") == "merged"
+            and metadata.get("linkKind") in FIXING_LINK_KINDS
+            and isinstance(url, str)
+            and parse_pull_request_url(url) is not None
+        ):
+            urls.add(url.rstrip("/"))
+    return sorted(urls)
+
+
+def load_regression_overrides(
+    path: str | os.PathLike[str] = REGRESSION_OVERRIDES_PATH,
+) -> dict[str, dict[str, Any]]:
+    override_path = Path(path)
+    if not override_path.exists():
+        return {}
+    with override_path.open() as stream:
+        payload = yaml.safe_load(stream) or {}
+    overrides = payload.get("overrides", payload) if isinstance(payload, dict) else {}
+    if not isinstance(overrides, dict):
+        return {}
+    return {
+        str(identifier): value for identifier, value in overrides.items() if isinstance(value, dict)
+    }

--- a/regressions.py
+++ b/regressions.py
@@ -8,7 +8,7 @@ import yaml
 
 from github_regressions import parse_pull_request_url
 
-REGRESSION_OVERRIDES_PATH = "regression_overrides.yml"
+REGRESSION_OVERRIDES_PATH = Path(__file__).with_name("regression_overrides.yml")
 FIXING_LINK_KINDS = {"closes", "contributes"}
 
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import github_regressions
 from github_regressions import deleted_line_numbers, parse_pull_request_url
+from regressions import extract_fixing_pr_urls
 
 
 class RegressionAttributionTest(unittest.TestCase):
@@ -149,6 +150,32 @@ class RegressionAttributionTest(unittest.TestCase):
         with patch.object(github_regressions, "_rest_get", side_effect=fake_rest):
             with self.assertRaises(github_regressions.GitHubRegressionDataError):
                 github_regressions.get_pull_request_attribution_metadata(url)
+
+    def test_extracts_merged_fixing_pr_links(self):
+        issue = {
+            "attachments": {
+                "nodes": [
+                    {
+                        "metadata": {
+                            "url": "https://github.com/example/repo/pull/2",
+                            "status": "merged",
+                            "linkKind": "closes",
+                        }
+                    },
+                    {
+                        "metadata": {
+                            "url": "https://github.com/example/repo/pull/3",
+                            "status": "merged",
+                            "linkKind": "links",
+                        }
+                    },
+                ]
+            }
+        }
+        self.assertEqual(
+            extract_fixing_pr_urls(issue),
+            ["https://github.com/example/repo/pull/2"],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,10 +1,13 @@
+import os
+import tempfile
 import unittest
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import patch
 
 import github_regressions
 from github_regressions import deleted_line_numbers, parse_pull_request_url
-from regressions import extract_fixing_pr_urls
+from regressions import extract_fixing_pr_urls, load_regression_overrides
 
 
 class RegressionAttributionTest(unittest.TestCase):
@@ -176,6 +179,39 @@ class RegressionAttributionTest(unittest.TestCase):
             extract_fixing_pr_urls(issue),
             ["https://github.com/example/repo/pull/2"],
         )
+
+    def test_loads_override_mappings_and_ignores_invalid_entries(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            wrapped = Path(tmp) / "wrapped.yml"
+            wrapped.write_text(
+                "overrides:\n  APO-1:\n    ignored: true\n  APO-2: skip\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(load_regression_overrides(wrapped), {"APO-1": {"ignored": True}})
+
+            direct = Path(tmp) / "direct.yml"
+            direct.write_text(
+                "APO-3:\n  inducing_pr: https://github.com/example/repo/pull/9\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                load_regression_overrides(direct),
+                {"APO-3": {"inducing_pr": "https://github.com/example/repo/pull/9"}},
+            )
+
+            self.assertEqual(load_regression_overrides(Path(tmp) / "missing.yml"), {})
+            invalid = Path(tmp) / "invalid.yml"
+            invalid.write_text("- just a list\n", encoding="utf-8")
+            self.assertEqual(load_regression_overrides(invalid), {})
+
+    def test_loads_committed_overrides_independent_of_cwd(self):
+        original = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                os.chdir(tmp)
+                self.assertEqual(load_regression_overrides(), {})
+            finally:
+                os.chdir(original)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fetch completed priority bugs and merged fixing PR links from Linear
- load version-controlled attribution corrections and exclusions
- cover fixing-link extraction behavior

## Stack

1. #448
2. #451
3. #452
4. #453 <-- you are here
5. #454
6. #455
7. #456
8. #457
9. #458

## Proof

Ran this PR's Linear candidate helpers against live completed priority bugs for the last 30 days:

```text
completed_priority_bugs=64
with_merged_fixing_prs=57
samples=
  APO-11183 ['https://github.com/ApollosProject/apollos-platforms/pull/6877']
  APO-11136 ['https://github.com/ApollosProject/apollos-admin/pull/4011', 'https://github.com/ApollosProject/apollos-admin/pull/4021']
  APO-10993 ['https://github.com/ApollosProject/apollos-cluster/pull/3743', 'https://github.com/ApollosProject/apollos-cluster/pull/3801', 'https://github.com/ApollosProject/apollos-cluster/pull/3839', 'https://github.com/ApollosProject/toolbox/pull/36']
  APO-11161 ['https://github.com/ApollosProject/apollos-admin/pull/3933', 'https://github.com/ApollosProject/apollos-admin/pull/3939']
  APO-11361 ['https://github.com/ApollosProject/apollos-cluster/pull/3848']
  APO-11000 ['https://github.com/ApollosProject/apollos-cluster/pull/3751', 'https://github.com/ApollosProject/apollos-cluster/pull/3823']
  APO-11062 ['https://github.com/ApollosProject/apollos-cluster/pull/3765']
  APO-11162 ['https://github.com/ApollosProject/apollos-cluster/pull/3795']
overrides={}
```

This exercises the live Linear GraphQL query, merged `closes`/`contributes` fixing-link extraction, and empty override loading.

## To Test
- `python -m unittest tests.test_regressions`
- `ruff check . && mypy .`

References #439
