### PR TITLE
Color every people-page metric at ±1.5σ

### DIFF
--- a/person_stats.py
+++ b/person_stats.py
@@ -33,7 +33,6 @@ STDEV_DIRECTION_HINTS = {
 }
 
 STDEV_COLOR_THRESHOLD = 1.5
-STDEV_COLOR_METRIC_KEYS = frozenset({"prs_merged", "prs_reviewed", "all_work_done"})
 
 MetricValue = float | int | None
 
@@ -108,9 +107,8 @@ def metric_stdevs_for_person(
             "label": format_stdev_label(z),
             "tooltip": format_stdev_tooltip(values, hint=STDEV_DIRECTION_HINTS.get(key)),
         }
-        if key in STDEV_COLOR_METRIC_KEYS:
-            tone = stdev_tone(z)
-            if tone is not None:
-                entry["tone"] = tone
+        tone = stdev_tone(z)
+        if tone is not None:
+            entry["tone"] = tone
         result[key] = entry
     return result

--- a/templates/partials/person_content.html
+++ b/templates/partials/person_content.html
@@ -105,18 +105,17 @@
   <div>
     <article>
       <header><a href="https://linear.app/differential/view/sla-issues-7e2098ebf79e">Priority Bugs Fixed</a></header>
-      <h1>{{ priority_bugs_fixed }}</h1>
+      {{ metric_heading('priority_bugs_fixed', priority_bugs_fixed) }}
       {{ stdev_badge('priority_bugs_fixed') }}
     </article>
   </div>
   <div>
     <article>
       <header>Priority Bug Time to Fix</header>
-      {% if priority_bug_avg_time_to_fix is not none %}
-      <h1>{{ priority_bug_avg_time_to_fix }}d</h1>
-      {% else %}
-      <h1>n/a</h1>
-      {% endif %}
+      {{ metric_heading(
+        'priority_bug_avg_time_to_fix',
+        (priority_bug_avg_time_to_fix ~ 'd') if priority_bug_avg_time_to_fix is not none else 'n/a'
+      ) }}
       {{ stdev_badge('priority_bug_avg_time_to_fix') }}
     </article>
   </div>
@@ -135,11 +134,10 @@
   <div>
     <article>
       <header>Time to Completion</header>
-      {% if avg_all_time_to_fix is not none %}
-      <h1>{{ avg_all_time_to_fix }}d</h1>
-      {% else %}
-      <h1>n/a</h1>
-      {% endif %}
+      {{ metric_heading(
+        'avg_all_time_to_fix',
+        (avg_all_time_to_fix ~ 'd') if avg_all_time_to_fix is not none else 'n/a'
+      ) }}
       {{ stdev_badge('avg_all_time_to_fix') }}
     </article>
   </div>
@@ -148,32 +146,31 @@
   <div>
     <article>
       <header><a href="https://linear.app/differential/projects/all">Current Projects</a></header>
-      <h1>{{ lead_current_projects }}</h1>
+      {{ metric_heading('lead_current_projects', lead_current_projects) }}
       {{ stdev_badge('lead_current_projects') }}
     </article>
   </div>
   <div>
     <article>
       <header><a href="https://linear.app/differential/projects/all">Completed Projects</a></header>
-      <h1>{{ lead_completed_projects }}</h1>
+      {{ metric_heading('lead_completed_projects', lead_completed_projects) }}
       {{ stdev_badge('lead_completed_projects') }}
     </article>
   </div>
   <div>
     <article>
       <header><a href="https://linear.app/differential/projects/all">Incomplete Projects</a></header>
-      <h1>{{ lead_incomplete_projects }}</h1>
+      {{ metric_heading('lead_incomplete_projects', lead_incomplete_projects) }}
       {{ stdev_badge('lead_incomplete_projects') }}
     </article>
   </div>
   <div>
     <article>
       <header><a href="https://linear.app/differential/projects/all">Avg Days Early/Late</a></header>
-      {% if lead_completed_projects_avg_early_late %}
-      <h1>{{ lead_completed_projects_avg_early_late }}</h1>
-      {% else %}
-      <h1>n/a</h1>
-      {% endif %}
+      {{ metric_heading(
+        'lead_completed_projects_avg_early_late',
+        lead_completed_projects_avg_early_late or 'n/a'
+      ) }}
       {{ stdev_badge('lead_completed_projects_avg_early_late') }}
     </article>
   </div>

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -20,6 +20,27 @@ def _issue(*, priority=4, bug=False):
     }
 
 
+def _project(lead_name: str, project_id: str, *, status: str, completed: bool = False) -> dict:
+    return {
+        "id": project_id,
+        "name": f"Project {project_id}",
+        "url": f"https://linear.example/project/{project_id}",
+        "status": {"name": status},
+        "completedAt": "2026-08-01T00:00:00.000Z" if completed else None,
+        "lead": {"displayName": lead_name},
+        "members": [],
+    }
+
+
+def _outlier_metrics(*, better: bool) -> dict[str, int]:
+    high = 10 if better else 0
+    low = 0 if better else 10
+    metrics = dict.fromkeys(person_stats.CARD_METRIC_KEYS, high)
+    for key in person_stats.LOWER_IS_BETTER_METRIC_KEYS:
+        metrics[key] = low
+    return metrics
+
+
 class PersonStatsTest(unittest.TestCase):
     def test_z_scores_skip_zero_variance_and_keep_copy_short(self):
         self.assertIsNone(person_stats.z_score(9, [4, 4]))
@@ -92,16 +113,16 @@ class PersonStatsTest(unittest.TestCase):
             )
         )
 
-    def test_pr_cards_color_at_one_and_a_half_sigma(self):
+    def test_all_card_metrics_color_at_one_and_a_half_sigma(self):
         self.assertEqual(person_stats.stdev_tone(1.5), "high")
         self.assertEqual(person_stats.stdev_tone(-1.5), "low")
         self.assertIsNone(person_stats.stdev_tone(1.49))
         self.assertIsNone(person_stats.stdev_tone(-1.49))
 
-        high_person = {"prs_merged": 10, "prs_reviewed": 10, "all_work_done": 10}
-        clustered_low = {"prs_merged": 0, "prs_reviewed": 0, "all_work_done": 0}
-        low_person = {"prs_merged": 0, "prs_reviewed": 0, "all_work_done": 0}
-        clustered_high = {"prs_merged": 10, "prs_reviewed": 10, "all_work_done": 10}
+        high_person = _outlier_metrics(better=True)
+        clustered_low = _outlier_metrics(better=False)
+        low_person = _outlier_metrics(better=False)
+        clustered_high = _outlier_metrics(better=True)
 
         high_stdevs = person_stats.metric_stdevs_for_person(
             high_person, [high_person, clustered_low, clustered_low, clustered_low]
@@ -110,14 +131,12 @@ class PersonStatsTest(unittest.TestCase):
             low_person, [low_person, clustered_high, clustered_high, clustered_high]
         )
 
-        self.assertEqual(high_stdevs["prs_merged"]["tone"], "high")
-        self.assertEqual(high_stdevs["prs_reviewed"]["tone"], "high")
-        self.assertEqual(high_stdevs["all_work_done"]["tone"], "high")
-        self.assertEqual(low_stdevs["prs_merged"]["tone"], "low")
-        self.assertEqual(low_stdevs["prs_reviewed"]["tone"], "low")
-        self.assertEqual(low_stdevs["all_work_done"]["tone"], "low")
+        for key in person_stats.CARD_METRIC_KEYS:
+            with self.subTest(key=key):
+                self.assertEqual(high_stdevs[key]["tone"], "high")
+                self.assertEqual(low_stdevs[key]["tone"], "low")
 
-    def test_person_cards_color_pr_headings_beyond_stdev_threshold(self):
+    def test_person_cards_color_headings_beyond_stdev_threshold(self):
         app_module._build_person_context.cache_clear()
         self.addCleanup(app_module._build_person_context.cache_clear)
         config = {
@@ -132,13 +151,21 @@ class PersonStatsTest(unittest.TestCase):
         }
 
         def fake_completed(login, days=30, window=None):
-            return [_issue() for _ in range(10)] if login == "alice" else []
+            return [_issue(priority=2, bug=True) for _ in range(10)] if login == "alice" else []
+
+        projects = [
+            *[
+                _project("Alice", f"alice-done-{index}", status="Completed", completed=True)
+                for index in range(10)
+            ],
+            *[_project("Alice", f"alice-open-{index}", status="Incomplete") for index in range(10)],
+        ]
 
         with (
             patch.object(app_module, "load_config", return_value=config),
             patch.object(app_module, "get_open_issues_for_person", return_value=[]),
             patch.object(app_module, "get_completed_issues_for_person", side_effect=fake_completed),
-            patch.object(app_module, "get_projects", return_value=[]),
+            patch.object(app_module, "get_projects", return_value=projects),
             patch.object(
                 app_module,
                 "get_merged_pr_counts_for_user",
@@ -150,12 +177,19 @@ class PersonStatsTest(unittest.TestCase):
         ):
             context = app_module._build_person_context("alice", 30, 1)
 
-        self.assertEqual(context["metric_stdevs"]["prs_merged"]["tone"], "high")
-        self.assertEqual(context["metric_stdevs"]["prs_reviewed"]["tone"], "high")
-        self.assertEqual(context["metric_stdevs"]["all_work_done"]["tone"], "high")
+        for key in (
+            "prs_merged",
+            "prs_reviewed",
+            "priority_bugs_fixed",
+            "all_work_done",
+            "lead_completed_projects",
+        ):
+            self.assertEqual(context["metric_stdevs"][key]["tone"], "high")
+        self.assertEqual(context["metric_stdevs"]["lead_incomplete_projects"]["tone"], "low")
         with app_module.app.test_request_context():
             body = app_module.render_template("partials/person_content.html", **context)
-        self.assertEqual(body.count('<h1 class="high">10</h1>'), 3)
+        self.assertEqual(body.count('<h1 class="high">10</h1>'), 5)
+        self.assertEqual(body.count('<h1 class="low">10</h1>'), 1)
         self.assertNotIn('<h1 class="high">0</h1>', body)
         self.assertNotIn("2/week", body)
         self.assertNotIn("5/week", body)


### PR DESCRIPTION
## Issue
People-page cards other than PRs and All Work Done showed σ badges but never turned green or red. Nathan’s completed projects at +1.6σ stayed the default color.

## Solution
Apply the existing ±1.5σ green/red highlighting to every people-page card metric. Lower-is-better metrics still flip the sign first.

Closes #473

## To Test
- Open `/team/nathan?days=30` and confirm Completed Projects is green at about +1.6σ
- Confirm nearby project cards inside the band stay the default color
- Confirm PRs Reviewed is still green at about +1.7σ

## Proof
Live `/team/nathan?days=30` on `main`: Completed Projects **4 / +1.6σ** is uncolored. Current Projects +0.9σ, Incomplete +0.4σ, and Avg Days Early/Late −1.4σ also stay default.

![Nathan project cards before](https://github.com/ApollosProject/bug-board/releases/download/proof-475/nathan-projects-before.png)

Same page on this PR: Completed Projects is green. The other three project cards stay default because they are inside ±1.5σ.

![Nathan project cards after](https://github.com/ApollosProject/bug-board/releases/download/proof-475/nathan-projects-after.png)
