### PR TITLE
Refresh regression metrics in the worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ python -m unittest discover -s tests -p 'test_*.py'
 - `AIRFLOW_FLEET_HEALTH_MAX_STALE_SECONDS` – Optional max age accepted by the web endpoint when reading cached data (default: `180`)
 - `AIRFLOW_FLEET_HEALTH_REDIS_TTL_SECONDS` – Optional Redis TTL for cached fleet health record (default: `900`)
 - `LEADERBOARD_REDIS_TTL_SECONDS` – Optional Redis TTL for the cached homepage leaderboard (default: `900`)
+- `REGRESSION_REDIS_TTL_SECONDS` – Optional Redis TTL for cached regression metrics (default: `86400`)
 - `BIGQUERY_ANALYTICS_PROJECT_ID` – Optional Google Cloud project that contains the Segment BigQuery export (default: `apollos-project`)
 - `BIGQUERY_ANALYTICS_DATASETS` – Optional comma-separated BigQuery datasets containing Segment export tables (default: `apollos,apollos_tv,apollos_roku`)
 - `BIGQUERY_ANALYTICS_TABLES` – Optional comma-separated Segment tables to inspect for app runtime versions (default: `identifies,screens,app_became_active,app_became_backgrounded,app_became_inactive`)

--- a/jobs.py
+++ b/jobs.py
@@ -184,29 +184,40 @@ def refresh_leaderboard_cache_job():
     logging.info("Refreshed leaderboard cache (days=%s, entries=%s)", context.get("days"), n)
 
 
+def _refresh_and_log_regression_summary_cache() -> None:
+    summary = refresh_regression_summary_cache() or {}
+    logging.info(
+        "Refreshed regression summary (days=%s, regressions=%s, attributed=%s, complete=%s)",
+        summary.get("days"),
+        summary.get("regression_count"),
+        summary.get("attributed_count"),
+        summary.get("complete"),
+    )
+
+
+def _refresh_regression_summary_cache_in_background() -> None:
+    try:
+        _refresh_and_log_regression_summary_cache()
+    finally:
+        _regression_cache_refresh_lock.release()
+
+
 def refresh_regression_summary_cache_job():
     if not _regression_cache_refresh_lock.acquire(blocking=False):
         logging.info("Regression summary refresh is already running")
         return
     try:
-        summary = refresh_regression_summary_cache() or {}
-        logging.info(
-            "Refreshed regression summary (days=%s, regressions=%s, attributed=%s, complete=%s)",
-            summary.get("days"),
-            summary.get("regression_count"),
-            summary.get("attributed_count"),
-            summary.get("complete"),
-        )
+        _refresh_and_log_regression_summary_cache()
     finally:
         _regression_cache_refresh_lock.release()
 
 
 def start_regression_summary_cache_refresh_job():
-    if _regression_cache_refresh_lock.locked():
+    if not _regression_cache_refresh_lock.acquire(blocking=False):
         logging.info("Regression summary refresh is already running")
         return
     threading.Thread(
-        target=refresh_regression_summary_cache_job,
+        target=_refresh_regression_summary_cache_in_background,
         name="regression-summary-cache-refresh",
         daemon=True,
     ).start()

--- a/jobs.py
+++ b/jobs.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import threading
 import time
 from datetime import date, datetime, timedelta, timezone
 from urllib.parse import urlsplit, urlunsplit
@@ -32,6 +33,7 @@ from linear.issues import (
 from linear.projects import get_projects
 from openai_client import get_chat_function_call
 from project_dates import format_project_target_status, parse_iso_date
+from regression_cache import refresh_regression_summary_cache
 from support import get_support_slugs
 
 load_dotenv()
@@ -42,6 +44,7 @@ RETRY_SLEEP_SECONDS = 5
 MAX_DIFF_CHARS = 12000
 MAX_DIFF_FILES = 20
 FLEET_HEALTH_REFRESH_DEFAULT_SECONDS = 60
+REGRESSION_CACHE_REFRESH_HOURS = 6
 AIRFLOW_FLEET_HEARTBEAT_TIMEOUT_SECONDS = 10
 AIRFLOW_FLEET_UNKNOWN_HEARTBEAT_FAILURE_THRESHOLD = 3
 STALE_LINEAR_ISSUE_DAYS = 21
@@ -55,6 +58,7 @@ INACTIVE_PROJECT_STATUS_NAMES = {
 PROJECT_UPDATE_DUE_WEEKDAY = 4
 PROJECT_UPDATE_EARLY_WINDOW_DAYS = 2
 _airflow_fleet_unknown_heartbeat_failures = 0
+_regression_cache_refresh_lock = threading.Lock()
 
 
 def _read_positive_int_env(name: str, default: int) -> int:
@@ -178,6 +182,34 @@ def refresh_leaderboard_cache_job():
     context = refresh_leaderboard_cache(DEFAULT_LEADERBOARD_DAYS)
     n = len(context.get("leaderboard_entries") or [])
     logging.info("Refreshed leaderboard cache (days=%s, entries=%s)", context.get("days"), n)
+
+
+def refresh_regression_summary_cache_job():
+    if not _regression_cache_refresh_lock.acquire(blocking=False):
+        logging.info("Regression summary refresh is already running")
+        return
+    try:
+        summary = refresh_regression_summary_cache() or {}
+        logging.info(
+            "Refreshed regression summary (days=%s, regressions=%s, attributed=%s, complete=%s)",
+            summary.get("days"),
+            summary.get("regression_count"),
+            summary.get("attributed_count"),
+            summary.get("complete"),
+        )
+    finally:
+        _regression_cache_refresh_lock.release()
+
+
+def start_regression_summary_cache_refresh_job():
+    if _regression_cache_refresh_lock.locked():
+        logging.info("Regression summary refresh is already running")
+        return
+    threading.Thread(
+        target=refresh_regression_summary_cache_job,
+        name="regression-summary-cache-refresh",
+        daemon=True,
+    ).start()
 
 
 def report_airflow_fleet_health_heartbeat(payload: dict, status: int) -> None:
@@ -942,6 +974,7 @@ def run_debug_jobs() -> None:
     if should_use_redis_cache():
         refresh_airflow_fleet_health_cache_job()
         refresh_leaderboard_cache_job()
+        refresh_regression_summary_cache_job()
     post_inactive_engineers()
     post_priority_bugs()
     post_leaderboard()
@@ -960,9 +993,17 @@ def configure_scheduled_jobs() -> None:
         refresh_airflow_fleet_health_cache_job()
         schedule.every(refresh_interval_seconds).seconds.do(refresh_leaderboard_cache_job)
         refresh_leaderboard_cache_job()
+        schedule.every(REGRESSION_CACHE_REFRESH_HOURS).hours.do(
+            start_regression_summary_cache_refresh_job
+        )
+        start_regression_summary_cache_refresh_job()
         logging.info(
             "Scheduled airflow fleet health and leaderboard cache refresh every %s seconds",
             refresh_interval_seconds,
+        )
+        logging.info(
+            "Scheduled regression dashboard cache refresh every %s hours",
+            REGRESSION_CACHE_REFRESH_HOURS,
         )
     else:
         logging.info("REDIS_URL not set; cache refresh is disabled")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,5 @@ ignore_decorators = ["@app.route", "@app.template_filter"]
 ignore_names = [
     "breakdown",
     "post_weekly_changelog",
-    "refresh_regression_summary_cache",
 ]
 min_confidence = 60

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -250,18 +250,34 @@ class ConfigureScheduledJobsTest(unittest.TestCase):
                             start_regression_refresh.assert_called_once_with()
 
 
-class RunDebugJobsTest(unittest.TestCase):
-    def test_regression_refresh_starts_in_daemon_thread(self):
+class RegressionSummaryCacheRefreshTest(unittest.TestCase):
+    def tearDown(self):
+        lock = jobs_module._regression_cache_refresh_lock
+        if lock.locked():
+            lock.release()
+
+    def test_starts_refresh_in_daemon_thread(self):
         with patch.object(jobs_module.threading, "Thread") as thread:
             jobs_module.start_regression_summary_cache_refresh_job()
 
         thread.assert_called_once_with(
-            target=jobs_module.refresh_regression_summary_cache_job,
+            target=jobs_module._refresh_regression_summary_cache_in_background,
             name="regression-summary-cache-refresh",
             daemon=True,
         )
         thread.return_value.start.assert_called_once_with()
 
+    def test_start_skips_when_refresh_is_already_running(self):
+        self.assertTrue(jobs_module._regression_cache_refresh_lock.acquire(blocking=False))
+        with patch.object(jobs_module.threading, "Thread") as thread:
+            with patch.object(jobs_module.logging, "info") as info:
+                jobs_module.start_regression_summary_cache_refresh_job()
+
+        thread.assert_not_called()
+        info.assert_called_once_with("Regression summary refresh is already running")
+
+
+class RunDebugJobsTest(unittest.TestCase):
     def test_runs_leaderboard_stale_and_project_updates(self):
         with patch.object(jobs_module, "should_use_redis_cache", return_value=False):
             with patch.object(jobs_module, "post_inactive_engineers"):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -47,6 +47,10 @@ def _install_import_shims() -> None:
     leaderboard_cache_module.refresh_leaderboard_cache = lambda *args, **kwargs: {}
     sys.modules.setdefault("leaderboard_cache", leaderboard_cache_module)
 
+    regression_cache_module = cast(Any, types.ModuleType("regression_cache"))
+    regression_cache_module.refresh_regression_summary_cache = lambda *args, **kwargs: {}
+    sys.modules.setdefault("regression_cache", regression_cache_module)
+
     github_module = cast(Any, types.ModuleType("github"))
     github_module.GitHubDataError = type("GitHubDataError", (RuntimeError,), {})
     github_module.get_pr_diff = lambda *args, **kwargs: ""
@@ -95,6 +99,7 @@ for module_name in [
     "github",
     "leaderboard",
     "leaderboard_cache",
+    "regression_cache",
     "linear",
     "linear.issues",
     "linear.projects",
@@ -135,6 +140,11 @@ class _FakeScheduledJob:
     @property
     def seconds(self):
         self.unit = "seconds"
+        return self
+
+    @property
+    def hours(self):
+        self.unit = "hours"
         return self
 
     def at(self, at_time, timezone=None):
@@ -216,17 +226,42 @@ class ConfigureScheduledJobsTest(unittest.TestCase):
         with patch.object(jobs_module, "should_use_redis_cache", return_value=True):
             with patch.object(jobs_module, "refresh_airflow_fleet_health_cache_job"):
                 with patch.object(jobs_module, "refresh_leaderboard_cache_job"):
-                    with patch.object(jobs_module.schedule, "every", side_effect=fake_every):
-                        jobs_module.configure_scheduled_jobs()
-                        self.assertTrue(
-                            any(
-                                job["func"] is jobs_module.refresh_leaderboard_cache_job
-                                for job in recorded_jobs
+                    with patch.object(
+                        jobs_module, "start_regression_summary_cache_refresh_job"
+                    ) as start_regression_refresh:
+                        with patch.object(jobs_module.schedule, "every", side_effect=fake_every):
+                            jobs_module.configure_scheduled_jobs()
+                            self.assertTrue(
+                                any(
+                                    job["func"] is jobs_module.refresh_leaderboard_cache_job
+                                    for job in recorded_jobs
+                                )
                             )
-                        )
+                            self.assertIn(
+                                {
+                                    "interval": jobs_module.REGRESSION_CACHE_REFRESH_HOURS,
+                                    "unit": "hours",
+                                    "at_time": None,
+                                    "timezone": None,
+                                    "func": jobs_module.start_regression_summary_cache_refresh_job,
+                                },
+                                recorded_jobs,
+                            )
+                            start_regression_refresh.assert_called_once_with()
 
 
 class RunDebugJobsTest(unittest.TestCase):
+    def test_regression_refresh_starts_in_daemon_thread(self):
+        with patch.object(jobs_module.threading, "Thread") as thread:
+            jobs_module.start_regression_summary_cache_refresh_job()
+
+        thread.assert_called_once_with(
+            target=jobs_module.refresh_regression_summary_cache_job,
+            name="regression-summary-cache-refresh",
+            daemon=True,
+        )
+        thread.return_value.start.assert_called_once_with()
+
     def test_runs_leaderboard_stale_and_project_updates(self):
         with patch.object(jobs_module, "should_use_redis_cache", return_value=False):
             with patch.object(jobs_module, "post_inactive_engineers"):


### PR DESCRIPTION
## Summary
- refresh regression summaries in a non-blocking worker thread
- prevent overlapping refresh jobs
- schedule one 30-day refresh every six hours

## Stack

1. #448
2. #451
3. #452
4. #453
5. #454
6. #455
7. #456
8. #457 <-- you are here
9. #458

## Proof

`configure_scheduled_jobs()` with `REDIS_URL=redis://127.0.0.1:6379/15` scheduled the worker and started a live daemon refresh against Linear/GitHub:

```text
SCHEDULED_REGRESSION_JOB interval=6 unit=hours func=start_regression_summary_cache_refresh_job
IMMEDIATE_START_INVOKED thread=regression-summary-cache-refresh
```

While that live refresh was in flight, overlapping calls were skipped:

```text
Regression summary refresh is already running
Regression summary refresh is already running
```

The daemon thread then wrote the 30-day summary to Redis (`regressions:summary:30`, TTL 86400):

```text
Refreshed regression summary (days=30, regressions=57, attributed=52, complete=False)
REDIS_PAYLOAD_SUMMARY days=30 configured=True complete=False regression_count=57 attributed_count=52 TTL=86400
```

## To Test
- `python -m unittest tests.test_jobs`
- `ruff check . && mypy .`

References #439
