### PR TITLE
Count completed projects as planned weeks

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,6 +43,7 @@ from person_stats import issue_card_values, metric_stdevs_for_person
 from project_dates import (
     format_project_start_status,
     format_project_target_status,
+    get_project_planned_weeks,
     parse_iso_date,
 )
 from regression_cache import get_cached_regression_summary
@@ -163,6 +164,12 @@ def get_project_schedule_variance_days(project: dict[str, Any]) -> int | None:
     if target_date is None or completed_date is None:
         return None
     return (completed_date - target_date).days
+
+
+def completed_project_weeks(projects: list[dict[str, Any]]) -> int:
+    return sum(
+        get_project_planned_weeks(project) for project in projects if is_completed_project(project)
+    )
 
 
 def format_average_project_schedule_variance(
@@ -1514,7 +1521,7 @@ def _build_person_context(
         if normalize_display_name((project.get("lead") or {}).get("displayName"))
         == normalized_person_name
     ]
-    lead_completed_projects = sum(1 for project in led_projects if is_completed_project(project))
+    lead_completed_projects = completed_project_weeks(led_projects)
     lead_incomplete_projects = sum(1 for project in led_projects if is_incomplete_project(project))
     lead_current_projects = sum(1 for project in led_projects if not project.get("is_inactive"))
     lead_completed_project_variances = [
@@ -1579,9 +1586,7 @@ def _build_person_context(
                 "lead_current_projects": sum(
                     1 for project in other_led if not project.get("is_inactive")
                 ),
-                "lead_completed_projects": sum(
-                    1 for project in other_led if is_completed_project(project)
-                ),
+                "lead_completed_projects": completed_project_weeks(other_led),
                 "lead_incomplete_projects": sum(
                     1 for project in other_led if is_incomplete_project(project)
                 ),

--- a/project_dates.py
+++ b/project_dates.py
@@ -13,6 +13,23 @@ def parse_iso_date(value: str | None) -> date | None:
         return None
 
 
+def get_project_planned_weeks(project: dict) -> int:
+    start = parse_iso_date(project.get("startDate"))
+    target = parse_iso_date(project.get("targetDate"))
+    if start is None and target is None:
+        return 1
+    if start is None:
+        start = target
+    if target is None:
+        target = start
+    if start is None or target is None:
+        return 1
+    if start > target:
+        start, target = target, start
+    inclusive_days = (target - start).days + 1
+    return max(1, round(inclusive_days / 7))
+
+
 def _format_hours(delta: timedelta) -> str:
     seconds = max(delta.total_seconds(), 0)
     hours = math.ceil(seconds / 3600) if seconds else 0

--- a/templates/partials/person_content.html
+++ b/templates/partials/person_content.html
@@ -152,7 +152,7 @@
   </div>
   <div>
     <article>
-      <header><a href="https://linear.app/differential/projects/all">Completed Projects</a></header>
+      <header><a href="https://linear.app/differential/projects/all">Completed Project Weeks</a></header>
       {{ metric_heading('lead_completed_projects', lead_completed_projects) }}
       {{ stdev_badge('lead_completed_projects') }}
     </article>

--- a/tests/test_failing_dags.py
+++ b/tests/test_failing_dags.py
@@ -936,7 +936,7 @@ class TeamContextProjectFilteringTest(unittest.TestCase):
                                     context = app_module._build_person_context("darryl", 7, 1)
 
         self.assertEqual(context["lead_current_projects"], 0)
-        self.assertEqual(context["lead_completed_projects"], 1)
+        self.assertEqual(context["lead_completed_projects"], 2)
         self.assertEqual(context["lead_incomplete_projects"], 0)
         self.assertEqual(context["lead_completed_projects_avg_early_late"], "on time")
 
@@ -995,7 +995,7 @@ class TeamContextProjectFilteringTest(unittest.TestCase):
                                 with patch.object(app_module, "get_support_slugs", return_value=[]):
                                     context = app_module._build_person_context("darryl", 7, 1)
 
-        self.assertEqual(context["lead_completed_projects"], 2)
+        self.assertEqual(context["lead_completed_projects"], 3)
         self.assertEqual(context["lead_completed_projects_avg_early_late"], "1d late")
 
     def test_project_deadline_uses_hours_when_less_than_day_left(self):

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -20,13 +20,23 @@ def _issue(*, priority=4, bug=False):
     }
 
 
-def _project(lead_name: str, project_id: str, *, status: str, completed: bool = False) -> dict:
+def _project(
+    lead_name: str,
+    project_id: str,
+    *,
+    status: str,
+    completed: bool = False,
+    start_date: str | None = None,
+    target_date: str | None = None,
+) -> dict:
     return {
         "id": project_id,
         "name": f"Project {project_id}",
         "url": f"https://linear.example/project/{project_id}",
         "status": {"name": status},
         "completedAt": "2026-08-01T00:00:00.000Z" if completed else None,
+        "startDate": start_date,
+        "targetDate": target_date,
         "lead": {"displayName": lead_name},
         "members": [],
     }
@@ -248,3 +258,65 @@ class PersonStatsTest(unittest.TestCase):
         styles = Path(__file__).resolve().parents[1].joinpath("static/styles.css").read_text()
         self.assertIn("max-width: min(12rem, calc(100vw - 2rem));", styles)
         self.assertIn("white-space: normal;", styles)
+
+    def test_completed_project_weeks_treat_two_short_projects_like_one_long_project(self):
+        app_module._build_person_context.cache_clear()
+        self.addCleanup(app_module._build_person_context.cache_clear)
+        config = {
+            "people": {
+                "alice": {
+                    "team": "engineering",
+                    "linear_username": "alice",
+                    "github_username": "alice-gh",
+                },
+                "bob": {
+                    "team": "engineering",
+                    "linear_username": "bob",
+                    "github_username": "bob-gh",
+                },
+            }
+        }
+        projects = [
+            _project(
+                "Alice",
+                "alice-two-week-1",
+                status="Completed",
+                completed=True,
+                start_date="2026-03-02",
+                target_date="2026-03-15",
+            ),
+            _project(
+                "Alice",
+                "alice-two-week-2",
+                status="Completed",
+                completed=True,
+                start_date="2026-03-16",
+                target_date="2026-03-29",
+            ),
+            _project(
+                "Bob",
+                "bob-four-week",
+                status="Completed",
+                completed=True,
+                start_date="2026-03-02",
+                target_date="2026-03-29",
+            ),
+        ]
+
+        with (
+            patch.object(app_module, "load_config", return_value=config),
+            patch.object(app_module, "get_open_issues_for_person", return_value=[]),
+            patch.object(app_module, "get_completed_issues_for_person", return_value=[]),
+            patch.object(app_module, "get_projects", return_value=projects),
+            patch.object(app_module, "get_merged_pr_counts_for_user", return_value=(0, 0)),
+            patch.object(app_module, "get_support_slugs", return_value=set()),
+        ):
+            alice = app_module._build_person_context("alice", 30, 1)
+            bob = app_module._build_person_context("bob", 30, 1)
+
+        self.assertEqual(alice["lead_completed_projects"], 4)
+        self.assertEqual(bob["lead_completed_projects"], 4)
+        with app_module.app.test_request_context():
+            body = app_module.render_template("partials/person_content.html", **alice)
+        self.assertIn("Completed Project Weeks", body)
+        self.assertNotIn("Completed Projects</a>", body)

--- a/tests/test_project_dates.py
+++ b/tests/test_project_dates.py
@@ -1,7 +1,11 @@
 import unittest
 from datetime import date, datetime, timezone
 
-from project_dates import format_project_start_status, format_project_target_status
+from project_dates import (
+    format_project_start_status,
+    format_project_target_status,
+    get_project_planned_weeks,
+)
 
 
 class ProjectDateStatusFormattingTest(unittest.TestCase):
@@ -48,6 +52,30 @@ class ProjectDateStatusFormattingTest(unittest.TestCase):
 
         self.assertEqual(days_left, 3)
         self.assertEqual(status_text, "3d left")
+
+
+class ProjectPlannedWeeksTest(unittest.TestCase):
+    def test_two_week_and_four_week_projects_use_calendar_span(self):
+        two_week = {"startDate": "2026-03-02", "targetDate": "2026-03-15"}
+        four_week = {"startDate": "2026-03-02", "targetDate": "2026-03-29"}
+
+        self.assertEqual(get_project_planned_weeks(two_week), 2)
+        self.assertEqual(get_project_planned_weeks(four_week), 4)
+        self.assertEqual(
+            get_project_planned_weeks(two_week) + get_project_planned_weeks(two_week),
+            get_project_planned_weeks(four_week),
+        )
+
+    def test_missing_dates_count_as_one_week(self):
+        self.assertEqual(get_project_planned_weeks({}), 1)
+        self.assertEqual(get_project_planned_weeks({"startDate": "2026-03-02"}), 1)
+        self.assertEqual(get_project_planned_weeks({"targetDate": "2026-03-15"}), 1)
+
+    def test_inverted_dates_still_count_the_span(self):
+        self.assertEqual(
+            get_project_planned_weeks({"startDate": "2026-03-15", "targetDate": "2026-03-02"}),
+            2,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue
The people-page completed-projects card counted projects, so two 2-week projects looked like twice as much work as one 4-week project.

## Solution
Count planned weeks from each completed project's Linear `startDate`–`targetDate` span. Two 2-week projects and one 4-week project both score 4. Projects without dates still count as 1 week.

Closes #474

## To Test
- Open `/team/nathan?days=30` and confirm the card is labeled **Completed Project Weeks**
- Confirm Nathan's value is weeks, not a project count
- Confirm two 2-week completed projects still equal one 4-week project

## Proof
Live `/team/nathan?days=30` on `main` counted **Completed Projects 4**.

![Nathan completed projects before](https://github.com/ApollosProject/bug-board/releases/download/proof-475/nathan-projects-before.png)

Same page on this PR: **Completed Project Weeks 23** (+2.2σ, green).

![Nathan completed project weeks after](https://github.com/ApollosProject/bug-board/releases/download/proof-476/nathan-project-weeks.png)