### PR TITLE
Cache regression summaries in Redis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ exclude = ["venv", ".venv", "env", ".env", "__pycache__", ".git", "static", "tem
 ignore_decorators = ["@app.route", "@app.template_filter"]
 ignore_names = [
     "breakdown",
-    "build_regression_summary",
     "post_weekly_changelog",
+    "refresh_regression_summary_cache",
 ]
 min_confidence = 60

--- a/regression_cache.py
+++ b/regression_cache.py
@@ -16,6 +16,18 @@ REQUIRED_SUMMARY_KEYS = {
 }
 
 
+def _is_cacheable_summary(payload: Any) -> bool:
+    return (
+        isinstance(payload, dict)
+        and payload.get("days") == REGRESSION_DAYS
+        and payload.get("configured") is True
+        and REQUIRED_SUMMARY_KEYS <= payload.keys()
+        and all(
+            isinstance(payload.get(key), list) for key in ("author_metrics", "reviewer_metrics")
+        )
+    )
+
+
 def get_cached_regression_summary() -> dict[str, Any] | None:
     client = _get_redis_client()
     if client is None:
@@ -26,19 +38,14 @@ def get_cached_regression_summary() -> dict[str, Any] | None:
     except Exception:
         logging.exception("Failed to read regression summary from Redis")
         return None
-    if (
-        not isinstance(payload, dict)
-        or payload.get("days") != REGRESSION_DAYS
-        or not REQUIRED_SUMMARY_KEYS <= payload.keys()
-        or not all(
-            isinstance(payload.get(key), list) for key in ("author_metrics", "reviewer_metrics")
-        )
-    ):
+    if not _is_cacheable_summary(payload):
         return None
     return payload
 
 
 def store_cached_regression_summary(payload: dict[str, Any]) -> bool:
+    if not _is_cacheable_summary(payload):
+        return False
     client = _get_redis_client()
     if client is None:
         return False

--- a/regression_cache.py
+++ b/regression_cache.py
@@ -1,0 +1,74 @@
+import json
+import logging
+import time
+from typing import Any
+
+from fleet_health_cache import _get_redis_client, _read_non_negative_int_env
+from regressions import REGRESSION_DAYS
+
+REGRESSION_CACHE_KEY = f"regressions:summary:{REGRESSION_DAYS}"
+DEFAULT_REGRESSION_REDIS_TTL_SECONDS = 86400
+REQUIRED_SUMMARY_KEYS = {
+    "configured",
+    "complete",
+    "author_metrics",
+    "reviewer_metrics",
+}
+
+
+def get_cached_regression_summary() -> dict[str, Any] | None:
+    client = _get_redis_client()
+    if client is None:
+        return None
+    try:
+        raw = client.get(REGRESSION_CACHE_KEY)
+        payload = (json.loads(raw) if raw else {}).get("payload")
+    except Exception:
+        logging.exception("Failed to read regression summary from Redis")
+        return None
+    if (
+        not isinstance(payload, dict)
+        or payload.get("days") != REGRESSION_DAYS
+        or not REQUIRED_SUMMARY_KEYS <= payload.keys()
+        or not all(
+            isinstance(payload.get(key), list) for key in ("author_metrics", "reviewer_metrics")
+        )
+    ):
+        return None
+    return payload
+
+
+def store_cached_regression_summary(payload: dict[str, Any]) -> bool:
+    client = _get_redis_client()
+    if client is None:
+        return False
+    ttl_seconds = _read_non_negative_int_env(
+        "REGRESSION_REDIS_TTL_SECONDS",
+        DEFAULT_REGRESSION_REDIS_TTL_SECONDS,
+    )
+    value = json.dumps(
+        {"cached_at_epoch": time.time(), "payload": payload},
+        separators=(",", ":"),
+    )
+    try:
+        client.setex(
+            REGRESSION_CACHE_KEY,
+            ttl_seconds or DEFAULT_REGRESSION_REDIS_TTL_SECONDS,
+            value,
+        )
+    except Exception:
+        logging.exception("Failed to write regression summary to Redis")
+        return False
+    return True
+
+
+def refresh_regression_summary_cache() -> dict[str, Any] | None:
+    from regressions import build_regression_summary
+
+    try:
+        summary = build_regression_summary()
+    except Exception:
+        logging.exception("Failed to refresh regression summary")
+        return get_cached_regression_summary()
+    store_cached_regression_summary(summary)
+    return summary

--- a/tests/test_regression_cache.py
+++ b/tests/test_regression_cache.py
@@ -1,0 +1,68 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import regression_cache
+
+
+def _summary():
+    return {
+        "days": 30,
+        "configured": True,
+        "complete": True,
+        "regression_count": 4,
+        "attributed_count": 3,
+        "author_regression_rate": 2.5,
+        "authored_regression_count": 2,
+        "authored_pr_count": 80,
+        "reviewer_escape_rate": 1.2,
+        "approved_regression_count": 1,
+        "reviewed_pr_count": 84,
+        "author_metrics": [
+            {
+                "slug": "alice",
+                "github_username": "alice-gh",
+                "regression_count": 2,
+                "pr_count": 20,
+                "rate": 10.0,
+            }
+        ],
+        "reviewer_metrics": [
+            {
+                "slug": "alice",
+                "github_username": "alice-gh",
+                "regression_count": 1,
+                "pr_count": 25,
+                "rate": 4.0,
+            }
+        ],
+    }
+
+
+class RegressionCacheTest(unittest.TestCase):
+    def test_cache_roundtrip(self):
+        values: dict[str, str] = {}
+        client = MagicMock()
+        client.get.side_effect = values.get
+        client.setex.side_effect = lambda key, ttl, value: values.__setitem__(key, value)
+
+        with (
+            patch.object(regression_cache, "_get_redis_client", return_value=client),
+            patch.object(
+                regression_cache,
+                "_read_non_negative_int_env",
+                return_value=86400,
+            ),
+        ):
+            self.assertTrue(regression_cache.store_cached_regression_summary(_summary()))
+            self.assertEqual(regression_cache.get_cached_regression_summary(), _summary())
+
+    def test_refresh_failure_returns_no_fake_summary(self):
+        with (
+            patch("regressions.build_regression_summary", side_effect=RuntimeError("boom")),
+            patch.object(regression_cache, "get_cached_regression_summary", return_value=None),
+        ):
+            self.assertIsNone(regression_cache.refresh_regression_summary_cache())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_regression_cache.py
+++ b/tests/test_regression_cache.py
@@ -56,12 +56,57 @@ class RegressionCacheTest(unittest.TestCase):
             self.assertTrue(regression_cache.store_cached_regression_summary(_summary()))
             self.assertEqual(regression_cache.get_cached_regression_summary(), _summary())
 
+    def test_store_rejects_unconfigured_summary(self):
+        values: dict[str, str] = {}
+        client = MagicMock()
+        client.get.side_effect = values.get
+        client.setex.side_effect = lambda key, ttl, value: values.__setitem__(key, value)
+        unconfigured = {
+            "days": 30,
+            "configured": False,
+            "complete": False,
+            "author_metrics": [],
+            "reviewer_metrics": [],
+        }
+
+        with (
+            patch.object(regression_cache, "_get_redis_client", return_value=client),
+            patch.object(
+                regression_cache,
+                "_read_non_negative_int_env",
+                return_value=86400,
+            ),
+        ):
+            self.assertTrue(regression_cache.store_cached_regression_summary(_summary()))
+            self.assertFalse(regression_cache.store_cached_regression_summary(unconfigured))
+            self.assertEqual(regression_cache.get_cached_regression_summary(), _summary())
+            self.assertEqual(client.setex.call_count, 1)
+
     def test_refresh_failure_returns_no_fake_summary(self):
         with (
             patch("regressions.build_regression_summary", side_effect=RuntimeError("boom")),
             patch.object(regression_cache, "get_cached_regression_summary", return_value=None),
         ):
             self.assertIsNone(regression_cache.refresh_regression_summary_cache())
+
+    def test_refresh_failure_preserves_last_good_summary(self):
+        values: dict[str, str] = {}
+        client = MagicMock()
+        client.get.side_effect = values.get
+        client.setex.side_effect = lambda key, ttl, value: values.__setitem__(key, value)
+
+        with (
+            patch.object(regression_cache, "_get_redis_client", return_value=client),
+            patch.object(
+                regression_cache,
+                "_read_non_negative_int_env",
+                return_value=86400,
+            ),
+            patch("regressions.build_regression_summary", side_effect=RuntimeError("boom")),
+        ):
+            self.assertTrue(regression_cache.store_cached_regression_summary(_summary()))
+            self.assertEqual(regression_cache.refresh_regression_summary_cache(), _summary())
+            self.assertEqual(regression_cache.get_cached_regression_summary(), _summary())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- store validated 30-day regression summaries in Redis
- reject unconfigured payloads so they cannot overwrite last good
- preserve the last good summary when refresh fails
- cover cache roundtrip and failure behavior

## Stack

1. #448
2. #451
3. #452
4. #453
5. #454
6. #455
7. #456 <-- you are here
8. #457
9. #458

## Proof

Unconfigured (`REDIS_URL` unset) skipped Redis:

```text
store=False
get=None
```

`refresh_regression_summary_cache()` wrote a live 30-day Linear/GitHub summary into local Redis (`redis://127.0.0.1:6379/15`) and `get_cached_regression_summary()` returned the same payload:

```text
refresh_returned=True
cached_equal_to_refresh=True
days=30
configured=True
complete=False
regression_count=57
attributed_count=51
authored_regression_count=5
authored_pr_count=672
author_regression_rate=0.7
approved_regression_count=8
reviewed_pr_count=763
reviewer_escape_rate=1.0
redis_key=regressions:summary:30
ttl_seconds=86400
```

A later refresh failure returned that same Redis payload (`live_last_good_preserved=True`) instead of inventing a new summary.

## To Test
- `python -m unittest tests.test_regression_cache`
- `ruff check . && mypy .`

References #439