### PR TITLE
Compute regression responsibility metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ exclude = ["venv", ".venv", "env", ".env", "__pycache__", ".git", "static", "tem
 ignore_decorators = ["@app.route", "@app.template_filter"]
 ignore_names = [
     "breakdown",
-    "collect_regression_attributions",
+    "build_regression_summary",
     "post_weekly_changelog",
 ]
 min_confidence = 60

--- a/regressions.py
+++ b/regressions.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 import logging
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
 import yaml
 
+from config import load_config
+from constants import ENGINEERING_TEAM_SLUG
+from github import get_merged_pr_counts_for_user
 from github_regressions import (
     GitHubRegressionDataError,
     get_fixing_pr_attribution,
@@ -17,6 +21,7 @@ from github_regressions import (
 from linear.issues import get_completed_regression_candidates
 from time_window import TimeWindow
 
+REGRESSION_DAYS = 30
 REGRESSION_OVERRIDES_PATH = Path(__file__).with_name("regression_overrides.yml")
 FIXING_LINK_KINDS = {"closes", "contributes"}
 MAX_ATTRIBUTION_WORKERS = 2
@@ -165,3 +170,130 @@ def collect_regression_attributions(
         ),
         len(failed_urls),
     )
+
+
+def _engineering_people() -> dict[str, dict[str, str]]:
+    return {
+        username.casefold(): {"slug": slug, "github_username": username}
+        for slug, info in load_config().get("people", {}).items()
+        for username in [info.get("github_username")]
+        if info.get("team") == ENGINEERING_TEAM_SLUG and isinstance(username, str) and username
+    }
+
+
+def _team_pr_counts(
+    people: dict[str, dict[str, str]],
+    window: TimeWindow,
+) -> tuple[dict[str, int], dict[str, int]]:
+    authored: dict[str, int] = {}
+    reviewed: dict[str, int] = {}
+    with ThreadPoolExecutor(max_workers=min(4, max(len(people), 1))) as executor:
+        futures = {
+            executor.submit(
+                get_merged_pr_counts_for_user,
+                person["github_username"],
+                window.duration_days,
+                window,
+            ): username
+            for username, person in people.items()
+        }
+        for future in as_completed(futures):
+            username = futures[future]
+            authored[username], reviewed[username] = future.result()
+    return authored, reviewed
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def _rate(numerator: int, denominator: int) -> float | None:
+    return round(numerator / denominator * 100, 1) if denominator else None
+
+
+def _person_metrics(
+    records: list[dict[str, Any]],
+    people: dict[str, dict[str, str]],
+    authored_counts: dict[str, int],
+    reviewed_counts: dict[str, int],
+    window: TimeWindow,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    authored_regressions = {username: 0 for username in people}
+    approved_regressions = {username: 0 for username in people}
+    for record in records:
+        attribution = record.get("attribution")
+        if not isinstance(attribution, dict):
+            continue
+        merged_at = _parse_datetime(attribution.get("merged_at"))
+        if merged_at is None or not window.start <= merged_at < window.end:
+            continue
+        author = attribution.get("author")
+        if isinstance(author, str) and author.casefold() in authored_regressions:
+            authored_regressions[author.casefold()] += 1
+        for reviewer in attribution.get("reviewers") or []:
+            if isinstance(reviewer, str) and reviewer.casefold() in approved_regressions:
+                approved_regressions[reviewer.casefold()] += 1
+
+    author_rows, reviewer_rows = [], []
+    for username, person in people.items():
+        authored_count = authored_counts.get(username, 0)
+        reviewed_count = reviewed_counts.get(username, 0)
+        author_rows.append(
+            {
+                **person,
+                "regression_count": authored_regressions[username],
+                "pr_count": authored_count,
+                "rate": _rate(authored_regressions[username], authored_count),
+            }
+        )
+        reviewer_rows.append(
+            {
+                **person,
+                "regression_count": approved_regressions[username],
+                "pr_count": reviewed_count,
+                "rate": _rate(approved_regressions[username], reviewed_count),
+            }
+        )
+    return author_rows, reviewer_rows
+
+
+def build_regression_summary() -> dict[str, Any]:
+    if not os.getenv("LINEAR_API_KEY") or not os.getenv("GITHUB_TOKEN"):
+        return {
+            "days": REGRESSION_DAYS,
+            "configured": False,
+            "complete": False,
+            "author_metrics": [],
+            "reviewer_metrics": [],
+        }
+    window = TimeWindow.from_days(REGRESSION_DAYS)
+    people = _engineering_people()
+    authored_counts, reviewed_counts = _team_pr_counts(people, window)
+    records, failed_count = collect_regression_attributions(window)
+    author_metrics, reviewer_metrics = _person_metrics(
+        records, people, authored_counts, reviewed_counts, window
+    )
+    authored_regressions = sum(row["regression_count"] for row in author_metrics)
+    approved_regressions = sum(row["regression_count"] for row in reviewer_metrics)
+    authored_prs = sum(row["pr_count"] for row in author_metrics)
+    reviewed_prs = sum(row["pr_count"] for row in reviewer_metrics)
+    return {
+        "days": REGRESSION_DAYS,
+        "configured": True,
+        "complete": failed_count == 0,
+        "regression_count": len(records),
+        "attributed_count": sum(record.get("attribution") is not None for record in records),
+        "authored_regression_count": authored_regressions,
+        "authored_pr_count": authored_prs,
+        "author_regression_rate": _rate(authored_regressions, authored_prs),
+        "approved_regression_count": approved_regressions,
+        "reviewed_pr_count": reviewed_prs,
+        "reviewer_escape_rate": _rate(approved_regressions, reviewed_prs),
+        "author_metrics": author_metrics,
+        "reviewer_metrics": reviewer_metrics,
+    }

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,18 +1,21 @@
 import os
 import tempfile
 import unittest
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
 import github_regressions
 from github_regressions import deleted_line_numbers, parse_pull_request_url
 from regressions import (
+    _person_metrics,
     apply_regression_overrides,
+    build_regression_summary,
     extract_fixing_pr_urls,
     load_regression_overrides,
     merge_issue_attributions,
 )
+from time_window import TimeWindow
 
 
 class RegressionAttributionTest(unittest.TestCase):
@@ -259,6 +262,44 @@ class RegressionAttributionTest(unittest.TestCase):
         )
         self.assertEqual(loaded, [manual["url"]])
         self.assertEqual(corrected, [{**record, "attribution": manual}])
+
+    def test_person_metrics_use_the_inducing_pr_cohort(self):
+        window = TimeWindow.from_dates(date(2026, 8, 1), date(2026, 8, 31))
+        people = {
+            "alice": {"slug": "alice", "github_username": "alice"},
+            "bob": {"slug": "bob", "github_username": "bob"},
+        }
+        records = [
+            {
+                "attribution": {
+                    "merged_at": "2026-08-10T00:00:00Z",
+                    "author": "alice",
+                    "reviewers": ["bob"],
+                }
+            },
+            {
+                "attribution": {
+                    "merged_at": "2025-08-10T00:00:00Z",
+                    "author": "alice",
+                    "reviewers": ["bob"],
+                }
+            },
+        ]
+        authors, reviewers = _person_metrics(
+            records,
+            people,
+            {"alice": 20, "bob": 5},
+            {"alice": 10, "bob": 25},
+            window,
+        )
+        self.assertEqual(authors[0]["rate"], 5.0)
+        self.assertEqual(reviewers[1]["rate"], 4.0)
+
+    def test_unconfigured_summary_skips_external_work(self):
+        with patch.dict("os.environ", {}, clear=True):
+            summary = build_regression_summary()
+        self.assertFalse(summary["configured"])
+        self.assertEqual(summary["author_metrics"], [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- normalize attributed regressions by authored and approved PR cohorts
- return stable empty metrics when credentials are absent
- cover person-level cohort calculations

## Stack

1. #448
2. #451
3. #452
4. #453
5. #454
6. #455 <-- you are here
7. #456
8. #457
9. #458

## Proof

Unconfigured run (no `LINEAR_API_KEY` / `GITHUB_TOKEN`) returned empty metrics without calling Linear or GitHub:

```text
configured=False complete=False days=30
author_metrics=[] reviewer_metrics=[]
```

Ran `build_regression_summary()` against live Linear and GitHub for the last 30 days:

```text
days=30
configured=True
complete=False
regression_count=57
attributed_count=49
authored_regression_count=5
authored_pr_count=668
author_regression_rate=0.7
approved_regression_count=8
reviewed_pr_count=761
reviewer_escape_rate=1.1
author_metrics=
  nlewis84 slug=nathan regs=2 prs=76 rate=2.6
  dylan-manchester slug=dylan regs=1 prs=56 rate=1.8
  redreceipt slug=michael regs=2 prs=353 rate=0.6
  awitherow slug=austin regs=0 prs=73 rate=0.0
  bkraeling slug=brandon regs=0 prs=99 rate=0.0
  nickw slug=nick regs=0 prs=0 rate=None
  solideo-gloria slug=zach regs=0 prs=6 rate=0.0
  vitlelis slug=vitor regs=0 prs=5 rate=0.0
reviewer_metrics=
  nickw slug=nick regs=1 prs=24 rate=4.2
  vitlelis slug=vitor regs=3 prs=112 rate=2.7
  bkraeling slug=brandon regs=1 prs=51 rate=2.0
  awitherow slug=austin regs=1 prs=58 rate=1.7
  redreceipt slug=michael regs=1 prs=152 rate=0.7
  nlewis84 slug=nathan regs=1 prs=186 rate=0.5
  dylan-manchester slug=dylan regs=0 prs=125 rate=0.0
  solideo-gloria slug=zach regs=0 prs=53 rate=0.0
```

This exercises engineering-team cohort membership, merged authored/approved PR denominators, inducing-PR window filtering, and incomplete-blame `complete=False` handling.

## To Test
- `python -m unittest tests.test_regressions`
- `ruff check . && mypy .`

References #439
