### PR TITLE
Add leaderboard CSV stdevs and regression columns

### DIFF
--- a/leaderboard_export.py
+++ b/leaderboard_export.py
@@ -6,6 +6,11 @@ import re
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from config import load_config
+from constants import ENGINEERING_TEAM_SLUG
+from person_stats import z_score
+from regression_cache import get_cached_regression_summary
+
 PARAMS = (
     ("urgent", "urgent_issues", "urgent_points"),
     ("high", "high_issues", "high_points"),
@@ -20,12 +25,23 @@ CSV_COLUMNS = [
     "person",
     "slug",
     "score",
-    *(name for _key, count, points in PARAMS for name in ((count, points) if count else (points,))),
+    "score_stdev",
+    *(
+        name
+        for _key, count, points in PARAMS
+        for name in ((count, points, f"{points}_stdev") if count else (points, f"{points}_stdev"))
+    ),
+    "regressions_authored",
+    "author_regression_rate",
+    "regressions_approved",
+    "reviewer_escape_rate",
 ]
+POINT_COLS = [points for _key, _count, points in PARAMS]
 
 
-def _name(slug: str) -> str:
-    return re.sub(r"[._-]+", " ", slug).title()
+def _name(slug: str, info: Mapping[str, Any] | None = None) -> str:
+    raw = (info or {}).get("linear_username") or slug
+    return re.sub(r"[._-]+", " ", raw if isinstance(raw, str) else slug).title()
 
 
 def render_leaderboard_csv(rows: Sequence[Mapping[str, Any]]) -> str:
@@ -36,14 +52,14 @@ def render_leaderboard_csv(rows: Sequence[Mapping[str, Any]]) -> str:
     return buf.getvalue()
 
 
-def _row(entry: Mapping[str, Any]) -> dict[str, Any]:
+def _row(entry: Mapping[str, Any], name: str | None = None) -> dict[str, Any]:
     slug = entry.get("slug") if isinstance(entry.get("slug"), str) else ""
     raw_points = entry.get("points")
     raw_counts = entry.get("counts")
     points = raw_points if isinstance(raw_points, Mapping) else {}
     counts = raw_counts if isinstance(raw_counts, Mapping) else {}
     row = {
-        "person": entry.get("display_name") or _name(str(slug)),
+        "person": name or entry.get("display_name") or _name(str(slug)),
         "slug": slug,
         "score": int(entry.get("score") or 0),
     }
@@ -54,7 +70,55 @@ def _row(entry: Mapping[str, Any]) -> dict[str, Any]:
     return row
 
 
-def build_leaderboard_export_rows(entries: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+def build_leaderboard_export_rows(
+    entries: Sequence[Mapping[str, Any]],
+    *,
+    people: Mapping[str, Mapping[str, Any]] | None = None,
+    regression_summary: Mapping[str, Any] | None = None,
+) -> list[dict[str, Any]]:
     rows = [_row(entry) for entry in entries if isinstance(entry, Mapping)]
+    if people is None:
+        people = {
+            slug: info
+            for slug, info in load_config().get("people", {}).items()
+            if isinstance(info, Mapping) and info.get("team") == ENGINEERING_TEAM_SLUG
+        }
+    seen = {row["slug"] for row in rows if row["slug"]}
+    for slug, info in people.items():
+        if slug not in seen:
+            rows.append(_row({"slug": slug, "score": 0}, _name(slug, info)))
     rows.sort(key=lambda row: (-int(row["score"]), str(row["person"])))
+    for column in ["score", *POINT_COLS]:
+        values = [float(row[column] or 0) for row in rows]
+        for row, value in zip(rows, values, strict=True):
+            z_value = z_score(value, values)
+            row[f"{column}_stdev"] = "" if z_value is None else f"{z_value:.1f}"
+    if regression_summary is None:
+        regression_summary = get_cached_regression_summary()
+    ready = bool(regression_summary and regression_summary.get("configured"))
+    authors = {
+        item["slug"]: item
+        for item in (regression_summary or {}).get("author_metrics") or []
+        if isinstance(item, Mapping) and isinstance(item.get("slug"), str)
+    }
+    reviewers = {
+        item["slug"]: item
+        for item in (regression_summary or {}).get("reviewer_metrics") or []
+        if isinstance(item, Mapping) and isinstance(item.get("slug"), str)
+    }
+    for row in rows:
+        author = authors.get(str(row["slug"]), {}) if ready else None
+        reviewer = reviewers.get(str(row["slug"]), {}) if ready else None
+        row["regressions_authored"] = (
+            "" if author is None else int(author.get("regression_count") or 0)
+        )
+        row["author_regression_rate"] = (
+            "" if not author or author.get("rate") is None else author["rate"]
+        )
+        row["regressions_approved"] = (
+            "" if reviewer is None else int(reviewer.get("regression_count") or 0)
+        )
+        row["reviewer_escape_rate"] = (
+            "" if not reviewer or reviewer.get("rate") is None else reviewer["rate"]
+        )
     return rows

--- a/tests/test_leaderboard_export.py
+++ b/tests/test_leaderboard_export.py
@@ -7,14 +7,15 @@ from leaderboard_export import build_leaderboard_export_rows, render_leaderboard
 
 class LeaderboardExportTest(unittest.TestCase):
     def test_csv_lists_score_parameters_and_route(self):
+        people = {"a": {}, "b": {}, "c": {}}
         rows = build_leaderboard_export_rows(
             [
                 {
                     "slug": "a",
                     "display_name": "A",
                     "score": 10,
-                    "points": {"urgent": 20, "prs": 10},
-                    "counts": {"urgent": 1, "prs": 10},
+                    "points": {"prs": 10, "urgent": 20},
+                    "counts": {"prs": 10, "urgent": 1},
                 },
                 {
                     "slug": "b",
@@ -23,22 +24,39 @@ class LeaderboardExportTest(unittest.TestCase):
                     "points": {"prs": 2},
                     "counts": {"prs": 2},
                 },
-            ]
+            ],
+            people=people,
+            regression_summary={
+                "configured": True,
+                "author_metrics": [{"slug": "c", "regression_count": 2, "rate": 4.0}],
+            },
         )
-        self.assertEqual([row["slug"] for row in rows], ["a", "b"])
-        self.assertEqual((rows[0]["urgent_issues"], rows[0]["prs_merged"]), (1, 10))
-        self.assertIn("person,slug,score,urgent_issues", render_leaderboard_csv(rows))
+        self.assertEqual([row["slug"] for row in rows], ["a", "b", "c"])
+        self.assertEqual(
+            (rows[0]["urgent_issues"], rows[0]["score_stdev"], rows[2]["regressions_authored"]),
+            (1, "1.4", 2),
+        )
+        self.assertIn("person,slug,score,score_stdev,urgent_issues", render_leaderboard_csv(rows))
+        client = app_module.app.test_client()
         ctx = {
             "days": 30,
             "preset_days": 30,
             "window_query": {"days": 30},
-            "leaderboard_entries": [{"slug": "a", "display_name": "A", "score": 10}],
+            "leaderboard_entries": [
+                {
+                    "slug": "a",
+                    "display_name": "A",
+                    "score": 10,
+                    "points": {"prs": 10},
+                    "counts": {"prs": 10},
+                }
+            ],
         }
-        client = app_module.app.test_client()
         with patch.object(app_module, "_leaderboard_page_context", return_value=ctx):
             csv_text = client.get("/leaderboard.csv").get_data(as_text=True)
             html = client.get("/partials/index/leaderboard").get_data(as_text=True)
         self.assertTrue(csv_text.startswith("person,slug,score"))
+        self.assertIn("a,10,", csv_text)
         self.assertIn("/leaderboard.csv?days=30", html)
         self.assertIn('class="leaderboard-export"', html)
         self.assertIn(">Export CSV</a>", html)


### PR DESCRIPTION
## Issue
#427 asked for stdevs and regression columns on the leaderboard CSV even though regressions do not affect score yet.

## Solution
Add per-person z-score columns for score and each points parameter, plus authored/approved regression counts and rates. Engineers with a zero score still appear so regression-only rows are kept.

Closes #427

## Stack

1. #469
2. #470 <-- you are here

## To Test
- Download `/leaderboard.csv?days=30` and confirm stdev and regression columns are present
- Confirm someone with no leaderboard points still appears if they have regression data

## Proof
Local gunicorn `GET /leaderboard.csv?days=30` returned `200` with `Content-Disposition: attachment; filename="leaderboard-30d.csv"`. The file includes `score_stdev`, each `*_points_stdev`, and the four regression columns. This environment has no Redis, so the HTTP response leaves regression cells blank:

```
person,slug,score,score_stdev,urgent_issues,urgent_points,urgent_points_stdev,high_issues,high_points,high_points_stdev,medium_issues,medium_points,medium_points_stdev,low_issues,low_points,low_points_stdev,pr_reviews,pr_review_points,pr_review_points_stdev,prs_merged,pr_points,pr_points_stdev,cycle_lead_points,cycle_lead_points_stdev,cycle_member_points,cycle_member_points_stdev,regressions_authored,author_regression_rate,regressions_approved,reviewer_escape_rate
michael.neeley,michael,1297,2.5,7,140,2.6,27,270,2.6,30,150,2.6,48,48,2.6,149,149,1.1,345,345,2.5,150,0.9,45,1.7,,,,
nathan,nathan,397,0.1,0,0,-0.4,2,20,-0.2,1,5,-0.3,0,0,-0.4,177,177,1.6,75,75,-0.1,120,0.4,0,-0.6,,,,
Dylan,dylan,357,-0.0,0,0,-0.4,0,0,-0.5,0,0,-0.4,0,0,-0.4,122,122,0.6,55,55,-0.3,180,1.3,0,-0.6,,,,
```

Live `build_regression_summary()` (the Redis payload production would serve) joined through the same export function fills those columns. All eight engineers currently have 30d scores, so no zero-score padded row appears in this window:

```
person,slug,score,score_stdev,regressions_authored,author_regression_rate,regressions_approved,reviewer_escape_rate
michael.neeley,michael,1297,2.5,2,0.6,1,0.7
nathan,nathan,397,0.1,2,2.7,1,0.5
Dylan,dylan,357,-0.0,1,1.8,0,0.0
brandon,brandon,294,-0.2,0,0.0,1,2.0
vitor.lelis,vitor,161,-0.6,0,0.0,3,2.8
```
