### PR TITLE
Orient person-page σ badges so plus is better

### DIFF
--- a/person_stats.py
+++ b/person_stats.py
@@ -16,13 +16,21 @@ CARD_METRIC_KEYS = (
     "lead_completed_projects_avg_early_late",
 )
 
+# Displayed σ is oriented so + is better than the engineering average and − is worse.
 LOWER_IS_BETTER_METRIC_KEYS = frozenset(
     {
         "priority_bug_avg_time_to_fix",
         "avg_all_time_to_fix",
+        "lead_incomplete_projects",
         "lead_completed_projects_avg_early_late",
     }
 )
+STDEV_DIRECTION_HINTS = {
+    "priority_bug_avg_time_to_fix": "lower is better",
+    "avg_all_time_to_fix": "lower is better",
+    "lead_incomplete_projects": "lower is better",
+    "lead_completed_projects_avg_early_late": "earlier is better",
+}
 
 STDEV_COLOR_THRESHOLD = 1.5
 STDEV_COLOR_METRIC_KEYS = frozenset({"prs_merged", "prs_reviewed", "all_work_done"})
@@ -75,9 +83,9 @@ def stdev_tone(z: float, *, threshold: float = STDEV_COLOR_THRESHOLD) -> str | N
     return None
 
 
-def format_stdev_tooltip(values: list[float], *, lower_is_better: bool = False) -> str:
+def format_stdev_tooltip(values: list[float], *, hint: str | None = None) -> str:
     tooltip = f"eng avg {statistics.fmean(values):.1f} · σ {statistics.pstdev(values):.1f}"
-    return f"{tooltip} · lower is better" if lower_is_better else tooltip
+    return f"{tooltip} · {hint}" if hint else tooltip
 
 
 def metric_stdevs_for_person(
@@ -94,12 +102,11 @@ def metric_stdevs_for_person(
         z = z_score(float(person_value), values)
         if z is None:
             continue
-        lower_is_better = key in LOWER_IS_BETTER_METRIC_KEYS
-        if lower_is_better:
+        if key in LOWER_IS_BETTER_METRIC_KEYS:
             z = -z
         entry: dict[str, str] = {
             "label": format_stdev_label(z),
-            "tooltip": format_stdev_tooltip(values, lower_is_better=lower_is_better),
+            "tooltip": format_stdev_tooltip(values, hint=STDEV_DIRECTION_HINTS.get(key)),
         }
         if key in STDEV_COLOR_METRIC_KEYS:
             tone = stdev_tone(z)

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -26,32 +26,70 @@ class PersonStatsTest(unittest.TestCase):
         self.assertEqual(person_stats.z_score(10, [10, 2]), 1.0)
         self.assertEqual(person_stats.format_stdev_tooltip([10, 2]), "eng avg 6.0 · σ 4.0")
 
-    def test_time_metric_stdevs_reward_shorter_times(self):
-        person_metrics = {
+    def test_every_card_metric_has_an_explicit_stdev_direction(self):
+        classified = person_stats.LOWER_IS_BETTER_METRIC_KEYS | frozenset(
+            {
+                "prs_merged",
+                "prs_reviewed",
+                "priority_bugs_fixed",
+                "all_work_done",
+                "lead_current_projects",
+                "lead_completed_projects",
+            }
+        )
+        self.assertEqual(classified, frozenset(person_stats.CARD_METRIC_KEYS))
+        self.assertEqual(
+            frozenset(person_stats.STDEV_DIRECTION_HINTS),
+            person_stats.LOWER_IS_BETTER_METRIC_KEYS,
+        )
+
+    def test_stdev_signs_treat_plus_as_better(self):
+        better = {
             "prs_merged": 10,
+            "prs_reviewed": 10,
+            "priority_bugs_fixed": 10,
             "priority_bug_avg_time_to_fix": 2,
-            "avg_all_time_to_fix": 10,
+            "all_work_done": 10,
+            "avg_all_time_to_fix": 2,
+            "lead_current_projects": 10,
+            "lead_completed_projects": 10,
+            "lead_incomplete_projects": 0,
             "lead_completed_projects_avg_early_late": -3,
         }
-        team_metrics = [
-            person_metrics,
-            {
-                "prs_merged": 2,
-                "priority_bug_avg_time_to_fix": 10,
-                "avg_all_time_to_fix": 2,
-                "lead_completed_projects_avg_early_late": 5,
-            },
-        ]
+        worse = {
+            "prs_merged": 2,
+            "prs_reviewed": 2,
+            "priority_bugs_fixed": 2,
+            "priority_bug_avg_time_to_fix": 10,
+            "all_work_done": 2,
+            "avg_all_time_to_fix": 10,
+            "lead_current_projects": 2,
+            "lead_completed_projects": 2,
+            "lead_incomplete_projects": 8,
+            "lead_completed_projects_avg_early_late": 5,
+        }
 
-        stdevs = person_stats.metric_stdevs_for_person(person_metrics, team_metrics)
+        better_stdevs = person_stats.metric_stdevs_for_person(better, [better, worse])
+        worse_stdevs = person_stats.metric_stdevs_for_person(worse, [better, worse])
 
-        self.assertEqual(stdevs["prs_merged"]["label"], "+1.0σ")
-        self.assertNotIn("tone", stdevs["prs_merged"])
-        self.assertEqual(stdevs["priority_bug_avg_time_to_fix"]["label"], "+1.0σ")
-        self.assertEqual(stdevs["avg_all_time_to_fix"]["label"], "−1.0σ")
-        self.assertEqual(stdevs["lead_completed_projects_avg_early_late"]["label"], "+1.0σ")
+        for key in person_stats.CARD_METRIC_KEYS:
+            with self.subTest(key=key):
+                self.assertTrue(better_stdevs[key]["label"].startswith("+"), better_stdevs[key])
+                self.assertTrue(worse_stdevs[key]["label"].startswith("−"), worse_stdevs[key])
+
+        self.assertEqual(better_stdevs["prs_merged"]["label"], "+1.0σ")
+        self.assertNotIn("tone", better_stdevs["prs_merged"])
+        self.assertEqual(better_stdevs["priority_bug_avg_time_to_fix"]["label"], "+1.0σ")
+        self.assertEqual(worse_stdevs["avg_all_time_to_fix"]["label"], "−1.0σ")
+        self.assertEqual(better_stdevs["lead_incomplete_projects"]["label"], "+1.0σ")
+        self.assertEqual(better_stdevs["lead_completed_projects_avg_early_late"]["label"], "+1.0σ")
         self.assertTrue(
-            stdevs["priority_bug_avg_time_to_fix"]["tooltip"].endswith("lower is better")
+            better_stdevs["priority_bug_avg_time_to_fix"]["tooltip"].endswith("lower is better")
+        )
+        self.assertTrue(
+            better_stdevs["lead_completed_projects_avg_early_late"]["tooltip"].endswith(
+                "earlier is better"
+            )
         )
 
     def test_pr_cards_color_at_one_and_a_half_sigma(self):


### PR DESCRIPTION
## Summary
- Audit every person-page σ badge so **+ is better than the engineering average** and **− is worse**.
- Invert incomplete-project counts (more incomplete is worse). Keep time-to-fix inverted, and treat avg days early/late as earlier-is-better.
- Cover all card metrics with a sign-direction regression test so new metrics have to pick a polarity.

## Test plan
- [ ] Open a person page with enough engineering peers for σ badges to render.
- [ ] Confirm shorter time-to-fix / time-to-completion shows **+σ**, longer shows **−σ**.
- [ ] Confirm “Xd early” shows **+σ** vs a later peer, and “Xd late” shows **−σ**.
- [ ] Confirm more incomplete projects shows **−σ**, fewer shows **+σ**.
- [ ] Confirm output counts (PRs, work done, completed projects) still treat higher as **+σ**.

Closes #468

Made with [Cursor](https://cursor.com)