### PR TITLE
Color person-page counts at 1.5σ, drop weekly rates

### DIFF
--- a/person_stats.py
+++ b/person_stats.py
@@ -25,7 +25,7 @@ LOWER_IS_BETTER_METRIC_KEYS = frozenset(
 )
 
 STDEV_COLOR_THRESHOLD = 1.5
-STDEV_COLOR_METRIC_KEYS = frozenset({"prs_merged", "prs_reviewed"})
+STDEV_COLOR_METRIC_KEYS = frozenset({"prs_merged", "prs_reviewed", "all_work_done"})
 
 MetricValue = float | int | None
 

--- a/person_stats.py
+++ b/person_stats.py
@@ -24,6 +24,9 @@ LOWER_IS_BETTER_METRIC_KEYS = frozenset(
     }
 )
 
+STDEV_COLOR_THRESHOLD = 1.5
+STDEV_COLOR_METRIC_KEYS = frozenset({"prs_merged", "prs_reviewed"})
+
 MetricValue = float | int | None
 
 
@@ -64,6 +67,14 @@ def format_stdev_label(z: float) -> str:
     return f"{sign}{abs(z):.1f}σ"
 
 
+def stdev_tone(z: float, *, threshold: float = STDEV_COLOR_THRESHOLD) -> str | None:
+    if z >= threshold:
+        return "high"
+    if z <= -threshold:
+        return "low"
+    return None
+
+
 def format_stdev_tooltip(values: list[float], *, lower_is_better: bool = False) -> str:
     tooltip = f"eng avg {statistics.fmean(values):.1f} · σ {statistics.pstdev(values):.1f}"
     return f"{tooltip} · lower is better" if lower_is_better else tooltip
@@ -86,8 +97,13 @@ def metric_stdevs_for_person(
         lower_is_better = key in LOWER_IS_BETTER_METRIC_KEYS
         if lower_is_better:
             z = -z
-        result[key] = {
+        entry: dict[str, str] = {
             "label": format_stdev_label(z),
             "tooltip": format_stdev_tooltip(values, lower_is_better=lower_is_better),
         }
+        if key in STDEV_COLOR_METRIC_KEYS:
+            tone = stdev_tone(z)
+            if tone is not None:
+                entry["tone"] = tone
+        result[key] = entry
     return result

--- a/templates/partials/person_content.html
+++ b/templates/partials/person_content.html
@@ -127,14 +127,8 @@
     <article>
       <header>
         <a href="https://linear.app/differential/profiles/{{ linear_username }}">All Work Done</a>
-        <small id="work-done-tooltip" data-tooltip="< 2/week: red; ≥ 5/week: green" style="font-size: 0.8em; opacity: 0.6;">ⓘ</small>
       </header>
-      {% if days >= 7 %}
-        {% set rate = (all_work_done * 7 / days) %}
-      {% endif %}
-      <h1{% if days >= 7 and rate < 2 %} class="low"{% elif days >= 7 and rate >= 5 %} class="high"{% endif %}>
-        {{ all_work_done }}
-      </h1>
+      {{ metric_heading('all_work_done', all_work_done) }}
       {{ stdev_badge('all_work_done') }}
     </article>
   </div>

--- a/templates/partials/person_content.html
+++ b/templates/partials/person_content.html
@@ -4,6 +4,10 @@
   <small class="metric-stdev" data-tooltip="{{ stat.tooltip }}" data-placement="bottom">{{ stat.label }}</small>
   {%- endif -%}
 {%- endmacro %}
+{% macro metric_heading(key, value) -%}
+  {%- set tone = (metric_stdevs or {}).get(key, {}).get('tone') -%}
+  <h1{% if tone %} class="{{ tone }}"{% endif %}>{{ value }}</h1>
+{%- endmacro %}
 <h2>{{ 'Current Support Work' if on_call_support else 'Current Project Work' }}</h2>
 {% if open_current_cycle %}
 {% for project, issues in open_current_cycle.items() %}
@@ -51,14 +55,14 @@
         PRs Merged
         {% endif %}
       </header>
-      <h1>{{ prs_merged }}</h1>
+      {{ metric_heading('prs_merged', prs_merged) }}
       {{ stdev_badge('prs_merged') }}
     </article>
   </div>
   <div>
     <article>
       <header>PRs Reviewed</header>
-      <h1>{{ prs_reviewed }}</h1>
+      {{ metric_heading('prs_reviewed', prs_reviewed) }}
       {{ stdev_badge('prs_reviewed') }}
     </article>
   </div>

--- a/templates/person.html
+++ b/templates/person.html
@@ -4,9 +4,6 @@
 
 {% block extra_head %}
 <style>
-  #work-done-tooltip[data-tooltip]::before {
-    font-size: 0.7em;
-  }
   h1.low {
     color: #b33;
   }

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -74,9 +74,10 @@ class PersonStatsTest(unittest.TestCase):
 
         self.assertEqual(high_stdevs["prs_merged"]["tone"], "high")
         self.assertEqual(high_stdevs["prs_reviewed"]["tone"], "high")
-        self.assertNotIn("tone", high_stdevs["all_work_done"])
+        self.assertEqual(high_stdevs["all_work_done"]["tone"], "high")
         self.assertEqual(low_stdevs["prs_merged"]["tone"], "low")
         self.assertEqual(low_stdevs["prs_reviewed"]["tone"], "low")
+        self.assertEqual(low_stdevs["all_work_done"]["tone"], "low")
 
     def test_person_cards_color_pr_headings_beyond_stdev_threshold(self):
         app_module._build_person_context.cache_clear()
@@ -92,10 +93,13 @@ class PersonStatsTest(unittest.TestCase):
             }
         }
 
+        def fake_completed(login, days=30, window=None):
+            return [_issue() for _ in range(10)] if login == "alice" else []
+
         with (
             patch.object(app_module, "load_config", return_value=config),
             patch.object(app_module, "get_open_issues_for_person", return_value=[]),
-            patch.object(app_module, "get_completed_issues_for_person", return_value=[]),
+            patch.object(app_module, "get_completed_issues_for_person", side_effect=fake_completed),
             patch.object(app_module, "get_projects", return_value=[]),
             patch.object(
                 app_module,
@@ -110,11 +114,13 @@ class PersonStatsTest(unittest.TestCase):
 
         self.assertEqual(context["metric_stdevs"]["prs_merged"]["tone"], "high")
         self.assertEqual(context["metric_stdevs"]["prs_reviewed"]["tone"], "high")
-        self.assertNotIn("tone", context["metric_stdevs"].get("all_work_done", {}))
+        self.assertEqual(context["metric_stdevs"]["all_work_done"]["tone"], "high")
         with app_module.app.test_request_context():
             body = app_module.render_template("partials/person_content.html", **context)
-        self.assertEqual(body.count('<h1 class="high">10</h1>'), 2)
+        self.assertEqual(body.count('<h1 class="high">10</h1>'), 3)
         self.assertNotIn('<h1 class="high">0</h1>', body)
+        self.assertNotIn("2/week", body)
+        self.assertNotIn("5/week", body)
 
     def test_person_cards_include_on_page_stdev_badges(self):
         app_module._build_person_context.cache_clear()
@@ -162,7 +168,10 @@ class PersonStatsTest(unittest.TestCase):
         with app_module.app.test_request_context():
             body = app_module.render_template("partials/person_content.html", **context)
         self.assertIn("<h1>10</h1>", body)
+        self.assertIn("<h1>8</h1>", body)
         self.assertNotIn('<h1 class="high">10</h1>', body)
+        self.assertNotIn('class="low"', body)
+        self.assertNotIn("2/week", body)
         self.assertIn('data-placement="bottom"', body)
         styles = Path(__file__).resolve().parents[1].joinpath("static/styles.css").read_text()
         self.assertIn("max-width: min(12rem, calc(100vw - 2rem));", styles)

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -46,12 +46,75 @@ class PersonStatsTest(unittest.TestCase):
         stdevs = person_stats.metric_stdevs_for_person(person_metrics, team_metrics)
 
         self.assertEqual(stdevs["prs_merged"]["label"], "+1.0σ")
+        self.assertNotIn("tone", stdevs["prs_merged"])
         self.assertEqual(stdevs["priority_bug_avg_time_to_fix"]["label"], "+1.0σ")
         self.assertEqual(stdevs["avg_all_time_to_fix"]["label"], "−1.0σ")
         self.assertEqual(stdevs["lead_completed_projects_avg_early_late"]["label"], "+1.0σ")
         self.assertTrue(
             stdevs["priority_bug_avg_time_to_fix"]["tooltip"].endswith("lower is better")
         )
+
+    def test_pr_cards_color_at_one_and_a_half_sigma(self):
+        self.assertEqual(person_stats.stdev_tone(1.5), "high")
+        self.assertEqual(person_stats.stdev_tone(-1.5), "low")
+        self.assertIsNone(person_stats.stdev_tone(1.49))
+        self.assertIsNone(person_stats.stdev_tone(-1.49))
+
+        high_person = {"prs_merged": 10, "prs_reviewed": 10, "all_work_done": 10}
+        clustered_low = {"prs_merged": 0, "prs_reviewed": 0, "all_work_done": 0}
+        low_person = {"prs_merged": 0, "prs_reviewed": 0, "all_work_done": 0}
+        clustered_high = {"prs_merged": 10, "prs_reviewed": 10, "all_work_done": 10}
+
+        high_stdevs = person_stats.metric_stdevs_for_person(
+            high_person, [high_person, clustered_low, clustered_low, clustered_low]
+        )
+        low_stdevs = person_stats.metric_stdevs_for_person(
+            low_person, [low_person, clustered_high, clustered_high, clustered_high]
+        )
+
+        self.assertEqual(high_stdevs["prs_merged"]["tone"], "high")
+        self.assertEqual(high_stdevs["prs_reviewed"]["tone"], "high")
+        self.assertNotIn("tone", high_stdevs["all_work_done"])
+        self.assertEqual(low_stdevs["prs_merged"]["tone"], "low")
+        self.assertEqual(low_stdevs["prs_reviewed"]["tone"], "low")
+
+    def test_person_cards_color_pr_headings_beyond_stdev_threshold(self):
+        app_module._build_person_context.cache_clear()
+        self.addCleanup(app_module._build_person_context.cache_clear)
+        config = {
+            "people": {
+                slug: {
+                    "team": "engineering",
+                    "linear_username": slug,
+                    "github_username": f"{slug}-gh",
+                }
+                for slug in ("alice", "bob", "cara", "drew")
+            }
+        }
+
+        with (
+            patch.object(app_module, "load_config", return_value=config),
+            patch.object(app_module, "get_open_issues_for_person", return_value=[]),
+            patch.object(app_module, "get_completed_issues_for_person", return_value=[]),
+            patch.object(app_module, "get_projects", return_value=[]),
+            patch.object(
+                app_module,
+                "get_merged_pr_counts_for_user",
+                side_effect=lambda username, days=30, window=None: (
+                    (10, 10) if username == "alice-gh" else (0, 0)
+                ),
+            ),
+            patch.object(app_module, "get_support_slugs", return_value=set()),
+        ):
+            context = app_module._build_person_context("alice", 30, 1)
+
+        self.assertEqual(context["metric_stdevs"]["prs_merged"]["tone"], "high")
+        self.assertEqual(context["metric_stdevs"]["prs_reviewed"]["tone"], "high")
+        self.assertNotIn("tone", context["metric_stdevs"].get("all_work_done", {}))
+        with app_module.app.test_request_context():
+            body = app_module.render_template("partials/person_content.html", **context)
+        self.assertEqual(body.count('<h1 class="high">10</h1>'), 2)
+        self.assertNotIn('<h1 class="high">0</h1>', body)
 
     def test_person_cards_include_on_page_stdev_badges(self):
         app_module._build_person_context.cache_clear()
@@ -95,8 +158,11 @@ class PersonStatsTest(unittest.TestCase):
             context = app_module._build_person_context("alice", 30, 1)
 
         self.assertEqual(context["metric_stdevs"]["prs_merged"]["tooltip"], "eng avg 6.0 · σ 4.0")
+        self.assertNotIn("tone", context["metric_stdevs"]["prs_merged"])
         with app_module.app.test_request_context():
             body = app_module.render_template("partials/person_content.html", **context)
+        self.assertIn("<h1>10</h1>", body)
+        self.assertNotIn('<h1 class="high">10</h1>', body)
         self.assertIn('data-placement="bottom"', body)
         styles = Path(__file__).resolve().parents[1].joinpath("static/styles.css").read_text()
         self.assertIn("max-width: min(12rem, calc(100vw - 2rem));", styles)


### PR DESCRIPTION
## Issue
Person-page **All Work Done** used red/green from weekly min/max rates (`< 2/week` / `≥ 5/week`). #443 asked to color by standard deviation instead, at ±1.5σ, starting with **PRs Merged** and **PRs Reviewed**. Weekly rates should not affect colors at all.

## Solution
Color **PRs Merged**, **PRs Reviewed**, and **All Work Done** from the engineering-group z-score: green at ≥ +1.5σ, red at ≤ −1.5σ. Remove the weekly-rate tooltip and `< 2` / `≥ 5` coloring.

Closes #443

## To Test
- Open `/team/<engineer>?days=30` and confirm PR and All Work Done counts turn green or red only at about ±1.5σ
- Confirm a count near ±1.0σ stays the default color
- Confirm the All Work Done card has no 2/week or 5/week tooltip

## Proof
Live `/team/michael?days=30` (PR cards; All Work Done now uses the same σ rule): PRs Merged **361 / +2.5σ** is green; PRs Reviewed **152 / +1.0σ** stays default.

![Michael PR cards](https://github.com/ApollosProject/bug-board/releases/download/proof-467/michael-prs.png)

Live `/team/nathan?days=30`: PRs Merged **76 / −0.1σ** stays default; PRs Reviewed **192 / +1.8σ** is green.

![Nathan PR cards](https://github.com/ApollosProject/bug-board/releases/download/proof-467/nathan-prs.png)