### PR TITLE
Credit Cursor PR co-authors in merged stats

### DIFF
--- a/github.py
+++ b/github.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from functools import lru_cache
@@ -30,6 +31,8 @@ TRACKED_REPOSITORIES = (
     "differential/crossroads-anywhere",
 )
 GITHUB_GRAPHQL_EXECUTE_TIMEOUT_SECONDS = 30
+CURSOR_AGENT_LOGIN = "cursoragent"
+_cursor_pr_cache_lock = threading.Lock()
 
 
 class GitHubDataError(RuntimeError):
@@ -340,6 +343,106 @@ def _merged_search_qualifier(days: int = 30, window: TimeWindow | None = None) -
     return TimeWindow.resolve(days, window=window).github_merged_qualifier()
 
 
+def _search_prs(query, search_query: str) -> List[Dict[str, Any]]:
+    prs: List[Dict[str, Any]] = []
+    cursor = None
+    for _ in range(10):
+        try:
+            data = _execute(query, variable_values={"query": search_query, "cursor": cursor})
+        except Exception:
+            return []
+        payload = data.get("search", {}) or {}
+        prs.extend(node for node in payload.get("nodes", []) or [] if node)
+        page_info = payload.get("pageInfo", {}) or {}
+        next_cursor = page_info.get("endCursor") if page_info.get("hasNextPage") else None
+        if not next_cursor or next_cursor == cursor:
+            break
+        cursor = next_cursor
+    return prs
+
+
+@lru_cache(maxsize=32)
+def _get_cursor_authored_merged_prs_cached(search_query: str, _minute: int) -> List[Dict[str, Any]]:
+    query = gql(
+        """
+        query CursorAuthoredMergedPRs($query: String!, $cursor: String) {
+          search(type: ISSUE, query: $query, first: 100, after: $cursor) {
+            nodes {
+              ... on PullRequest {
+                author { login }
+                commits(first: 1) {
+                  nodes {
+                    commit {
+                      author { user { login } }
+                      authors(first: 10) {
+                        nodes { user { login } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+        """
+    )
+    return _search_prs(query, search_query)
+
+
+def _get_cursor_authored_merged_prs(
+    days: int = 30, window: TimeWindow | None = None
+) -> List[Dict[str, Any]]:
+    orgs = get_github_orgs() if token else []
+    if not orgs:
+        return []
+    org_filter = " ".join(f"org:{org}" for org in orgs)
+    search_query = (
+        f"{org_filter} is:pr is:merged {_merged_search_qualifier(days, window)} author:app/cursor"
+    )
+    with _cursor_pr_cache_lock:
+        return _get_cursor_authored_merged_prs_cached(search_query, int(time.monotonic() // 60))
+
+
+def _cursor_coauthors(pr: Dict[str, Any]) -> List[str]:
+    pr_author = ((pr.get("author") or {}).get("login") or "").casefold()
+    if pr_author != "cursor":
+        return []
+
+    commits = (pr.get("commits") or {}).get("nodes", []) or []
+    if not commits:
+        return []
+    commit = (commits[0] or {}).get("commit") or {}
+    primary_author = (
+        ((commit.get("author") or {}).get("user") or {}).get("login") or ""
+    ).casefold()
+    if primary_author != CURSOR_AGENT_LOGIN:
+        return []
+
+    coauthors: Dict[str, str] = {}
+    for author in (commit.get("authors") or {}).get("nodes", []) or []:
+        login = ((author.get("user") or {}).get("login") or "").strip()
+        normalized_login = login.casefold()
+        if normalized_login and normalized_login != primary_author:
+            coauthors.setdefault(normalized_login, login)
+    return list(coauthors.values())
+
+
+def _group_cursor_prs_by_coauthor(
+    prs: List[Dict[str, Any]],
+) -> Dict[str, List[Dict[str, Any]]]:
+    prs_by_coauthor: Dict[str, List[Dict[str, Any]]] = {}
+    canonical_logins: Dict[str, str] = {}
+    for pr in prs:
+        for coauthor in _cursor_coauthors(pr):
+            coauthor = canonical_logins.setdefault(coauthor.casefold(), coauthor)
+            prs_by_coauthor.setdefault(coauthor, []).append(pr)
+    return prs_by_coauthor
+
+
 def _get_merged_prs(days: int = 30, window: TimeWindow | None = None):
     """Return merged PRs within the last ``days`` days using GitHub search."""
     if not token:
@@ -372,34 +475,13 @@ def _get_merged_prs(days: int = 30, window: TimeWindow | None = None):
         }
         """
     )
-    prs = []
-    cursor = None
-    max_pages = 10
-    pages = 0
-    while True:
-        try:
-            data = _execute(query, variable_values={"query": search_query, "cursor": cursor})
-        except Exception:
-            return []
-        payload = data.get("search", {}) or {}
-        nodes = payload.get("nodes", []) or []
-        for node in nodes:
-            if node:
-                prs.append(node)
-        page_info = payload.get("pageInfo", {}) or {}
-        if not page_info.get("hasNextPage"):
-            break
-        cursor = page_info.get("endCursor")
-        pages += 1
-        if pages >= max_pages:
-            break
-    return prs
+    return _search_prs(query, search_query)
 
 
 def get_merged_pr_counts_for_user(
     username: str, days: int = 30, window: TimeWindow | None = None
 ) -> tuple[int, int]:
-    """Return authored and approved-review PR counts for one GitHub user."""
+    """Return credited-author and approved-review PR counts for one GitHub user."""
     if not token or not username:
         return 0, 0
     orgs = get_github_orgs()
@@ -464,6 +546,14 @@ def get_merged_pr_counts_for_user(
             break
         cursor = next_cursor
 
+    authored_count += sum(
+        len(prs)
+        for author, prs in _group_cursor_prs_by_coauthor(
+            _get_cursor_authored_merged_prs(days, window)
+        ).items()
+        if author.casefold() == normalized_username
+    )
+
     return authored_count, reviewed_count
 
 
@@ -491,9 +581,18 @@ def get_merged_pr_activity(
     days: int = 30,
     window: TimeWindow | None = None,
 ) -> tuple[Dict[str, List[Dict[str, Any]]], Dict[str, List[Dict[str, Any]]]]:
-    """Return merged PRs grouped by author and reviewer from one GitHub search."""
-    prs = _get_merged_prs(days, window)
-    return _group_merged_prs_by_author(prs), _group_merged_prs_by_reviewer(prs)
+    """Return merged PRs grouped by credited author and reviewer."""
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        prs_future = executor.submit(_get_merged_prs, days, window)
+        cursor_prs_future = executor.submit(_get_cursor_authored_merged_prs, days, window)
+        prs = prs_future.result()
+        cursor_prs = cursor_prs_future.result()
+    prs_by_author = _group_merged_prs_by_author(prs)
+    canonical_authors = {author.casefold(): author for author in prs_by_author}
+    for coauthor, coauthored_prs in _group_cursor_prs_by_coauthor(cursor_prs).items():
+        author = canonical_authors.get(coauthor.casefold(), coauthor)
+        prs_by_author.setdefault(author, []).extend(coauthored_prs)
+    return prs_by_author, _group_merged_prs_by_reviewer(prs)
 
 
 def get_prs_waiting_for_review_by_reviewer():

--- a/tests/test_gql_client_requests.py
+++ b/tests/test_gql_client_requests.py
@@ -19,6 +19,7 @@ class _RecordingClient:
 
 class GraphQLClientRequestTests(unittest.TestCase):
     def test_person_pr_counts_use_scoped_searches_and_only_count_approvals(self):
+        github._get_cursor_authored_merged_prs_cached.cache_clear()
         response = {
             "authored": {"issueCount": 60},
             "reviewed": {
@@ -34,13 +35,42 @@ class GraphQLClientRequestTests(unittest.TestCase):
             patch.object(github, "token", "token"),
             patch.object(github, "get_github_orgs", return_value=["apollosproject"]),
             patch.object(github, "_execute", return_value=response) as execute,
+            patch.object(github.time, "monotonic", return_value=120),
         ):
             counts = github.get_merged_pr_counts_for_user("bkraeling", 30)
+            self.assertEqual(github.get_merged_pr_counts_for_user("bkraeling", 30), counts)
 
         self.assertEqual(counts, (60, 1))
-        variables = execute.call_args.kwargs["variable_values"]
+        variables = execute.call_args_list[0].kwargs["variable_values"]
         self.assertIn("author:bkraeling", variables["authored"])
         self.assertIn("reviewed-by:bkraeling", variables["reviewed"])
+        delegated_variables = execute.call_args_list[1].kwargs["variable_values"]
+        self.assertIn("author:app/cursor", delegated_variables["query"])
+        self.assertEqual(execute.call_count, 3)
+
+    def test_person_pr_counts_include_cursor_coauthored_prs_once_each(self):
+        response = {
+            "authored": {"issueCount": 3},
+            "reviewed": {
+                "nodes": [],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+            },
+        }
+        cursor_prs = [
+            self._cursor_pr("alice", "Alice"),
+            self._cursor_pr("ALICE"),
+            self._cursor_pr("bob"),
+        ]
+
+        with (
+            patch.object(github, "token", "token"),
+            patch.object(github, "get_github_orgs", return_value=["apollosproject"]),
+            patch.object(github, "_execute", return_value=response),
+            patch.object(github, "_get_cursor_authored_merged_prs", return_value=cursor_prs),
+        ):
+            counts = github.get_merged_pr_counts_for_user("Alice", 30)
+
+        self.assertEqual(counts, (5, 0))
 
     def test_merged_pr_activity_fetches_once_and_groups_authors_and_reviewers(self):
         prs = [
@@ -54,14 +84,53 @@ class GraphQLClientRequestTests(unittest.TestCase):
             },
         ]
 
-        with patch.object(github, "_get_merged_prs", return_value=prs) as fetch:
+        cursor_prs = [self._cursor_pr("ALICE"), self._cursor_pr("CARA"), self._cursor_pr("Cara")]
+        with (
+            patch.object(github, "_get_merged_prs", return_value=prs) as fetch,
+            patch.object(github, "_get_cursor_authored_merged_prs", return_value=cursor_prs),
+        ):
             authored, reviewed = github.get_merged_pr_activity(30)
 
         fetch.assert_called_once_with(30, None)
-        self.assertEqual(list(authored), ["alice", "bob"])
+        self.assertEqual(list(authored), ["alice", "bob", "CARA"])
         self.assertEqual(list(reviewed), ["bob", "alice"])
-        self.assertEqual(len(authored["alice"]), 1)
+        self.assertEqual((len(authored["alice"]), len(authored["CARA"])), (2, 2))
         self.assertEqual(len(reviewed["bob"]), 1)
+
+    @staticmethod
+    def _cursor_pr(*coauthors):
+        return {
+            "author": {"login": "cursor"},
+            "commits": {
+                "nodes": [
+                    {
+                        "commit": {
+                            "author": {"user": {"login": "cursoragent"}},
+                            "authors": {
+                                "nodes": [
+                                    {"user": {"login": login}}
+                                    for login in ("cursoragent", *coauthors)
+                                ]
+                            },
+                        }
+                    }
+                ]
+            },
+        }
+
+    def test_cursor_coauthors_require_cursor_app_and_generated_first_commit(self):
+        human_pr = self._cursor_pr("alice")
+        human_pr["author"] = {"login": "bob"}
+        human_first_commit = self._cursor_pr("alice")
+        human_first_commit["commits"]["nodes"][0]["commit"]["author"] = {"user": {"login": "bob"}}
+        later_cursor_commit = self._cursor_pr()
+        later_cursor_commit["commits"]["nodes"].append(
+            self._cursor_pr("alice")["commits"]["nodes"][0]
+        )
+
+        self.assertEqual(github._cursor_coauthors(human_pr), [])
+        self.assertEqual(github._cursor_coauthors(human_first_commit), [])
+        self.assertEqual(github._cursor_coauthors(later_cursor_commit), [])
 
     def test_github_client_allows_slow_repository_queries(self):
         previous_client = getattr(github._thread_local, "client", None)


### PR DESCRIPTION
## Issue

GitHub attributes Cursor-created PRs to the Cursor app, so normal `author:` searches omit the human who initiated the work as a commit co-author.

Closes #464

## Solution

- Search merged PRs authored specifically by the Cursor app.
- Credit linked co-authors only when Cursor Agent authored the first commit; ordinary PR and later-commit co-authors remain excluded.
- Apply the same case-insensitive attribution to person counts and aggregate leaderboard/Slack activity.
- Reuse the paginated PR-search path, and coalesce identical concurrent Cursor searches in a one-minute cache.

## To Test

- `python -m unittest tests.test_gql_client_requests` (23 passed)
- `python -m unittest discover -s tests -p 'test_*.py'` (163 passed)
- `ruff check .`
- `ruff format --check github.py tests/test_gql_client_requests.py`
- `mypy .`
- `vulture . --config pyproject.toml`
- `git diff --check`

## Proof

Exact head `9679a5301995db9a42e7c039b43715de329a32c5` queried live GitHub GraphQL data through both production count paths:

```console
$ source venv/bin/activate
$ python -c 'import github; username = "solideo-gloria"; cursor_prs = github._get_cursor_authored_merged_prs(30); delegated = sum(len(prs) for author, prs in github._group_cursor_prs_by_coauthor(cursor_prs).items() if author.casefold() == username); (credited, _) = github.get_merged_pr_counts_for_user(username, 30); activity, _ = github.get_merged_pr_activity(30); aggregate = sum(len(prs) for author, prs in activity.items() if author.casefold() == username); print({"cursor_prs": len(cursor_prs), "direct_authored": credited - delegated, "cursor_delegated": delegated, "credited_total": credited, "aggregate_total": aggregate})'
{'cursor_prs': 37, 'direct_authored': 5, 'cursor_delegated': 21, 'credited_total': 26, 'aggregate_total': 26}
```

This reproduces the missing-credit cause (5 direct PRs) and shows the fix adds exactly Zach's 21 Cursor-delegated PRs to both displayed totals.
