### PR TITLE
Add leaderboard CSV export

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,11 +25,7 @@ from github import (
 )
 from leaderboard import calculate_cycle_project_points
 from leaderboard_cache import DEFAULT_LEADERBOARD_DAYS, get_cached_leaderboard
-from leaderboard_export import (
-    build_leaderboard_export_rows,
-    leaderboard_csv_filename,
-    render_leaderboard_csv,
-)
+from leaderboard_export import build_leaderboard_export_rows, render_leaderboard_csv
 from linear.issues import (
     by_platform,
     by_project,
@@ -1050,24 +1046,20 @@ def leaderboard_csv():
     context = _leaderboard_page_context()
     if context.get("leaderboard_unavailable"):
         return Response("Leaderboard is refreshing.\n", status=503, mimetype="text/plain")
-
-    people_config = load_config().get("people", {})
-    engineering_people = {
-        slug: info
-        for slug, info in people_config.items()
-        if info.get("team") == ENGINEERING_TEAM_SLUG
-    }
-    rows = build_leaderboard_export_rows(
-        context.get("leaderboard_entries") or [],
-        engineering_people=engineering_people,
-        regression_summary=get_cached_regression_summary(),
+    preset = context.get("preset_days")
+    filename = (
+        f"leaderboard-{preset}d.csv"
+        if isinstance(preset, int)
+        else f"leaderboard-{context.get('start') or 'start'}-to-{context.get('end') or 'end'}.csv"
     )
     return Response(
-        render_leaderboard_csv(rows),
+        render_leaderboard_csv(
+            build_leaderboard_export_rows(context.get("leaderboard_entries") or [])
+        ),
         mimetype="text/csv; charset=utf-8",
         headers={
             "Cache-Control": "no-store",
-            "Content-Disposition": (f'attachment; filename="{leaderboard_csv_filename(context)}"'),
+            "Content-Disposition": f'attachment; filename="{filename}"',
         },
     )
 

--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from typing import Any, TypedDict, TypeVar
 from urllib.parse import quote
 
-from flask import Flask, abort, jsonify, render_template, request
+from flask import Flask, Response, abort, jsonify, render_template, request
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from airflow_fleet_health import AirflowFleetHealthError, evaluate_fleet_health
@@ -25,6 +25,11 @@ from github import (
 )
 from leaderboard import calculate_cycle_project_points
 from leaderboard_cache import DEFAULT_LEADERBOARD_DAYS, get_cached_leaderboard
+from leaderboard_export import (
+    build_leaderboard_export_rows,
+    leaderboard_csv_filename,
+    render_leaderboard_csv,
+)
 from linear.issues import (
     by_platform,
     by_project,
@@ -451,6 +456,8 @@ class LeaderboardEntry(TypedDict):
     display_name: str | None
     score: int
     breakdown: str | None
+    points: dict[str, int]
+    counts: dict[str, int]
 
 
 BREAKDOWN_CATEGORIES: list[BreakdownCategory] = [
@@ -759,6 +766,8 @@ def _build_leaderboard_entries(
                 count_breakdown_by_slug.get(slug),
             )
             or None,
+            "points": dict(points_breakdown_by_slug.get(slug) or {}),
+            "counts": dict(count_breakdown_by_slug.get(slug) or {}),
         }
         for slug, score in scores_by_slug.items()
     ]
@@ -773,6 +782,8 @@ def _build_leaderboard_entries(
                     count_breakdown_by_external.get(key),
                 )
                 or None,
+                "points": dict(points_breakdown_by_external.get(key) or {}),
+                "counts": dict(count_breakdown_by_external.get(key) or {}),
             }
             for key, score in scores_by_external.items()
         ]
@@ -1010,29 +1021,55 @@ def index_open_items_partial():
     return render_template("partials/index_open_items.html", **context)
 
 
-@app.route("/partials/index/leaderboard")
-def index_leaderboard_partial():
+def _leaderboard_page_context() -> dict:
     window = _request_time_window()
     if should_use_redis_cache() and window.preset_days == DEFAULT_LEADERBOARD_DAYS:
         cached = get_cached_leaderboard(window.preset_days)
         if cached is not None:
-            return render_template(
-                "partials/index_leaderboard.html",
-                **{**window.template_vars(), **cached},
-            )
+            return {**window.template_vars(), **cached}
         if not _is_development_mode():
             logging.info(
                 "Leaderboard cache miss while REDIS_URL is configured (days=%s)",
                 window.preset_days,
             )
-            return render_template(
-                "partials/index_leaderboard.html",
+            return {
                 **window.template_vars(),
-                leaderboard_entries=[],
-                leaderboard_unavailable=True,
-            )
-    context = _cached_window_context(_build_leaderboard_context, window)
-    return render_template("partials/index_leaderboard.html", **context)
+                "leaderboard_entries": [],
+                "leaderboard_unavailable": True,
+            }
+    return _cached_window_context(_build_leaderboard_context, window)
+
+
+@app.route("/partials/index/leaderboard")
+def index_leaderboard_partial():
+    return render_template("partials/index_leaderboard.html", **_leaderboard_page_context())
+
+
+@app.route("/leaderboard.csv")
+def leaderboard_csv():
+    context = _leaderboard_page_context()
+    if context.get("leaderboard_unavailable"):
+        return Response("Leaderboard is refreshing.\n", status=503, mimetype="text/plain")
+
+    people_config = load_config().get("people", {})
+    engineering_people = {
+        slug: info
+        for slug, info in people_config.items()
+        if info.get("team") == ENGINEERING_TEAM_SLUG
+    }
+    rows = build_leaderboard_export_rows(
+        context.get("leaderboard_entries") or [],
+        engineering_people=engineering_people,
+        regression_summary=get_cached_regression_summary(),
+    )
+    return Response(
+        render_leaderboard_csv(rows),
+        mimetype="text/csv; charset=utf-8",
+        headers={
+            "Cache-Control": "no-store",
+            "Content-Disposition": (f'attachment; filename="{leaderboard_csv_filename(context)}"'),
+        },
+    )
 
 
 @app.route("/partials/index/regressions")

--- a/leaderboard_export.py
+++ b/leaderboard_export.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import csv
+import io
+import re
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+from constants import ENGINEERING_TEAM_SLUG
+from person_stats import z_score
+
+PARAMETER_SPECS: tuple[tuple[str, str | None, str], ...] = (
+    ("urgent", "urgent_issues", "urgent_points"),
+    ("high", "high_issues", "high_points"),
+    ("medium", "medium_issues", "medium_points"),
+    ("low", "low_issues", "low_points"),
+    ("reviews", "pr_reviews", "pr_review_points"),
+    ("prs", "prs_merged", "pr_points"),
+    ("cycle_lead", None, "cycle_lead_points"),
+    ("cycle_member", None, "cycle_member_points"),
+)
+
+CSV_COLUMNS: tuple[str, ...] = (
+    "person",
+    "slug",
+    "score",
+    "score_stdev",
+    *(
+        name
+        for _key, count_column, points_column in PARAMETER_SPECS
+        for name in (
+            *([count_column] if count_column else []),
+            points_column,
+            f"{points_column}_stdev",
+        )
+    ),
+    "regressions_authored",
+    "author_regression_rate",
+    "regressions_approved",
+    "reviewer_escape_rate",
+)
+
+
+def format_export_name(slug: str, info: Mapping[str, Any] | None = None) -> str:
+    username = (info or {}).get("linear_username") or slug
+    if not isinstance(username, str) or not username:
+        username = slug
+    return re.sub(r"[._-]+", " ", username).title()
+
+
+def leaderboard_csv_filename(context: Mapping[str, Any]) -> str:
+    preset = context.get("preset_days")
+    if isinstance(preset, int):
+        return f"leaderboard-{preset}d.csv"
+    start = context.get("start") or "start"
+    end = context.get("end") or "end"
+    return f"leaderboard-{start}-to-{end}.csv"
+
+
+def render_leaderboard_csv(rows: Sequence[Mapping[str, Any]]) -> str:
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=list(CSV_COLUMNS), lineterminator="\n")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({column: row.get(column, "") for column in CSV_COLUMNS})
+    return buffer.getvalue()
+
+
+def build_leaderboard_export_rows(
+    entries: Sequence[Mapping[str, Any]],
+    *,
+    engineering_people: Mapping[str, Mapping[str, Any]] | None = None,
+    regression_summary: Mapping[str, Any] | None = None,
+    format_name: Callable[[str, Mapping[str, Any] | None], str] = format_export_name,
+) -> list[dict[str, Any]]:
+    rows = [
+        _entry_to_base_row(entry, format_name=format_name)
+        for entry in entries
+        if isinstance(entry, Mapping)
+    ]
+    rows.extend(
+        _missing_engineering_rows(
+            rows,
+            engineering_people or {},
+            format_name=format_name,
+        )
+    )
+    rows.sort(key=lambda row: (-int(row["score"] or 0), str(row["person"])))
+    _attach_parameter_stdevs(rows)
+    _attach_regression_columns(rows, regression_summary)
+    return rows
+
+
+def _entry_to_base_row(
+    entry: Mapping[str, Any],
+    *,
+    format_name: Callable[[str, Mapping[str, Any] | None], str],
+) -> dict[str, Any]:
+    slug = entry.get("slug")
+    slug_value = slug if isinstance(slug, str) and slug else ""
+    display_name = entry.get("display_name")
+    if not isinstance(display_name, str) or not display_name:
+        display_name = format_name(slug_value, None) if slug_value else ""
+    raw_points = entry.get("points")
+    raw_counts = entry.get("counts")
+    points = raw_points if isinstance(raw_points, Mapping) else {}
+    counts = raw_counts if isinstance(raw_counts, Mapping) else {}
+    row: dict[str, Any] = {
+        "person": display_name,
+        "slug": slug_value,
+        "score": int(entry.get("score") or 0),
+    }
+    for key, count_column, points_column in PARAMETER_SPECS:
+        if count_column:
+            row[count_column] = int(counts.get(key) or 0)
+        row[points_column] = int(points.get(key) or 0)
+    return row
+
+
+def _missing_engineering_rows(
+    rows: Sequence[Mapping[str, Any]],
+    engineering_people: Mapping[str, Mapping[str, Any]],
+    *,
+    format_name: Callable[[str, Mapping[str, Any] | None], str],
+) -> list[dict[str, Any]]:
+    present = {str(row.get("slug")) for row in rows if row.get("slug")}
+    missing: list[dict[str, Any]] = []
+    for slug, info in engineering_people.items():
+        if info.get("team") != ENGINEERING_TEAM_SLUG:
+            continue
+        if slug in present:
+            continue
+        missing.append(
+            _entry_to_base_row(
+                {
+                    "slug": slug,
+                    "display_name": format_name(slug, info),
+                    "score": 0,
+                    "points": {},
+                    "counts": {},
+                },
+                format_name=format_name,
+            )
+        )
+    return missing
+
+
+def _attach_parameter_stdevs(rows: list[dict[str, Any]]) -> None:
+    numeric_columns = ["score", *(points_column for _key, _count, points_column in PARAMETER_SPECS)]
+    for column in numeric_columns:
+        values = [float(row.get(column) or 0) for row in rows]
+        for row, value in zip(rows, values, strict=True):
+            z = z_score(value, values)
+            row[f"{column}_stdev"] = "" if z is None else f"{z:.1f}"
+
+
+def _metrics_by_slug(metrics: Any) -> dict[str, Mapping[str, Any]]:
+    if not isinstance(metrics, list):
+        return {}
+    by_slug: dict[str, Mapping[str, Any]] = {}
+    for item in metrics:
+        if isinstance(item, Mapping) and isinstance(item.get("slug"), str):
+            by_slug[item["slug"]] = item
+    return by_slug
+
+
+def _regression_value(metric: Mapping[str, Any] | None, field: str) -> Any:
+    if metric is None:
+        return 0 if field == "regression_count" else ""
+    value = metric.get(field)
+    if field == "regression_count":
+        return int(value or 0)
+    return "" if value is None else value
+
+
+def _attach_regression_columns(
+    rows: list[dict[str, Any]],
+    regression_summary: Mapping[str, Any] | None,
+) -> None:
+    configured = bool(regression_summary and regression_summary.get("configured"))
+    authors = _metrics_by_slug((regression_summary or {}).get("author_metrics"))
+    reviewers = _metrics_by_slug((regression_summary or {}).get("reviewer_metrics"))
+    for row in rows:
+        slug = str(row.get("slug") or "")
+        if not configured:
+            row["regressions_authored"] = ""
+            row["author_regression_rate"] = ""
+            row["regressions_approved"] = ""
+            row["reviewer_escape_rate"] = ""
+            continue
+        author = authors.get(slug)
+        reviewer = reviewers.get(slug)
+        row["regressions_authored"] = _regression_value(author, "regression_count")
+        row["author_regression_rate"] = _regression_value(author, "rate")
+        row["regressions_approved"] = _regression_value(reviewer, "regression_count")
+        row["reviewer_escape_rate"] = _regression_value(reviewer, "rate")

--- a/leaderboard_export.py
+++ b/leaderboard_export.py
@@ -3,13 +3,10 @@ from __future__ import annotations
 import csv
 import io
 import re
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
 
-from constants import ENGINEERING_TEAM_SLUG
-from person_stats import z_score
-
-PARAMETER_SPECS: tuple[tuple[str, str | None, str], ...] = (
+PARAMS = (
     ("urgent", "urgent_issues", "urgent_points"),
     ("high", "high_issues", "high_points"),
     ("medium", "medium_issues", "medium_points"),
@@ -19,178 +16,45 @@ PARAMETER_SPECS: tuple[tuple[str, str | None, str], ...] = (
     ("cycle_lead", None, "cycle_lead_points"),
     ("cycle_member", None, "cycle_member_points"),
 )
-
-CSV_COLUMNS: tuple[str, ...] = (
+CSV_COLUMNS = [
     "person",
     "slug",
     "score",
-    "score_stdev",
-    *(
-        name
-        for _key, count_column, points_column in PARAMETER_SPECS
-        for name in (
-            *([count_column] if count_column else []),
-            points_column,
-            f"{points_column}_stdev",
-        )
-    ),
-    "regressions_authored",
-    "author_regression_rate",
-    "regressions_approved",
-    "reviewer_escape_rate",
-)
+    *(name for _key, count, points in PARAMS for name in ((count, points) if count else (points,))),
+]
 
 
-def format_export_name(slug: str, info: Mapping[str, Any] | None = None) -> str:
-    username = (info or {}).get("linear_username") or slug
-    if not isinstance(username, str) or not username:
-        username = slug
-    return re.sub(r"[._-]+", " ", username).title()
-
-
-def leaderboard_csv_filename(context: Mapping[str, Any]) -> str:
-    preset = context.get("preset_days")
-    if isinstance(preset, int):
-        return f"leaderboard-{preset}d.csv"
-    start = context.get("start") or "start"
-    end = context.get("end") or "end"
-    return f"leaderboard-{start}-to-{end}.csv"
+def _name(slug: str) -> str:
+    return re.sub(r"[._-]+", " ", slug).title()
 
 
 def render_leaderboard_csv(rows: Sequence[Mapping[str, Any]]) -> str:
-    buffer = io.StringIO()
-    writer = csv.DictWriter(buffer, fieldnames=list(CSV_COLUMNS), lineterminator="\n")
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=CSV_COLUMNS, lineterminator="\n")
     writer.writeheader()
-    for row in rows:
-        writer.writerow({column: row.get(column, "") for column in CSV_COLUMNS})
-    return buffer.getvalue()
+    writer.writerows({col: row.get(col, "") for col in CSV_COLUMNS} for row in rows)
+    return buf.getvalue()
 
 
-def build_leaderboard_export_rows(
-    entries: Sequence[Mapping[str, Any]],
-    *,
-    engineering_people: Mapping[str, Mapping[str, Any]] | None = None,
-    regression_summary: Mapping[str, Any] | None = None,
-    format_name: Callable[[str, Mapping[str, Any] | None], str] = format_export_name,
-) -> list[dict[str, Any]]:
-    rows = [
-        _entry_to_base_row(entry, format_name=format_name)
-        for entry in entries
-        if isinstance(entry, Mapping)
-    ]
-    rows.extend(
-        _missing_engineering_rows(
-            rows,
-            engineering_people or {},
-            format_name=format_name,
-        )
-    )
-    rows.sort(key=lambda row: (-int(row["score"] or 0), str(row["person"])))
-    _attach_parameter_stdevs(rows)
-    _attach_regression_columns(rows, regression_summary)
-    return rows
-
-
-def _entry_to_base_row(
-    entry: Mapping[str, Any],
-    *,
-    format_name: Callable[[str, Mapping[str, Any] | None], str],
-) -> dict[str, Any]:
-    slug = entry.get("slug")
-    slug_value = slug if isinstance(slug, str) and slug else ""
-    display_name = entry.get("display_name")
-    if not isinstance(display_name, str) or not display_name:
-        display_name = format_name(slug_value, None) if slug_value else ""
+def _row(entry: Mapping[str, Any]) -> dict[str, Any]:
+    slug = entry.get("slug") if isinstance(entry.get("slug"), str) else ""
     raw_points = entry.get("points")
     raw_counts = entry.get("counts")
     points = raw_points if isinstance(raw_points, Mapping) else {}
     counts = raw_counts if isinstance(raw_counts, Mapping) else {}
-    row: dict[str, Any] = {
-        "person": display_name,
-        "slug": slug_value,
+    row = {
+        "person": entry.get("display_name") or _name(str(slug)),
+        "slug": slug,
         "score": int(entry.get("score") or 0),
     }
-    for key, count_column, points_column in PARAMETER_SPECS:
-        if count_column:
-            row[count_column] = int(counts.get(key) or 0)
-        row[points_column] = int(points.get(key) or 0)
+    for key, count_col, point_col in PARAMS:
+        if count_col:
+            row[count_col] = int(counts.get(key) or 0)
+        row[point_col] = int(points.get(key) or 0)
     return row
 
 
-def _missing_engineering_rows(
-    rows: Sequence[Mapping[str, Any]],
-    engineering_people: Mapping[str, Mapping[str, Any]],
-    *,
-    format_name: Callable[[str, Mapping[str, Any] | None], str],
-) -> list[dict[str, Any]]:
-    present = {str(row.get("slug")) for row in rows if row.get("slug")}
-    missing: list[dict[str, Any]] = []
-    for slug, info in engineering_people.items():
-        if info.get("team") != ENGINEERING_TEAM_SLUG:
-            continue
-        if slug in present:
-            continue
-        missing.append(
-            _entry_to_base_row(
-                {
-                    "slug": slug,
-                    "display_name": format_name(slug, info),
-                    "score": 0,
-                    "points": {},
-                    "counts": {},
-                },
-                format_name=format_name,
-            )
-        )
-    return missing
-
-
-def _attach_parameter_stdevs(rows: list[dict[str, Any]]) -> None:
-    numeric_columns = ["score", *(points_column for _key, _count, points_column in PARAMETER_SPECS)]
-    for column in numeric_columns:
-        values = [float(row.get(column) or 0) for row in rows]
-        for row, value in zip(rows, values, strict=True):
-            z = z_score(value, values)
-            row[f"{column}_stdev"] = "" if z is None else f"{z:.1f}"
-
-
-def _metrics_by_slug(metrics: Any) -> dict[str, Mapping[str, Any]]:
-    if not isinstance(metrics, list):
-        return {}
-    by_slug: dict[str, Mapping[str, Any]] = {}
-    for item in metrics:
-        if isinstance(item, Mapping) and isinstance(item.get("slug"), str):
-            by_slug[item["slug"]] = item
-    return by_slug
-
-
-def _regression_value(metric: Mapping[str, Any] | None, field: str) -> Any:
-    if metric is None:
-        return 0 if field == "regression_count" else ""
-    value = metric.get(field)
-    if field == "regression_count":
-        return int(value or 0)
-    return "" if value is None else value
-
-
-def _attach_regression_columns(
-    rows: list[dict[str, Any]],
-    regression_summary: Mapping[str, Any] | None,
-) -> None:
-    configured = bool(regression_summary and regression_summary.get("configured"))
-    authors = _metrics_by_slug((regression_summary or {}).get("author_metrics"))
-    reviewers = _metrics_by_slug((regression_summary or {}).get("reviewer_metrics"))
-    for row in rows:
-        slug = str(row.get("slug") or "")
-        if not configured:
-            row["regressions_authored"] = ""
-            row["author_regression_rate"] = ""
-            row["regressions_approved"] = ""
-            row["reviewer_escape_rate"] = ""
-            continue
-        author = authors.get(slug)
-        reviewer = reviewers.get(slug)
-        row["regressions_authored"] = _regression_value(author, "regression_count")
-        row["author_regression_rate"] = _regression_value(author, "rate")
-        row["regressions_approved"] = _regression_value(reviewer, "regression_count")
-        row["reviewer_escape_rate"] = _regression_value(reviewer, "rate")
+def build_leaderboard_export_rows(entries: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    rows = [_row(entry) for entry in entries if isinstance(entry, Mapping)]
+    rows.sort(key=lambda row: (-int(row["score"]), str(row["person"])))
+    return rows

--- a/static/styles.css
+++ b/static/styles.css
@@ -160,6 +160,17 @@ details.dropdown.site-menu > summary + ul {
   box-sizing: border-box;
 }
 
+.leaderboard-heading {
+  align-items: baseline; display: flex; flex-wrap: wrap;
+  gap: 0.5rem 1rem; justify-content: space-between; margin: 0 0 0.75rem;
+}
+.leaderboard-heading h2 { margin: 0; }
+a.leaderboard-export {
+  color: var(--pico-muted-color); font-size: 0.8rem; font-weight: 600;
+  text-decoration: none; white-space: nowrap;
+}
+a.leaderboard-export:is(:hover, :focus) { color: var(--pico-primary); }
+
 .project-timeline-heading {
   align-items: baseline; display: flex; flex-wrap: wrap;
   gap: 0.5rem 1rem; justify-content: space-between; margin: 1.5rem 0 0.75rem;

--- a/static/styles.css
+++ b/static/styles.css
@@ -260,24 +260,6 @@ details.dropdown.site-menu > summary + ul {
 }
 .project-timeline-ooo-unavailable { color: #b83a3a; }
 
-.leaderboard-heading {
-  align-items: baseline;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem 1rem;
-  justify-content: space-between;
-}
-
-.leaderboard-heading h2 {
-  margin-bottom: 0;
-}
-
-.leaderboard-export {
-  font-size: 0.85rem;
-  font-weight: 600;
-  white-space: nowrap;
-}
-
 .metric-stdev {
   color: var(--pico-muted-color);
   display: block;

--- a/static/styles.css
+++ b/static/styles.css
@@ -260,6 +260,24 @@ details.dropdown.site-menu > summary + ul {
 }
 .project-timeline-ooo-unavailable { color: #b83a3a; }
 
+.leaderboard-heading {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  justify-content: space-between;
+}
+
+.leaderboard-heading h2 {
+  margin-bottom: 0;
+}
+
+.leaderboard-export {
+  font-size: 0.85rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
 .metric-stdev {
   color: var(--pico-muted-color);
   display: block;

--- a/templates/partials/index_leaderboard.html
+++ b/templates/partials/index_leaderboard.html
@@ -8,13 +8,10 @@
   "Completed project lead: 30 pts/week",
   "Completed project member: 15 pts/week"
 ] | join('\n') %}
-<div class="leaderboard-heading">
-  <h2>Leaderboard ({{ window_label or (days ~ 'd') }})</h2>
-  <a
-    class="leaderboard-export"
-    href="{{ url_for('leaderboard_csv', **(window_query or {'days': days})) }}"
-  >Export CSV</a>
-</div>
+<h2>
+  Leaderboard ({{ window_label or (days ~ 'd') }})
+  <a href="{{ url_for('leaderboard_csv', **(window_query or {'days': days})) }}">Export CSV</a>
+</h2>
 <h4>
   Scores
   <small

--- a/templates/partials/index_leaderboard.html
+++ b/templates/partials/index_leaderboard.html
@@ -8,7 +8,13 @@
   "Completed project lead: 30 pts/week",
   "Completed project member: 15 pts/week"
 ] | join('\n') %}
-<h2>Leaderboard ({{ window_label or (days ~ 'd') }})</h2>
+<div class="leaderboard-heading">
+  <h2>Leaderboard ({{ window_label or (days ~ 'd') }})</h2>
+  <a
+    class="leaderboard-export"
+    href="{{ url_for('leaderboard_csv', **(window_query or {'days': days})) }}"
+  >Export CSV</a>
+</div>
 <h4>
   Scores
   <small

--- a/templates/partials/index_leaderboard.html
+++ b/templates/partials/index_leaderboard.html
@@ -8,10 +8,13 @@
   "Completed project lead: 30 pts/week",
   "Completed project member: 15 pts/week"
 ] | join('\n') %}
-<h2>
-  Leaderboard ({{ window_label or (days ~ 'd') }})
-  <a href="{{ url_for('leaderboard_csv', **(window_query or {'days': days})) }}">Export CSV</a>
-</h2>
+<div class="leaderboard-heading">
+  <h2>Leaderboard ({{ window_label or (days ~ 'd') }})</h2>
+  <a
+    class="leaderboard-export"
+    href="{{ url_for('leaderboard_csv', **(window_query or {'days': days})) }}"
+  >Export CSV</a>
+</div>
 <h4>
   Scores
   <small

--- a/tests/test_leaderboard_export.py
+++ b/tests/test_leaderboard_export.py
@@ -40,6 +40,17 @@ class LeaderboardExportTest(unittest.TestCase):
             html = client.get("/partials/index/leaderboard").get_data(as_text=True)
         self.assertTrue(csv_text.startswith("person,slug,score"))
         self.assertIn("/leaderboard.csv?days=30", html)
+        self.assertIn('class="leaderboard-export"', html)
+        self.assertIn(">Export CSV</a>", html)
+        self.assertNotIn("<h2>\n  Leaderboard", html)
+        with open("static/styles.css") as styles_file:
+            styles = styles_file.read()
+        heading = styles.split(".leaderboard-heading {", 1)[1].split("}", 1)[0]
+        export = styles.split("a.leaderboard-export {", 1)[1].split("}", 1)[0]
+        self.assertIn("display: flex;", heading)
+        self.assertIn("justify-content: space-between;", heading)
+        self.assertIn("font-size: 0.8rem;", export)
+        self.assertIn("text-decoration: none;", export)
         with patch.object(
             app_module, "_leaderboard_page_context", return_value={"leaderboard_unavailable": True}
         ):

--- a/tests/test_leaderboard_export.py
+++ b/tests/test_leaderboard_export.py
@@ -1,196 +1,46 @@
-import csv
-import io
 import unittest
 from unittest.mock import patch
 
 import app as app_module
-from leaderboard_export import (
-    CSV_COLUMNS,
-    build_leaderboard_export_rows,
-    leaderboard_csv_filename,
-    render_leaderboard_csv,
-)
-
-
-def _entry(slug, display_name, score, points=None, counts=None):
-    return {
-        "slug": slug,
-        "display_name": display_name,
-        "score": score,
-        "breakdown": None,
-        "points": points or {},
-        "counts": counts or {},
-    }
+from leaderboard_export import build_leaderboard_export_rows, render_leaderboard_csv
 
 
 class LeaderboardExportTest(unittest.TestCase):
-    def test_csv_includes_parameters_stdevs_and_zero_score_regressions(self):
+    def test_csv_lists_score_parameters_and_route(self):
         rows = build_leaderboard_export_rows(
             [
-                _entry("alice", "Alice", 10, {"prs": 10, "urgent": 20}, {"prs": 10, "urgent": 1}),
-                _entry("bob", "Bob", 2, {"prs": 2}, {"prs": 2}),
-            ],
-            engineering_people={
-                "alice": {"team": "engineering", "linear_username": "alice"},
-                "bob": {"team": "engineering", "linear_username": "bob"},
-                "cara": {"team": "engineering", "linear_username": "cara"},
-                "andy": {"team": "unassigned", "linear_username": "andy"},
-            },
-            regression_summary={
-                "configured": True,
-                "author_metrics": [{"slug": "cara", "regression_count": 2, "rate": 4.0}],
-                "reviewer_metrics": [{"slug": "cara", "regression_count": 1, "rate": 1.5}],
-            },
+                {
+                    "slug": "a",
+                    "display_name": "A",
+                    "score": 10,
+                    "points": {"urgent": 20, "prs": 10},
+                    "counts": {"urgent": 1, "prs": 10},
+                },
+                {
+                    "slug": "b",
+                    "display_name": "B",
+                    "score": 2,
+                    "points": {"prs": 2},
+                    "counts": {"prs": 2},
+                },
+            ]
         )
-
-        self.assertEqual([row["slug"] for row in rows], ["alice", "bob", "cara"])
-        self.assertNotIn("andy", [row["slug"] for row in rows])
-        self.assertEqual(rows[0]["urgent_issues"], 1)
-        self.assertEqual(rows[0]["urgent_points"], 20)
-        self.assertEqual(rows[0]["score_stdev"], "1.4")
-        self.assertEqual(rows[1]["score_stdev"], "-0.5")
-        self.assertEqual(rows[2]["score"], 0)
-        self.assertEqual(rows[2]["regressions_authored"], 2)
-        self.assertEqual(rows[2]["author_regression_rate"], 4.0)
-        self.assertEqual(rows[2]["regressions_approved"], 1)
-        self.assertEqual(rows[2]["reviewer_escape_rate"], 1.5)
-        self.assertEqual(rows[0]["regressions_authored"], 0)
-        self.assertEqual(rows[0]["author_regression_rate"], "")
-
-        body = render_leaderboard_csv(rows)
-        header = next(csv.reader(io.StringIO(body)))
-        self.assertEqual(header, list(CSV_COLUMNS))
-        self.assertIn("score_stdev", header)
-        self.assertIn("urgent_issues", header)
-        self.assertIn("cycle_member_points_stdev", header)
-        self.assertIn("reviewer_escape_rate", header)
-
-    def test_unconfigured_regressions_leave_rate_columns_blank(self):
-        rows = build_leaderboard_export_rows(
-            [_entry("alice", "Alice", 4)],
-            engineering_people={"alice": {"team": "engineering"}},
-            regression_summary=None,
-        )
-
-        self.assertEqual(rows[0]["regressions_authored"], "")
-        self.assertEqual(rows[0]["author_regression_rate"], "")
-        self.assertEqual(rows[0]["regressions_approved"], "")
-        self.assertEqual(rows[0]["reviewer_escape_rate"], "")
-
-    def test_filename_uses_preset_or_date_range(self):
-        self.assertEqual(
-            leaderboard_csv_filename(
-                {"preset_days": 30, "start": "2026-01-01", "end": "2026-01-31"}
-            ),
-            "leaderboard-30d.csv",
-        )
-        self.assertEqual(
-            leaderboard_csv_filename({"start": "2026-01-01", "end": "2026-01-31"}),
-            "leaderboard-2026-01-01-to-2026-01-31.csv",
-        )
-
-
-class LeaderboardExportRouteTest(unittest.TestCase):
-    def setUp(self):
-        self.client = app_module.app.test_client()
-
-    def test_route_downloads_csv_and_partial_links_to_it(self):
-        context = {
+        self.assertEqual([row["slug"] for row in rows], ["a", "b"])
+        self.assertEqual((rows[0]["urgent_issues"], rows[0]["prs_merged"]), (1, 10))
+        self.assertIn("person,slug,score,urgent_issues", render_leaderboard_csv(rows))
+        ctx = {
             "days": 30,
             "preset_days": 30,
-            "start": "2026-07-20",
-            "end": "2026-08-19",
-            "window_label": "30d",
             "window_query": {"days": 30},
-            "leaderboard_entries": [
-                _entry("alice", "Alice", 10, {"prs": 10}, {"prs": 10}),
-                _entry("bob", "Bob", 2, {"prs": 2}, {"prs": 2}),
-            ],
+            "leaderboard_entries": [{"slug": "a", "display_name": "A", "score": 10}],
         }
-        config = {
-            "people": {
-                "alice": {"team": "engineering", "linear_username": "alice"},
-                "bob": {"team": "engineering", "linear_username": "bob"},
-            }
-        }
-        regressions = {
-            "configured": True,
-            "author_metrics": [{"slug": "alice", "regression_count": 3, "rate": 2.5}],
-            "reviewer_metrics": [{"slug": "bob", "regression_count": 1, "rate": 0.8}],
-        }
-        with (
-            patch.object(app_module, "_leaderboard_page_context", return_value=context),
-            patch.object(app_module, "load_config", return_value=config),
-            patch.object(app_module, "get_cached_regression_summary", return_value=regressions),
-        ):
-            response = self.client.get("/leaderboard.csv?days=30")
-            partial = self.client.get("/partials/index/leaderboard?days=30")
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.content_type.startswith("text/csv"))
-        self.assertIn(
-            'attachment; filename="leaderboard-30d.csv"', response.headers["Content-Disposition"]
-        )
-        body = response.get_data(as_text=True)
-        self.assertIn("person,slug,score,score_stdev", body)
-        self.assertIn("alice,10,", body)
-        self.assertIn("3,2.5,", body)
-        self.assertIn("Export CSV", partial.get_data(as_text=True))
-        self.assertIn('href="/leaderboard.csv?days=30"', partial.get_data(as_text=True))
-
-        with open("static/styles.css") as styles_file:
-            styles = styles_file.read()
-        self.assertIn(".leaderboard-heading {", styles)
-        self.assertIn(".leaderboard-export {", styles)
-
-    def test_refreshing_leaderboard_returns_503(self):
+        client = app_module.app.test_client()
+        with patch.object(app_module, "_leaderboard_page_context", return_value=ctx):
+            csv_text = client.get("/leaderboard.csv").get_data(as_text=True)
+            html = client.get("/partials/index/leaderboard").get_data(as_text=True)
+        self.assertTrue(csv_text.startswith("person,slug,score"))
+        self.assertIn("/leaderboard.csv?days=30", html)
         with patch.object(
-            app_module,
-            "_leaderboard_page_context",
-            return_value={"leaderboard_unavailable": True, "preset_days": 30},
+            app_module, "_leaderboard_page_context", return_value={"leaderboard_unavailable": True}
         ):
-            response = self.client.get("/leaderboard.csv")
-
-        self.assertEqual(response.status_code, 503)
-        self.assertIn("refreshing", response.get_data(as_text=True))
-
-
-class LeaderboardEntryParametersTest(unittest.TestCase):
-    def test_entries_keep_structured_points_and_counts(self):
-        config = {
-            "people": {
-                "alice": {
-                    "team": "engineering",
-                    "linear_username": "alice",
-                    "github_username": "alice-gh",
-                },
-                "bob": {
-                    "team": "engineering",
-                    "linear_username": "bob",
-                    "github_username": "bob-gh",
-                },
-            }
-        }
-        completed = [
-            {"assignee": {"name": "alice", "displayName": "Alice"}, "priority": 1},
-            {"assignee": {"name": "alice", "displayName": "Alice"}, "priority": 3},
-        ]
-        with patch.object(app_module, "load_config", return_value=config):
-            entries = app_module._build_leaderboard_entries(
-                completed_work=completed,
-                merged_reviews={"alice-gh": ["r1", "r2"]},
-                merged_authored_prs={"bob-gh": ["p1"]},
-                cycle_lead_points={"Alice": 30},
-                cycle_member_points={"Bob": 15},
-            )
-
-        by_slug = {entry["slug"]: entry for entry in entries}
-        self.assertEqual(by_slug["alice"]["points"]["urgent"], 20)
-        self.assertEqual(by_slug["alice"]["counts"]["urgent"], 1)
-        self.assertEqual(by_slug["alice"]["points"]["reviews"], 2)
-        self.assertEqual(by_slug["alice"]["counts"]["reviews"], 2)
-        self.assertEqual(by_slug["alice"]["points"]["cycle_lead"], 30)
-        self.assertEqual(by_slug["bob"]["points"]["prs"], 1)
-        self.assertEqual(by_slug["bob"]["points"]["cycle_member"], 15)
-        self.assertEqual(by_slug["alice"]["score"], 57)
-        self.assertEqual(by_slug["bob"]["score"], 16)
+            self.assertEqual(client.get("/leaderboard.csv").status_code, 503)

--- a/tests/test_leaderboard_export.py
+++ b/tests/test_leaderboard_export.py
@@ -1,0 +1,196 @@
+import csv
+import io
+import unittest
+from unittest.mock import patch
+
+import app as app_module
+from leaderboard_export import (
+    CSV_COLUMNS,
+    build_leaderboard_export_rows,
+    leaderboard_csv_filename,
+    render_leaderboard_csv,
+)
+
+
+def _entry(slug, display_name, score, points=None, counts=None):
+    return {
+        "slug": slug,
+        "display_name": display_name,
+        "score": score,
+        "breakdown": None,
+        "points": points or {},
+        "counts": counts or {},
+    }
+
+
+class LeaderboardExportTest(unittest.TestCase):
+    def test_csv_includes_parameters_stdevs_and_zero_score_regressions(self):
+        rows = build_leaderboard_export_rows(
+            [
+                _entry("alice", "Alice", 10, {"prs": 10, "urgent": 20}, {"prs": 10, "urgent": 1}),
+                _entry("bob", "Bob", 2, {"prs": 2}, {"prs": 2}),
+            ],
+            engineering_people={
+                "alice": {"team": "engineering", "linear_username": "alice"},
+                "bob": {"team": "engineering", "linear_username": "bob"},
+                "cara": {"team": "engineering", "linear_username": "cara"},
+                "andy": {"team": "unassigned", "linear_username": "andy"},
+            },
+            regression_summary={
+                "configured": True,
+                "author_metrics": [{"slug": "cara", "regression_count": 2, "rate": 4.0}],
+                "reviewer_metrics": [{"slug": "cara", "regression_count": 1, "rate": 1.5}],
+            },
+        )
+
+        self.assertEqual([row["slug"] for row in rows], ["alice", "bob", "cara"])
+        self.assertNotIn("andy", [row["slug"] for row in rows])
+        self.assertEqual(rows[0]["urgent_issues"], 1)
+        self.assertEqual(rows[0]["urgent_points"], 20)
+        self.assertEqual(rows[0]["score_stdev"], "1.4")
+        self.assertEqual(rows[1]["score_stdev"], "-0.5")
+        self.assertEqual(rows[2]["score"], 0)
+        self.assertEqual(rows[2]["regressions_authored"], 2)
+        self.assertEqual(rows[2]["author_regression_rate"], 4.0)
+        self.assertEqual(rows[2]["regressions_approved"], 1)
+        self.assertEqual(rows[2]["reviewer_escape_rate"], 1.5)
+        self.assertEqual(rows[0]["regressions_authored"], 0)
+        self.assertEqual(rows[0]["author_regression_rate"], "")
+
+        body = render_leaderboard_csv(rows)
+        header = next(csv.reader(io.StringIO(body)))
+        self.assertEqual(header, list(CSV_COLUMNS))
+        self.assertIn("score_stdev", header)
+        self.assertIn("urgent_issues", header)
+        self.assertIn("cycle_member_points_stdev", header)
+        self.assertIn("reviewer_escape_rate", header)
+
+    def test_unconfigured_regressions_leave_rate_columns_blank(self):
+        rows = build_leaderboard_export_rows(
+            [_entry("alice", "Alice", 4)],
+            engineering_people={"alice": {"team": "engineering"}},
+            regression_summary=None,
+        )
+
+        self.assertEqual(rows[0]["regressions_authored"], "")
+        self.assertEqual(rows[0]["author_regression_rate"], "")
+        self.assertEqual(rows[0]["regressions_approved"], "")
+        self.assertEqual(rows[0]["reviewer_escape_rate"], "")
+
+    def test_filename_uses_preset_or_date_range(self):
+        self.assertEqual(
+            leaderboard_csv_filename(
+                {"preset_days": 30, "start": "2026-01-01", "end": "2026-01-31"}
+            ),
+            "leaderboard-30d.csv",
+        )
+        self.assertEqual(
+            leaderboard_csv_filename({"start": "2026-01-01", "end": "2026-01-31"}),
+            "leaderboard-2026-01-01-to-2026-01-31.csv",
+        )
+
+
+class LeaderboardExportRouteTest(unittest.TestCase):
+    def setUp(self):
+        self.client = app_module.app.test_client()
+
+    def test_route_downloads_csv_and_partial_links_to_it(self):
+        context = {
+            "days": 30,
+            "preset_days": 30,
+            "start": "2026-07-20",
+            "end": "2026-08-19",
+            "window_label": "30d",
+            "window_query": {"days": 30},
+            "leaderboard_entries": [
+                _entry("alice", "Alice", 10, {"prs": 10}, {"prs": 10}),
+                _entry("bob", "Bob", 2, {"prs": 2}, {"prs": 2}),
+            ],
+        }
+        config = {
+            "people": {
+                "alice": {"team": "engineering", "linear_username": "alice"},
+                "bob": {"team": "engineering", "linear_username": "bob"},
+            }
+        }
+        regressions = {
+            "configured": True,
+            "author_metrics": [{"slug": "alice", "regression_count": 3, "rate": 2.5}],
+            "reviewer_metrics": [{"slug": "bob", "regression_count": 1, "rate": 0.8}],
+        }
+        with (
+            patch.object(app_module, "_leaderboard_page_context", return_value=context),
+            patch.object(app_module, "load_config", return_value=config),
+            patch.object(app_module, "get_cached_regression_summary", return_value=regressions),
+        ):
+            response = self.client.get("/leaderboard.csv?days=30")
+            partial = self.client.get("/partials/index/leaderboard?days=30")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.content_type.startswith("text/csv"))
+        self.assertIn(
+            'attachment; filename="leaderboard-30d.csv"', response.headers["Content-Disposition"]
+        )
+        body = response.get_data(as_text=True)
+        self.assertIn("person,slug,score,score_stdev", body)
+        self.assertIn("alice,10,", body)
+        self.assertIn("3,2.5,", body)
+        self.assertIn("Export CSV", partial.get_data(as_text=True))
+        self.assertIn('href="/leaderboard.csv?days=30"', partial.get_data(as_text=True))
+
+        with open("static/styles.css") as styles_file:
+            styles = styles_file.read()
+        self.assertIn(".leaderboard-heading {", styles)
+        self.assertIn(".leaderboard-export {", styles)
+
+    def test_refreshing_leaderboard_returns_503(self):
+        with patch.object(
+            app_module,
+            "_leaderboard_page_context",
+            return_value={"leaderboard_unavailable": True, "preset_days": 30},
+        ):
+            response = self.client.get("/leaderboard.csv")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertIn("refreshing", response.get_data(as_text=True))
+
+
+class LeaderboardEntryParametersTest(unittest.TestCase):
+    def test_entries_keep_structured_points_and_counts(self):
+        config = {
+            "people": {
+                "alice": {
+                    "team": "engineering",
+                    "linear_username": "alice",
+                    "github_username": "alice-gh",
+                },
+                "bob": {
+                    "team": "engineering",
+                    "linear_username": "bob",
+                    "github_username": "bob-gh",
+                },
+            }
+        }
+        completed = [
+            {"assignee": {"name": "alice", "displayName": "Alice"}, "priority": 1},
+            {"assignee": {"name": "alice", "displayName": "Alice"}, "priority": 3},
+        ]
+        with patch.object(app_module, "load_config", return_value=config):
+            entries = app_module._build_leaderboard_entries(
+                completed_work=completed,
+                merged_reviews={"alice-gh": ["r1", "r2"]},
+                merged_authored_prs={"bob-gh": ["p1"]},
+                cycle_lead_points={"Alice": 30},
+                cycle_member_points={"Bob": 15},
+            )
+
+        by_slug = {entry["slug"]: entry for entry in entries}
+        self.assertEqual(by_slug["alice"]["points"]["urgent"], 20)
+        self.assertEqual(by_slug["alice"]["counts"]["urgent"], 1)
+        self.assertEqual(by_slug["alice"]["points"]["reviews"], 2)
+        self.assertEqual(by_slug["alice"]["counts"]["reviews"], 2)
+        self.assertEqual(by_slug["alice"]["points"]["cycle_lead"], 30)
+        self.assertEqual(by_slug["bob"]["points"]["prs"], 1)
+        self.assertEqual(by_slug["bob"]["points"]["cycle_member"], 15)
+        self.assertEqual(by_slug["alice"]["score"], 57)
+        self.assertEqual(by_slug["bob"]["score"], 16)


### PR DESCRIPTION
## Issue
#427 asked for a leaderboard CSV with every score parameter that is currently hidden in the homepage tooltip.

## Solution
Add `GET /leaderboard.csv` and an Export CSV link on the homepage leaderboard. The file uses the same time window and cache behavior as the HTML table, and includes person, score, and each issue/PR/project count and points column.

References #427

## Stack

1. #469 <-- you are here
2. #470

## To Test
- Open `/` and confirm the leaderboard heading has an Export CSV link for the selected 7/30/90d or custom date range
- Download `/leaderboard.csv?days=30` and confirm score-component columns match the tooltip breakdown
- With Redis configured and a stale/missing 30-day cache, `/leaderboard.csv?days=30` returns 503 until the worker refreshes

## Proof
Live homepage `/` shows **Export CSV** next to Leaderboard (30d), linking to `/leaderboard.csv?days=30`.

![Export CSV link](https://github.com/ApollosProject/bug-board/releases/download/proof-469/export-link.png)

![Leaderboard with export link](https://github.com/ApollosProject/bug-board/releases/download/proof-469/leaderboard.png)

Live `GET /leaderboard.csv?days=30` returned `200` with `Content-Disposition: attachment; filename="leaderboard-30d.csv"` and these columns/rows:

```
person,slug,score,urgent_issues,urgent_points,high_issues,high_points,medium_issues,medium_points,low_issues,low_points,pr_reviews,pr_review_points,prs_merged,pr_points,cycle_lead_points,cycle_member_points
michael.neeley,michael,1297,7,140,27,270,30,150,48,48,150,150,344,344,150,45
nathan,nathan,398,0,0,2,20,1,5,0,0,178,178,75,75,120,0
Dylan,dylan,358,0,0,0,0,0,0,0,0,123,123,55,55,180,0
```
