### PR TITLE
Gate Bug Board behind GitHub OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ python -m unittest discover -s tests -p 'test_*.py'
 
 - `LINEAR_API_KEY` – API token for Linear
 - `GITHUB_TOKEN` – GitHub token used for pull‑request data
+- `GITHUB_OAUTH_ENABLED` – Set to `true` to require GitHub sign-in; the app also enables the gate automatically when either OAuth credential is configured
+- `GITHUB_OAUTH_CLIENT_ID` – Client ID for the GitHub OAuth app that gates dashboard access
+- `GITHUB_OAUTH_CLIENT_SECRET` – Client secret for the GitHub OAuth app
+- `GITHUB_OAUTH_CALLBACK_URL` – OAuth callback URL (for example, `https://your-app.example/auth/github/callback`); when omitted, the app uses `APP_URL` plus `/auth/github/callback`
+- `GITHUB_OAUTH_ORG` – GitHub organization whose active members can sign in (default: `ApollosProject`)
+- `FLASK_SECRET_KEY` – Random value of at least 32 characters used to sign login sessions
 - `SLACK_WEBHOOK_URL` – Webhook URL used by the worker to post messages
 - `MANAGER_SLACK_WEBHOOK_URL` – Webhook URL used for manager-facing summaries
 - `APP_URL` – Public URL where the app is hosted
@@ -59,6 +65,30 @@ python -m unittest discover -s tests -p 'test_*.py'
 - `RIPPLING_PTO_TIMEZONE` – Optional IANA time zone used to place timed PTO entries on calendar days (default: `America/New_York`)
 
 These can be placed in a `.env` file or exported in your shell.
+
+### GitHub access gate
+
+Create an OAuth app owned by the `ApollosProject` GitHub organization and set its authorization
+callback URL to the same value as `GITHUB_OAUTH_CALLBACK_URL`. The application requests only the
+`read:org` scope, validates both the signed-in GitHub identity and active organization membership,
+and keeps the resulting login session for at most eight hours. The temporary GitHub access token is
+not stored in the session.
+
+Production uses `https://engineering.apollos.app` as `APP_URL` and
+`https://engineering.apollos.app/auth/github/callback` as `GITHUB_OAUTH_CALLBACK_URL`.
+
+Set `GITHUB_OAUTH_ENABLED=true`, `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET`, and
+`FLASK_SECRET_KEY` in the deployed environment. Also set either `GITHUB_OAUTH_CALLBACK_URL` or
+`APP_URL`. Once OAuth is enabled or partially configured, the dashboard fails closed with `503`
+until every required value is present. `GET /healthz` remains public for platform health checks;
+all dashboard and static-resource routes require a verified session.
+
+For local OAuth testing, GitHub permits a loopback callback such as
+`http://127.0.0.1:8000/auth/github/callback`. Generate a session key without committing it:
+
+```bash
+python -c 'import secrets; print(secrets.token_hex(32))'
+```
 
 3. Edit `config.yml` to configure team members and platform ownership.
 

--- a/app.py
+++ b/app.py
@@ -23,6 +23,7 @@ from github import (
     get_merged_pr_activity,
     get_merged_pr_counts_for_user,
 )
+from github_oauth import register_github_oauth
 from leaderboard import calculate_cycle_project_points
 from leaderboard_cache import DEFAULT_LEADERBOARD_DAYS, get_cached_leaderboard
 from leaderboard_export import build_leaderboard_export_rows, render_leaderboard_csv
@@ -198,6 +199,7 @@ def _apply_proxy_fix(flask_app: Flask) -> None:
 
 
 _apply_proxy_fix(app)
+register_github_oauth(app)
 
 INDEX_CONTEXT_CACHE_MAXSIZE = 16
 DEFAULT_ASTRO_UI_BASE_URL = "https://cloud.astronomer.io/cljsvo8d800yz01giqt70a7e7"

--- a/github_oauth.py
+++ b/github_oauth.py
@@ -1,0 +1,418 @@
+import base64
+import hashlib
+import hmac
+import logging
+import os
+import re
+import secrets
+from datetime import timedelta
+from urllib.parse import quote, urlencode, urlsplit, urlunsplit
+
+import requests
+from flask import Flask, Response, current_app, redirect, render_template, request, session
+
+GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
+GITHUB_API_URL = "https://api.github.com"
+GITHUB_API_VERSION = "2026-03-10"
+GITHUB_REQUEST_TIMEOUT_SECONDS = 10
+DEFAULT_GITHUB_ORG = "ApollosProject"
+
+OAUTH_STATE_SESSION_KEY = "github_oauth_state"
+OAUTH_VERIFIER_SESSION_KEY = "github_oauth_code_verifier"
+OAUTH_NEXT_SESSION_KEY = "github_oauth_next"
+AUTHENTICATED_LOGIN_SESSION_KEY = "github_login"
+AUTHENTICATED_USER_ID_SESSION_KEY = "github_user_id"
+AUTHENTICATED_ORG_SESSION_KEY = "github_org"
+
+PUBLIC_ENDPOINTS = {
+    "github_login",
+    "github_oauth_callback",
+    "github_logout",
+    "healthz",
+}
+
+
+class GitHubOAuthError(Exception):
+    """Raised when GitHub cannot complete the OAuth identity check."""
+
+
+class GitHubOrgAccessDenied(Exception):
+    """Raised when GitHub does not report an active organization membership."""
+
+
+def _truthy(value: str | bool | None) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _configured_callback_url() -> str:
+    explicit_url = os.getenv("GITHUB_OAUTH_CALLBACK_URL", "").strip()
+    if explicit_url:
+        return explicit_url
+
+    app_url = os.getenv("APP_URL", "").strip().rstrip("/")
+    if app_url:
+        return f"{app_url}/auth/github/callback"
+    return ""
+
+
+def _callback_url_is_safe(callback_url: str) -> bool:
+    parsed = urlsplit(callback_url)
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        return False
+    if parsed.scheme == "https" and parsed.netloc:
+        return True
+    return parsed.scheme == "http" and parsed.hostname in {"127.0.0.1", "localhost"}
+
+
+def _authentication_configuration_errors() -> list[str]:
+    required_values = {
+        "GITHUB_OAUTH_CLIENT_ID": current_app.config.get("GITHUB_OAUTH_CLIENT_ID"),
+        "GITHUB_OAUTH_CLIENT_SECRET": current_app.config.get("GITHUB_OAUTH_CLIENT_SECRET"),
+        "FLASK_SECRET_KEY": current_app.secret_key,
+        "GITHUB_OAUTH_CALLBACK_URL or APP_URL": current_app.config.get("GITHUB_OAUTH_CALLBACK_URL"),
+        "GITHUB_OAUTH_ORG": current_app.config.get("GITHUB_OAUTH_ORG"),
+    }
+    errors = [name for name, value in required_values.items() if not str(value or "").strip()]
+
+    secret_key = str(current_app.secret_key or "")
+    if secret_key and len(secret_key) < 32:
+        errors.append("FLASK_SECRET_KEY must contain at least 32 characters")
+
+    callback_url = str(current_app.config.get("GITHUB_OAUTH_CALLBACK_URL") or "")
+    if callback_url and not _callback_url_is_safe(callback_url):
+        errors.append("GITHUB_OAUTH_CALLBACK_URL must use HTTPS (or HTTP on localhost)")
+
+    org = str(current_app.config.get("GITHUB_OAUTH_ORG") or "")
+    if org and not re.fullmatch(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})", org):
+        errors.append("GITHUB_OAUTH_ORG must be a valid GitHub organization name")
+
+    return errors
+
+
+def _render_auth_message(title: str, message: str, status: int, allow_retry: bool = False):
+    response = render_template(
+        "auth.html",
+        title=title,
+        message=message,
+        allow_retry=allow_retry,
+    )
+    return response, status
+
+
+def _safe_next_url(value: str | None) -> str:
+    candidate = (value or "").strip()
+    if not candidate.startswith("/") or candidate.startswith("//") or "\\" in candidate:
+        return "/"
+
+    parsed = urlsplit(candidate)
+    if parsed.scheme or parsed.netloc or parsed.path.startswith("//"):
+        return "/"
+    return urlunsplit(("", "", parsed.path or "/", parsed.query, ""))
+
+
+def _current_relative_url() -> str:
+    relative_url = request.full_path
+    return relative_url[:-1] if relative_url.endswith("?") else relative_url
+
+
+def _authentication_return_url() -> str:
+    if request.headers.get("HX-Request", "").lower() != "true":
+        return _current_relative_url()
+
+    current_url = request.headers.get("HX-Current-URL")
+    if not current_url:
+        return "/"
+    parsed = urlsplit(current_url)
+    relative_url = urlunsplit(("", "", parsed.path or "/", parsed.query, ""))
+    return _safe_next_url(relative_url)
+
+
+def _pkce_challenge(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _github_api_headers(access_token: str) -> dict[str, str]:
+    return {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {access_token}",
+        "User-Agent": "apollos-bug-board",
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+    }
+
+
+def _exchange_code_for_token(code: str, code_verifier: str, callback_url: str) -> str:
+    try:
+        response = requests.post(
+            GITHUB_TOKEN_URL,
+            headers={"Accept": "application/json"},
+            data={
+                "client_id": current_app.config["GITHUB_OAUTH_CLIENT_ID"],
+                "client_secret": current_app.config["GITHUB_OAUTH_CLIENT_SECRET"],
+                "code": code,
+                "code_verifier": code_verifier,
+                "redirect_uri": callback_url,
+            },
+            timeout=GITHUB_REQUEST_TIMEOUT_SECONDS,
+            allow_redirects=False,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except (requests.RequestException, ValueError) as exc:
+        raise GitHubOAuthError("GitHub token exchange failed") from exc
+
+    access_token = payload.get("access_token") if isinstance(payload, dict) else None
+    if not isinstance(access_token, str) or not access_token:
+        raise GitHubOAuthError("GitHub did not return an access token")
+    return access_token
+
+
+def _get_github_identity(access_token: str) -> tuple[str, int]:
+    try:
+        response = requests.get(
+            f"{GITHUB_API_URL}/user",
+            headers=_github_api_headers(access_token),
+            timeout=GITHUB_REQUEST_TIMEOUT_SECONDS,
+            allow_redirects=False,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except (requests.RequestException, ValueError) as exc:
+        raise GitHubOAuthError("GitHub identity lookup failed") from exc
+
+    login = payload.get("login") if isinstance(payload, dict) else None
+    user_id = payload.get("id") if isinstance(payload, dict) else None
+    if not isinstance(login, str) or not login or not isinstance(user_id, int):
+        raise GitHubOAuthError("GitHub returned an invalid identity")
+    return login, user_id
+
+
+def _require_active_org_membership(access_token: str, org: str) -> None:
+    try:
+        response = requests.get(
+            f"{GITHUB_API_URL}/user/memberships/orgs/{quote(org, safe='')}",
+            headers=_github_api_headers(access_token),
+            timeout=GITHUB_REQUEST_TIMEOUT_SECONDS,
+            allow_redirects=False,
+        )
+        if response.status_code in {403, 404}:
+            raise GitHubOrgAccessDenied
+        response.raise_for_status()
+        payload = response.json()
+    except GitHubOrgAccessDenied:
+        raise
+    except (requests.RequestException, ValueError) as exc:
+        raise GitHubOAuthError("GitHub organization membership lookup failed") from exc
+
+    if not isinstance(payload, dict) or payload.get("state") != "active":
+        raise GitHubOrgAccessDenied
+
+
+def _has_authenticated_session(org: str) -> bool:
+    login = session.get(AUTHENTICATED_LOGIN_SESSION_KEY)
+    user_id = session.get(AUTHENTICATED_USER_ID_SESSION_KEY)
+    session_org = session.get(AUTHENTICATED_ORG_SESSION_KEY)
+    return (
+        isinstance(login, str)
+        and bool(login)
+        and isinstance(user_id, int)
+        and isinstance(session_org, str)
+        and session_org.casefold() == org.casefold()
+    )
+
+
+def register_github_oauth(app: Flask) -> None:
+    client_id = os.getenv("GITHUB_OAUTH_CLIENT_ID", "").strip()
+    client_secret = os.getenv("GITHUB_OAUTH_CLIENT_SECRET", "").strip()
+    callback_url = _configured_callback_url()
+    oauth_enabled = _truthy(os.getenv("GITHUB_OAUTH_ENABLED")) or bool(client_id or client_secret)
+
+    app.config.update(
+        GITHUB_OAUTH_ENABLED=oauth_enabled,
+        GITHUB_OAUTH_CLIENT_ID=client_id,
+        GITHUB_OAUTH_CLIENT_SECRET=client_secret,
+        GITHUB_OAUTH_CALLBACK_URL=callback_url,
+        GITHUB_OAUTH_ORG=os.getenv("GITHUB_OAUTH_ORG", DEFAULT_GITHUB_ORG).strip()
+        or DEFAULT_GITHUB_ORG,
+        PERMANENT_SESSION_LIFETIME=timedelta(hours=8),
+        SESSION_COOKIE_HTTPONLY=True,
+        SESSION_COOKIE_SAMESITE="Lax",
+        SESSION_COOKIE_SECURE=callback_url.startswith("https://"),
+    )
+    secret_key = os.getenv("FLASK_SECRET_KEY", "")
+    if secret_key:
+        app.secret_key = secret_key
+
+    @app.before_request
+    def require_github_org_membership():
+        if not current_app.config.get("GITHUB_OAUTH_ENABLED"):
+            return None
+        if request.endpoint in PUBLIC_ENDPOINTS:
+            return None
+
+        configuration_errors = _authentication_configuration_errors()
+        if configuration_errors:
+            logging.error(
+                "GitHub OAuth configuration error: %s",
+                "; ".join(configuration_errors),
+            )
+            return _render_auth_message(
+                "Authentication unavailable",
+                "Bug Board authentication is not configured correctly.",
+                503,
+            )
+
+        org = str(current_app.config["GITHUB_OAUTH_ORG"])
+        if _has_authenticated_session(org):
+            return None
+
+        login_url = f"/login?{urlencode({'next': _authentication_return_url()})}"
+        if request.headers.get("HX-Request", "").lower() == "true":
+            response = Response(status=401)
+            response.headers["HX-Redirect"] = login_url
+            response.headers["Cache-Control"] = "private, no-store"
+            return response
+        return redirect(login_url)
+
+    @app.after_request
+    def prevent_authenticated_response_caching(response: Response):
+        if current_app.config.get("GITHUB_OAUTH_ENABLED") and request.endpoint != "healthz":
+            response.headers["Cache-Control"] = "private, no-store"
+        return response
+
+    @app.get("/login")
+    def github_login():
+        configuration_errors = _authentication_configuration_errors()
+        if configuration_errors:
+            logging.error(
+                "GitHub OAuth configuration error: %s",
+                "; ".join(configuration_errors),
+            )
+            return _render_auth_message(
+                "Authentication unavailable",
+                "Bug Board authentication is not configured correctly.",
+                503,
+            )
+
+        state = secrets.token_urlsafe(32)
+        code_verifier = secrets.token_urlsafe(64)
+        callback_url = str(current_app.config["GITHUB_OAUTH_CALLBACK_URL"])
+        session.clear()
+        session.permanent = True
+        session[OAUTH_STATE_SESSION_KEY] = state
+        session[OAUTH_VERIFIER_SESSION_KEY] = code_verifier
+        session[OAUTH_NEXT_SESSION_KEY] = _safe_next_url(request.args.get("next"))
+
+        params = {
+            "allow_signup": "false",
+            "client_id": current_app.config["GITHUB_OAUTH_CLIENT_ID"],
+            "code_challenge": _pkce_challenge(code_verifier),
+            "code_challenge_method": "S256",
+            "prompt": "select_account",
+            "redirect_uri": callback_url,
+            "scope": "read:org",
+            "state": state,
+        }
+        return redirect(f"{GITHUB_AUTHORIZE_URL}?{urlencode(params)}")
+
+    @app.get("/auth/github/callback")
+    def github_oauth_callback():
+        configuration_errors = _authentication_configuration_errors()
+        if configuration_errors:
+            logging.error(
+                "GitHub OAuth configuration error: %s",
+                "; ".join(configuration_errors),
+            )
+            return _render_auth_message(
+                "Authentication unavailable",
+                "Bug Board authentication is not configured correctly.",
+                503,
+            )
+
+        expected_state = session.pop(OAUTH_STATE_SESSION_KEY, None)
+        code_verifier = session.pop(OAUTH_VERIFIER_SESSION_KEY, None)
+        next_url = _safe_next_url(session.pop(OAUTH_NEXT_SESSION_KEY, None))
+        received_state = request.args.get("state")
+        state_is_valid = (
+            isinstance(expected_state, str)
+            and isinstance(received_state, str)
+            and hmac.compare_digest(expected_state, received_state)
+        )
+        if not state_is_valid or not isinstance(code_verifier, str):
+            session.clear()
+            return _render_auth_message(
+                "Sign-in failed",
+                "The GitHub sign-in request expired or could not be verified. Please try again.",
+                400,
+                allow_retry=True,
+            )
+
+        code = request.args.get("code")
+        if request.args.get("error") or not code:
+            session.clear()
+            return _render_auth_message(
+                "Sign-in canceled",
+                "GitHub authorization was not completed.",
+                403,
+                allow_retry=True,
+            )
+
+        try:
+            access_token = _exchange_code_for_token(
+                code,
+                code_verifier,
+                str(current_app.config["GITHUB_OAUTH_CALLBACK_URL"]),
+            )
+            login, user_id = _get_github_identity(access_token)
+            org = str(current_app.config["GITHUB_OAUTH_ORG"])
+            _require_active_org_membership(access_token, org)
+        except GitHubOrgAccessDenied:
+            session.clear()
+            return _render_auth_message(
+                "Access denied",
+                f"Bug Board is available only to active members of the {org} GitHub organization.",
+                403,
+                allow_retry=True,
+            )
+        except GitHubOAuthError:
+            logging.exception("GitHub OAuth sign-in failed")
+            session.clear()
+            return _render_auth_message(
+                "Sign-in unavailable",
+                "GitHub could not complete sign-in. Please try again.",
+                502,
+                allow_retry=True,
+            )
+
+        session.clear()
+        session.permanent = True
+        session[AUTHENTICATED_LOGIN_SESSION_KEY] = login
+        session[AUTHENTICATED_USER_ID_SESSION_KEY] = user_id
+        session[AUTHENTICATED_ORG_SESSION_KEY] = org
+        return redirect(next_url)
+
+    @app.get("/logout")
+    def github_logout():
+        if not current_app.config.get("GITHUB_OAUTH_ENABLED"):
+            return redirect("/")
+        configuration_errors = _authentication_configuration_errors()
+        if configuration_errors:
+            logging.error(
+                "GitHub OAuth configuration error: %s",
+                "; ".join(configuration_errors),
+            )
+            return _render_auth_message(
+                "Authentication unavailable",
+                "Bug Board authentication is not configured correctly.",
+                503,
+            )
+        session.clear()
+        return _render_auth_message(
+            "Signed out",
+            "Your Bug Board session has ended.",
+            200,
+            allow_retry=True,
+        )

--- a/github_oauth.py
+++ b/github_oauth.py
@@ -14,7 +14,7 @@ from flask import Flask, Response, current_app, redirect, render_template, reque
 GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
 GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
 GITHUB_API_URL = "https://api.github.com"
-GITHUB_API_VERSION = "2026-03-10"
+GITHUB_API_VERSION = "2022-11-28"
 GITHUB_REQUEST_TIMEOUT_SECONDS = 10
 DEFAULT_GITHUB_ORG = "ApollosProject"
 
@@ -246,6 +246,18 @@ def register_github_oauth(app: Flask) -> None:
     if secret_key:
         app.secret_key = secret_key
 
+    reported_configuration_errors: set[tuple[str, ...]] = set()
+
+    def log_configuration_errors_once(configuration_errors: list[str]) -> None:
+        error_signature = tuple(configuration_errors)
+        if error_signature in reported_configuration_errors:
+            return
+        reported_configuration_errors.add(error_signature)
+        logging.error(
+            "GitHub OAuth configuration error: %s",
+            "; ".join(configuration_errors),
+        )
+
     @app.before_request
     def require_github_org_membership():
         if not current_app.config.get("GITHUB_OAUTH_ENABLED"):
@@ -255,10 +267,7 @@ def register_github_oauth(app: Flask) -> None:
 
         configuration_errors = _authentication_configuration_errors()
         if configuration_errors:
-            logging.error(
-                "GitHub OAuth configuration error: %s",
-                "; ".join(configuration_errors),
-            )
+            log_configuration_errors_once(configuration_errors)
             return _render_auth_message(
                 "Authentication unavailable",
                 "Bug Board authentication is not configured correctly.",
@@ -287,10 +296,7 @@ def register_github_oauth(app: Flask) -> None:
     def github_login():
         configuration_errors = _authentication_configuration_errors()
         if configuration_errors:
-            logging.error(
-                "GitHub OAuth configuration error: %s",
-                "; ".join(configuration_errors),
-            )
+            log_configuration_errors_once(configuration_errors)
             return _render_auth_message(
                 "Authentication unavailable",
                 "Bug Board authentication is not configured correctly.",
@@ -322,10 +328,7 @@ def register_github_oauth(app: Flask) -> None:
     def github_oauth_callback():
         configuration_errors = _authentication_configuration_errors()
         if configuration_errors:
-            logging.error(
-                "GitHub OAuth configuration error: %s",
-                "; ".join(configuration_errors),
-            )
+            log_configuration_errors_once(configuration_errors)
             return _render_auth_message(
                 "Authentication unavailable",
                 "Bug Board authentication is not configured correctly.",
@@ -394,16 +397,13 @@ def register_github_oauth(app: Flask) -> None:
         session[AUTHENTICATED_ORG_SESSION_KEY] = org
         return redirect(next_url)
 
-    @app.get("/logout")
+    @app.post("/logout")
     def github_logout():
         if not current_app.config.get("GITHUB_OAUTH_ENABLED"):
             return redirect("/")
         configuration_errors = _authentication_configuration_errors()
         if configuration_errors:
-            logging.error(
-                "GitHub OAuth configuration error: %s",
-                "; ".join(configuration_errors),
-            )
+            log_configuration_errors_once(configuration_errors)
             return _render_auth_message(
                 "Authentication unavailable",
                 "Bug Board authentication is not configured correctly.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,16 @@ select = ["E", "F", "I", "W"]
 
 [tool.vulture]
 exclude = ["venv", ".venv", "env", ".env", "__pycache__", ".git", "static", "templates", ".tox", "build", "dist", "*.egg-info", "tests"]
-ignore_decorators = ["@app.route", "@app.template_filter"]
+ignore_decorators = [
+    "@app.after_request",
+    "@app.before_request",
+    "@app.get",
+    "@app.route",
+    "@app.template_filter",
+]
 ignore_names = [
     "breakdown",
+    "permanent",
     "post_weekly_changelog",
 ]
 min_confidence = 60

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ ignore_decorators = [
     "@app.after_request",
     "@app.before_request",
     "@app.get",
+    "@app.post",
     "@app.route",
     "@app.template_filter",
 ]

--- a/static/styles.css
+++ b/static/styles.css
@@ -32,6 +32,26 @@ details.dropdown.site-menu > summary + ul {
   right: 0;
 }
 
+.logout-form {
+  margin: 0;
+}
+
+.logout-form button {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  color: var(--pico-primary);
+  margin: 0;
+  padding: var(--pico-nav-link-spacing-vertical) var(--pico-nav-link-spacing-horizontal);
+  width: auto;
+}
+
+.logout-form button:is(:hover, :focus) {
+  background: transparent;
+  color: var(--pico-primary-hover);
+  text-decoration: underline;
+}
+
 .hamburger-icon {
   display: inline-flex;
   flex-direction: column;

--- a/templates/auth.html
+++ b/templates/auth.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    <title>{{ title }} · Bug Board</title>
+    <style>
+      :root {
+        font-family: system-ui, sans-serif;
+        color-scheme: light dark;
+      }
+      body {
+        display: grid;
+        min-height: 100vh;
+        margin: 0;
+        place-items: center;
+        background: Canvas;
+        color: CanvasText;
+      }
+      main {
+        width: min(32rem, calc(100% - 3rem));
+        text-align: center;
+      }
+      a {
+        display: inline-block;
+        margin-top: 1rem;
+        padding: 0.7rem 1rem;
+        border-radius: 0.4rem;
+        background: #24292f;
+        color: #fff;
+        font-weight: 600;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>{{ title }}</h1>
+      <p>{{ message }}</p>
+      {% if allow_retry %}
+        <a href="{{ url_for('github_login') }}">Sign in with GitHub</a>
+      {% endif %}
+    </main>
+  </body>
+</html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,13 @@
           <li><a href="{{ url_for('index') }}">Bug Board</a></li>
         </ul>
         <ul>
+          {% if session.get('github_login') %}
+            <li>
+              <a href="{{ url_for('github_logout') }}" title="Sign out">
+                @{{ session.get('github_login') }}
+              </a>
+            </li>
+          {% endif %}
           <li>
             <details class="dropdown site-menu">
               <summary role="button" class="outline" aria-label="Open local pages menu">

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,9 +24,11 @@
         <ul>
           {% if session.get('github_login') %}
             <li>
-              <a href="{{ url_for('github_logout') }}" title="Sign out">
-                @{{ session.get('github_login') }}
-              </a>
+              <form class="logout-form" method="post" action="{{ url_for('github_logout') }}">
+                <button type="submit" title="Sign out">
+                  @{{ session.get('github_login') }}
+                </button>
+              </form>
             </li>
           {% endif %}
           <li>

--- a/tests/test_github_oauth.py
+++ b/tests/test_github_oauth.py
@@ -44,6 +44,12 @@ class GitHubOAuthTest(unittest.TestCase):
             oauth_session[github_oauth.OAUTH_VERIFIER_SESSION_KEY] = "v" * 64
             oauth_session[github_oauth.OAUTH_NEXT_SESSION_KEY] = next_url
 
+    def _seed_authenticated_session(self):
+        with self.client.session_transaction() as authenticated_session:
+            authenticated_session[github_oauth.AUTHENTICATED_LOGIN_SESSION_KEY] = "octocat"
+            authenticated_session[github_oauth.AUTHENTICATED_USER_ID_SESSION_KEY] = 123
+            authenticated_session[github_oauth.AUTHENTICATED_ORG_SESSION_KEY] = "ApollosProject"
+
     def test_protected_routes_redirect_to_login_but_health_remains_public(self):
         response = self.client.get("/projects?days=30")
 
@@ -109,6 +115,13 @@ class GitHubOAuthTest(unittest.TestCase):
             self.assertEqual(oauth_session[github_oauth.OAUTH_STATE_SESSION_KEY], "random-state")
             self.assertEqual(oauth_session[github_oauth.OAUTH_VERIFIER_SESSION_KEY], verifier)
             self.assertEqual(oauth_session[github_oauth.OAUTH_NEXT_SESSION_KEY], "/")
+
+    def test_github_api_version_matches_the_existing_rest_clients(self):
+        self.assertEqual(github_oauth.GITHUB_API_VERSION, "2022-11-28")
+        self.assertEqual(
+            github_oauth._github_api_headers("temporary-token")["X-GitHub-Api-Version"],
+            "2022-11-28",
+        )
 
     def test_callback_verifies_identity_and_active_org_membership(self):
         self._seed_oauth_session("/projects?days=30")
@@ -205,6 +218,57 @@ class GitHubOAuthTest(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         post.assert_not_called()
         get.assert_not_called()
+
+    def test_logout_requires_post_and_clears_the_authenticated_session(self):
+        self._seed_authenticated_session()
+
+        page_response = self.client.get("/projects")
+        page = page_response.get_data(as_text=True)
+        self.assertEqual(page_response.status_code, 200)
+        self.assertIn('method="post"', page)
+        self.assertIn('action="/logout"', page)
+        self.assertNotIn('href="/logout"', page)
+
+        get_response = self.client.get("/logout")
+        self.assertEqual(get_response.status_code, 405)
+        with self.client.session_transaction() as authenticated_session:
+            self.assertEqual(authenticated_session["github_login"], "octocat")
+
+        post_response = self.client.post("/logout")
+        self.assertEqual(post_response.status_code, 200)
+        self.assertIn("Signed out", post_response.get_data(as_text=True))
+        with self.client.session_transaction() as signed_out_session:
+            self.assertNotIn("github_login", signed_out_session)
+            self.assertNotIn("github_user_id", signed_out_session)
+            self.assertNotIn("github_org", signed_out_session)
+
+    def test_configuration_errors_are_logged_once_per_process(self):
+        with patch.dict(
+            os.environ,
+            {
+                "GITHUB_OAUTH_ENABLED": "true",
+                "GITHUB_OAUTH_CLIENT_ID": "oauth-client-id",
+                "APP_URL": "https://bug-board.example",
+            },
+            clear=True,
+        ):
+            test_app = Flask("oauth-logging-test")
+            test_app.get("/protected")(lambda: "ok")
+            github_oauth.register_github_oauth(test_app)
+
+        client = test_app.test_client()
+        with self.assertLogs(level="ERROR") as logs:
+            first_response = client.get("/protected")
+            second_response = client.get("/protected")
+            login_response = client.get("/login")
+
+        self.assertEqual(first_response.status_code, 503)
+        self.assertEqual(second_response.status_code, 503)
+        self.assertEqual(login_response.status_code, 503)
+        oauth_errors = [
+            message for message in logs.output if "GitHub OAuth configuration error" in message
+        ]
+        self.assertEqual(len(oauth_errors), 1)
 
     def test_partially_configured_oauth_fails_closed(self):
         with patch.dict(

--- a/tests/test_github_oauth.py
+++ b/tests/test_github_oauth.py
@@ -1,0 +1,233 @@
+import base64
+import hashlib
+import os
+import unittest
+from unittest.mock import Mock, patch
+from urllib.parse import parse_qs, urlsplit
+
+from flask import Flask
+
+import app as app_module
+import github_oauth
+
+
+class GitHubOAuthTest(unittest.TestCase):
+    def setUp(self):
+        self.config_patch = patch.dict(
+            app_module.app.config,
+            {
+                "GITHUB_OAUTH_ENABLED": True,
+                "GITHUB_OAUTH_CLIENT_ID": "oauth-client-id",
+                "GITHUB_OAUTH_CLIENT_SECRET": "oauth-client-secret",
+                "GITHUB_OAUTH_CALLBACK_URL": ("https://bug-board.example/auth/github/callback"),
+                "GITHUB_OAUTH_ORG": "ApollosProject",
+                "SECRET_KEY": "test-secret-key-with-at-least-32-characters",
+                "SESSION_COOKIE_SECURE": False,
+            },
+            clear=False,
+        )
+        self.config_patch.start()
+        self.addCleanup(self.config_patch.stop)
+        self.client = app_module.app.test_client()
+
+    @staticmethod
+    def _response(status_code, payload):
+        response = Mock(status_code=status_code)
+        response.json.return_value = payload
+        if status_code >= 400:
+            response.raise_for_status.side_effect = github_oauth.requests.HTTPError()
+        return response
+
+    def _seed_oauth_session(self, next_url="/"):
+        with self.client.session_transaction() as oauth_session:
+            oauth_session[github_oauth.OAUTH_STATE_SESSION_KEY] = "expected-state"
+            oauth_session[github_oauth.OAUTH_VERIFIER_SESSION_KEY] = "v" * 64
+            oauth_session[github_oauth.OAUTH_NEXT_SESSION_KEY] = next_url
+
+    def test_protected_routes_redirect_to_login_but_health_remains_public(self):
+        response = self.client.get("/projects?days=30")
+
+        self.assertEqual(response.status_code, 302)
+        login_url = urlsplit(response.location)
+        self.assertEqual(login_url.path, "/login")
+        self.assertEqual(parse_qs(login_url.query)["next"], ["/projects?days=30"])
+
+        static_response = self.client.get("/static/resources/engineering-expectations.pdf")
+        self.assertEqual(static_response.status_code, 302)
+        self.assertEqual(urlsplit(static_response.location).path, "/login")
+
+        health_response = self.client.get("/healthz")
+        self.assertEqual(health_response.status_code, 200)
+        self.assertEqual(health_response.get_json(), {"status": "ok"})
+
+    def test_htmx_requests_receive_a_full_page_redirect_instruction(self):
+        response = self.client.get(
+            "/partials/index/leaderboard",
+            headers={
+                "HX-Request": "true",
+                "HX-Current-URL": "https://bug-board.example/?days=30",
+            },
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.headers["HX-Redirect"],
+            "/login?next=%2F%3Fdays%3D30",
+        )
+
+    def test_login_uses_state_pkce_and_a_safe_return_path(self):
+        verifier = "v" * 64
+        with patch.object(
+            github_oauth.secrets,
+            "token_urlsafe",
+            side_effect=["random-state", verifier],
+        ):
+            response = self.client.get("/login?next=https://attacker.example")
+
+        self.assertEqual(response.status_code, 302)
+        authorization_url = urlsplit(response.location)
+        self.assertEqual(
+            f"{authorization_url.scheme}://{authorization_url.netloc}{authorization_url.path}",
+            github_oauth.GITHUB_AUTHORIZE_URL,
+        )
+        params = parse_qs(authorization_url.query)
+        expected_challenge = (
+            base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+            .rstrip(b"=")
+            .decode("ascii")
+        )
+        self.assertEqual(params["state"], ["random-state"])
+        self.assertEqual(params["scope"], ["read:org"])
+        self.assertEqual(params["code_challenge"], [expected_challenge])
+        self.assertEqual(params["code_challenge_method"], ["S256"])
+        self.assertEqual(
+            params["redirect_uri"],
+            ["https://bug-board.example/auth/github/callback"],
+        )
+
+        with self.client.session_transaction() as oauth_session:
+            self.assertEqual(oauth_session[github_oauth.OAUTH_STATE_SESSION_KEY], "random-state")
+            self.assertEqual(oauth_session[github_oauth.OAUTH_VERIFIER_SESSION_KEY], verifier)
+            self.assertEqual(oauth_session[github_oauth.OAUTH_NEXT_SESSION_KEY], "/")
+
+    def test_callback_verifies_identity_and_active_org_membership(self):
+        self._seed_oauth_session("/projects?days=30")
+        token_response = self._response(200, {"access_token": "temporary-token"})
+        identity_response = self._response(200, {"login": "octocat", "id": 123})
+        membership_response = self._response(200, {"state": "active"})
+
+        with (
+            patch.object(
+                github_oauth.requests,
+                "post",
+                return_value=token_response,
+                create=True,
+            ) as post,
+            patch.object(
+                github_oauth.requests,
+                "get",
+                side_effect=[identity_response, membership_response],
+                create=True,
+            ) as get,
+        ):
+            response = self.client.get(
+                "/auth/github/callback?code=temporary-code&state=expected-state"
+            )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.location, "/projects?days=30")
+        self.assertEqual(post.call_args.kwargs["data"]["code_verifier"], "v" * 64)
+        self.assertEqual(
+            post.call_args.kwargs["data"]["redirect_uri"],
+            "https://bug-board.example/auth/github/callback",
+        )
+        self.assertEqual(get.call_args_list[0].args[0], "https://api.github.com/user")
+        self.assertEqual(
+            get.call_args_list[1].args[0],
+            "https://api.github.com/user/memberships/orgs/ApollosProject",
+        )
+        self.assertEqual(
+            get.call_args_list[1].kwargs["headers"]["Authorization"],
+            "Bearer temporary-token",
+        )
+
+        with self.client.session_transaction() as authenticated_session:
+            self.assertEqual(authenticated_session["github_login"], "octocat")
+            self.assertEqual(authenticated_session["github_user_id"], 123)
+            self.assertEqual(authenticated_session["github_org"], "ApollosProject")
+            self.assertNotIn("access_token", authenticated_session)
+            self.assertNotIn(github_oauth.OAUTH_STATE_SESSION_KEY, authenticated_session)
+            self.assertNotIn(github_oauth.OAUTH_VERIFIER_SESSION_KEY, authenticated_session)
+
+        protected_response = self.client.get("/projects")
+        self.assertEqual(protected_response.status_code, 200)
+
+    def test_callback_rejects_non_members_without_authenticating_them(self):
+        self._seed_oauth_session()
+        token_response = self._response(200, {"access_token": "temporary-token"})
+        identity_response = self._response(200, {"login": "octocat", "id": 123})
+        membership_response = self._response(404, {"message": "Not Found"})
+
+        with (
+            patch.object(
+                github_oauth.requests,
+                "post",
+                return_value=token_response,
+                create=True,
+            ),
+            patch.object(
+                github_oauth.requests,
+                "get",
+                side_effect=[identity_response, membership_response],
+                create=True,
+            ),
+        ):
+            response = self.client.get(
+                "/auth/github/callback?code=temporary-code&state=expected-state"
+            )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("active members of the ApollosProject", response.get_data(as_text=True))
+        with self.client.session_transaction() as rejected_session:
+            self.assertNotIn("github_login", rejected_session)
+
+    def test_callback_rejects_invalid_state_before_contacting_github(self):
+        self._seed_oauth_session()
+
+        with (
+            patch.object(github_oauth.requests, "post", create=True) as post,
+            patch.object(github_oauth.requests, "get", create=True) as get,
+        ):
+            response = self.client.get(
+                "/auth/github/callback?code=temporary-code&state=wrong-state"
+            )
+
+        self.assertEqual(response.status_code, 400)
+        post.assert_not_called()
+        get.assert_not_called()
+
+    def test_partially_configured_oauth_fails_closed(self):
+        with patch.dict(
+            app_module.app.config,
+            {"GITHUB_OAUTH_CLIENT_SECRET": "", "SECRET_KEY": None},
+            clear=False,
+        ):
+            response = self.client.get("/")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertIn("Authentication unavailable", response.get_data(as_text=True))
+
+    def test_existing_app_url_does_not_enable_oauth_by_itself(self):
+        with patch.dict(os.environ, {"APP_URL": "https://bug-board.example"}, clear=True):
+            test_app = Flask("oauth-disabled-test")
+            github_oauth.register_github_oauth(test_app)
+
+        self.assertFalse(test_app.config["GITHUB_OAUTH_ENABLED"])
+        self.assertEqual(
+            test_app.config["GITHUB_OAUTH_CALLBACK_URL"],
+            "https://bug-board.example/auth/github/callback",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a GitHub OAuth authorization-code flow with signed state and PKCE
- require an active `ApollosProject` organization membership for every dashboard and static route while keeping `/healthz` public
- use an eight-hour signed session without persisting GitHub access tokens, and fail closed when OAuth is partially configured
- document `engineering.apollos.app` as the canonical production origin

## Deployment preparation

- registered the organization-owned `Bug Board` OAuth app with exact production and review callbacks; wildcard matching remains disabled
- configured the production Heroku app with the rotated OAuth credential and a fresh session-signing key
- added `engineering.apollos.app` to Heroku, enabled ACM, and created the authoritative DNS-only CNAME in Cloudflare
- verified the custom hostname serves a valid certificate and `/healthz` returns `{"status":"ok"}`; the production access gate activates only after this branch is deployed

## Exact-head review proof

- Heroku review release `v6` deploys `1d25e25c76c0452cf04571421e1f35c19a578c8c`
- unauthenticated `/` returns `302` to `/login`; `/healthz` remains `200`; protected responses use `Cache-Control: private, no-store`
- completed the real GitHub flow with read-only organization/team access and an active `ApollosProject` membership
- the exact callback returned to the review app and rendered the dashboard as `@redreceipt`
- verified the navbar renders logout as a POST button and that submitting it clears the live review session
- all five required CI jobs pass on the same head

## Test plan

- `ruff check .`
- `ruff format --check .`
- `vulture . --config pyproject.toml`
- `mypy .`
- `python -m unittest discover -s tests -p 'test_*.py'` (174 tests)
- Gunicorn smoke checks with OAuth disabled and with fake OAuth configuration

Closes #431
Closes #432
