### PR TITLE
Collect regression attribution records

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,7 @@ exclude = ["venv", ".venv", "env", ".env", "__pycache__", ".git", "static", "tem
 ignore_decorators = ["@app.route", "@app.template_filter"]
 ignore_names = [
     "breakdown",
-    "extract_fixing_pr_urls",
-    "get_fixing_pr_attribution",
-    "get_completed_regression_candidates",
-    "get_pull_request_attribution_metadata",
-    "load_regression_overrides",
+    "collect_regression_attributions",
     "post_weekly_changelog",
 ]
 min_confidence = 60

--- a/regressions.py
+++ b/regressions.py
@@ -65,10 +65,11 @@ def merge_issue_attributions(
             candidate_url = incoming.get("url")
             if not isinstance(candidate_url, str) or candidate_url in fixing_urls:
                 continue
-            candidate = candidates_by_url.setdefault(
-                candidate_url,
-                {**incoming, "line_count": 0, "score": 0.0},
-            )
+            candidate = candidates_by_url.get(candidate_url)
+            if candidate is None:
+                candidate = {**incoming, "line_count": 0, "score": 0.0}
+                candidate.pop("age_days", None)
+                candidates_by_url[candidate_url] = candidate
             candidate["line_count"] += int(incoming.get("line_count") or 0)
             candidate["score"] += float(incoming.get("score") or 0)
     candidates = sorted(
@@ -101,11 +102,12 @@ def apply_regression_overrides(
             continue
         inducing_url = override.get("inducing_pr")
         if isinstance(inducing_url, str):
+            inducing_url = inducing_url.rstrip("/")
             candidate = next(
                 (
                     item
                     for item in record.get("candidates") or []
-                    if item.get("url") == inducing_url.rstrip("/")
+                    if item.get("url") == inducing_url
                 ),
                 None,
             )

--- a/regressions.py
+++ b/regressions.py
@@ -1,15 +1,25 @@
 from __future__ import annotations
 
+import logging
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import yaml
 
-from github_regressions import parse_pull_request_url
+from github_regressions import (
+    GitHubRegressionDataError,
+    get_fixing_pr_attribution,
+    get_pull_request_attribution_metadata,
+    parse_pull_request_url,
+)
+from linear.issues import get_completed_regression_candidates
+from time_window import TimeWindow
 
 REGRESSION_OVERRIDES_PATH = Path(__file__).with_name("regression_overrides.yml")
 FIXING_LINK_KINDS = {"closes", "contributes"}
+MAX_ATTRIBUTION_WORKERS = 2
 
 
 def extract_fixing_pr_urls(issue: dict[str, Any]) -> list[str]:
@@ -42,3 +52,114 @@ def load_regression_overrides(
     return {
         str(identifier): value for identifier, value in overrides.items() if isinstance(value, dict)
     }
+
+
+def merge_issue_attributions(
+    issue: dict[str, Any],
+    fixing_urls: list[str],
+    attributions_by_fix_url: dict[str, dict[str, Any] | None],
+) -> dict[str, Any]:
+    candidates_by_url: dict[str, dict[str, Any]] = {}
+    for fixing_url in fixing_urls:
+        for incoming in (attributions_by_fix_url.get(fixing_url) or {}).get("candidates", []):
+            candidate_url = incoming.get("url")
+            if not isinstance(candidate_url, str) or candidate_url in fixing_urls:
+                continue
+            candidate = candidates_by_url.setdefault(
+                candidate_url,
+                {**incoming, "line_count": 0, "score": 0.0},
+            )
+            candidate["line_count"] += int(incoming.get("line_count") or 0)
+            candidate["score"] += float(incoming.get("score") or 0)
+    candidates = sorted(
+        candidates_by_url.values(),
+        key=lambda item: (item.get("score", 0), item.get("line_count", 0)),
+        reverse=True,
+    )
+    return {
+        "identifier": issue.get("identifier"),
+        "candidates": candidates,
+        "attribution": candidates[0] if candidates else None,
+    }
+
+
+def apply_regression_overrides(
+    records: list[dict[str, Any]],
+    overrides: dict[str, dict[str, Any]],
+    metadata_loader: Callable[[str], dict[str, Any] | None] = (
+        get_pull_request_attribution_metadata
+    ),
+) -> list[dict[str, Any]]:
+    corrected = []
+    for original in records:
+        record = dict(original)
+        override = overrides.get(str(record.get("identifier")))
+        if not override:
+            corrected.append(record)
+            continue
+        if override.get("ignored") is True:
+            continue
+        inducing_url = override.get("inducing_pr")
+        if isinstance(inducing_url, str):
+            candidate = next(
+                (
+                    item
+                    for item in record.get("candidates") or []
+                    if item.get("url") == inducing_url.rstrip("/")
+                ),
+                None,
+            )
+            if candidate is None:
+                try:
+                    candidate = metadata_loader(inducing_url)
+                except GitHubRegressionDataError as exc:
+                    logging.warning("Unable to load regression override: %s", exc)
+            if candidate is not None:
+                record["attribution"] = candidate
+        corrected.append(record)
+    return corrected
+
+
+def collect_regression_attributions(
+    window: TimeWindow,
+    *,
+    overrides_path: str | os.PathLike[str] = REGRESSION_OVERRIDES_PATH,
+) -> tuple[list[dict[str, Any]], int]:
+    if not os.getenv("LINEAR_API_KEY") or not os.getenv("GITHUB_TOKEN"):
+        return [], 0
+    issues = get_completed_regression_candidates(window.duration_days, window)
+    fixing_urls_by_issue = {str(issue.get("id")): extract_fixing_pr_urls(issue) for issue in issues}
+    all_fixing_urls = {url for fixing_urls in fixing_urls_by_issue.values() for url in fixing_urls}
+    results: dict[str, dict[str, Any] | None] = {}
+    failed_urls = set()
+    with ThreadPoolExecutor(
+        max_workers=min(MAX_ATTRIBUTION_WORKERS, max(len(all_fixing_urls), 1))
+    ) as executor:
+        futures = {executor.submit(get_fixing_pr_attribution, url): url for url in all_fixing_urls}
+        for future in as_completed(futures):
+            url = futures[future]
+            try:
+                result = future.result()
+                results[url] = result
+                if result is not None and not result.get("complete", True):
+                    failed_urls.add(url)
+            except Exception as exc:
+                logging.warning("Regression attribution failed for %s: %s", url, exc)
+                failed_urls.add(url)
+                results[url] = None
+    records = [
+        merge_issue_attributions(
+            issue,
+            fixing_urls_by_issue[str(issue.get("id"))],
+            results,
+        )
+        for issue in issues
+        if fixing_urls_by_issue[str(issue.get("id"))]
+    ]
+    return (
+        apply_regression_overrides(
+            records,
+            load_regression_overrides(overrides_path),
+        ),
+        len(failed_urls),
+    )

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -220,27 +220,44 @@ class RegressionAttributionTest(unittest.TestCase):
 
     def test_merges_candidates_and_applies_manual_override(self):
         fixing_url = "https://github.com/example/repo/pull/10"
+        other_fix = "https://github.com/example/repo/pull/11"
         winner = {
             "url": "https://github.com/example/repo/pull/5",
             "score": 2.5,
             "line_count": 3,
+            "age_days": 10,
+            "author": "author",
+        }
+        later = {
+            "url": "https://github.com/example/repo/pull/5",
+            "score": 1.5,
+            "line_count": 2,
+            "age_days": 40,
+            "author": "author",
         }
         record = merge_issue_attributions(
             {"identifier": "APO-123"},
-            [fixing_url],
-            {fixing_url: {"candidates": [winner]}},
+            [fixing_url, other_fix],
+            {
+                fixing_url: {"candidates": [winner]},
+                other_fix: {"candidates": [later]},
+            },
         )
-        self.assertEqual(record["attribution"], winner)
+        self.assertEqual(record["attribution"]["score"], 4.0)
+        self.assertEqual(record["attribution"]["line_count"], 5)
+        self.assertNotIn("age_days", record["attribution"])
 
+        loaded: list[str] = []
         manual = {"url": "https://github.com/example/repo/pull/9"}
         corrected = apply_regression_overrides(
             [record, {"identifier": "APO-ignored"}],
             {
-                "APO-123": {"inducing_pr": manual["url"]},
+                "APO-123": {"inducing_pr": f"{manual['url']}/"},
                 "APO-ignored": {"ignored": True},
             },
-            metadata_loader=lambda url: manual,
+            metadata_loader=lambda url: loaded.append(url) or manual,
         )
+        self.assertEqual(loaded, [manual["url"]])
         self.assertEqual(corrected, [{**record, "attribution": manual}])
 
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -7,7 +7,12 @@ from unittest.mock import patch
 
 import github_regressions
 from github_regressions import deleted_line_numbers, parse_pull_request_url
-from regressions import extract_fixing_pr_urls, load_regression_overrides
+from regressions import (
+    apply_regression_overrides,
+    extract_fixing_pr_urls,
+    load_regression_overrides,
+    merge_issue_attributions,
+)
 
 
 class RegressionAttributionTest(unittest.TestCase):
@@ -212,6 +217,31 @@ class RegressionAttributionTest(unittest.TestCase):
                 self.assertEqual(load_regression_overrides(), {})
             finally:
                 os.chdir(original)
+
+    def test_merges_candidates_and_applies_manual_override(self):
+        fixing_url = "https://github.com/example/repo/pull/10"
+        winner = {
+            "url": "https://github.com/example/repo/pull/5",
+            "score": 2.5,
+            "line_count": 3,
+        }
+        record = merge_issue_attributions(
+            {"identifier": "APO-123"},
+            [fixing_url],
+            {fixing_url: {"candidates": [winner]}},
+        )
+        self.assertEqual(record["attribution"], winner)
+
+        manual = {"url": "https://github.com/example/repo/pull/9"}
+        corrected = apply_regression_overrides(
+            [record, {"identifier": "APO-ignored"}],
+            {
+                "APO-123": {"inducing_pr": manual["url"]},
+                "APO-ignored": {"ignored": True},
+            },
+            metadata_loader=lambda url: manual,
+        )
+        self.assertEqual(corrected, [{**record, "attribution": manual}])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- analyze fixing PRs concurrently
- combine candidate evidence per Linear bug
- apply explicit manual corrections after automated attribution

## Stack

1. #448
2. #451
3. #452
4. #453
5. #454 <-- you are here
6. #455
7. #456
8. #457
9. #458

## Proof

Ran `collect_regression_attributions()` against live Linear and GitHub for the last 30 days:

```text
records=57
attributed=52
unattributed=5
failed_fixing_prs=10
overrides={}
samples=
  APO-11183 inducing=https://github.com/ApollosProject/apollos-platforms/pull/6799 author=nlewis84 score=4.864865 candidates=2
  APO-11136 inducing=https://github.com/ApollosProject/apollos-admin/pull/3838 author=dylan-manchester score=4.375 candidates=12
  APO-10993 inducing=https://github.com/ApollosProject/apollos-cluster/pull/450 author=redreceipt score=0.651685 candidates=6
  APO-11161 inducing=https://github.com/ApollosProject/apollos-admin/pull/2540 author=vinnyjth score=1.25523 candidates=5
  APO-11361 inducing=https://github.com/ApollosProject/apollos-cluster/pull/3072 author=vinnyjth score=0.26087 candidates=1
  APO-11000 inducing=https://github.com/ApollosProject/apollos-cluster/pull/3503 author=redreceipt score=3.58209 candidates=9
  APO-11062 inducing=https://github.com/ApollosProject/apollos-cluster/pull/1984 author=hellogerard score=0.490463 candidates=3
  APO-11162 inducing=https://github.com/ApollosProject/apollos-cluster/pull/2370 author=vinnyjth score=1.2 candidates=1
```

This exercises concurrent SZZ analysis of merged fixing PRs, per-bug candidate merging, and empty versioned override application. Incomplete blame on some files is counted in `failed_fixing_prs` rather than dropped silently.

## To Test
- `python -m unittest tests.test_regressions`
- `ruff check . && mypy .`

References #439