### PR TITLE
Link person project metrics to filtered Linear lists

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import logging
 import os
 import re
@@ -70,6 +72,23 @@ def github_merged_prs_url(username: str, days: int, window: TimeWindow | None = 
     ).github_merged_qualifier()
     query = f"is:closed is:pr author:{username} archived:false {qualifier}"
     return f"https://github.com/pulls?q={quote(query, safe='')}"
+
+
+def linear_project_list_url(projects: list[dict[str, Any]]) -> str:
+    project_ids = list(
+        dict.fromkeys(
+            project_id
+            for project in projects
+            if isinstance((project_id := project.get("id")), str) and project_id
+        )
+    )
+    project_filter = {"and": [{"id": {"in": project_ids}}]}
+    encoded_filter = (
+        base64.urlsafe_b64encode(json.dumps(project_filter, separators=(",", ":")).encode("utf-8"))
+        .decode("ascii")
+        .rstrip("=")
+    )
+    return f"https://linear.app/differential/projects/all?filter={encoded_filter}&layout=list"
 
 
 def _request_time_window() -> TimeWindow:
@@ -1523,15 +1542,23 @@ def _build_person_context(
         if normalize_display_name((project.get("lead") or {}).get("displayName"))
         == normalized_person_name
     ]
-    lead_completed_projects = completed_project_weeks(led_projects)
-    lead_incomplete_projects = sum(1 for project in led_projects if is_incomplete_project(project))
-    lead_current_projects = sum(1 for project in led_projects if not project.get("is_inactive"))
-    lead_completed_project_variances = [
-        variance_days
+    current_led_projects = [project for project in led_projects if not project.get("is_inactive")]
+    completed_led_projects = [project for project in led_projects if is_completed_project(project)]
+    incomplete_led_projects = [
+        project for project in led_projects if is_incomplete_project(project)
+    ]
+    completed_project_variances = [
+        (project, variance_days)
         for project in led_projects
         if is_completed_project(project)
         for variance_days in [get_project_schedule_variance_days(project)]
         if variance_days is not None
+    ]
+    lead_completed_projects = completed_project_weeks(completed_led_projects)
+    lead_incomplete_projects = len(incomplete_led_projects)
+    lead_current_projects = len(current_led_projects)
+    lead_completed_project_variances = [
+        variance_days for _, variance_days in completed_project_variances
     ]
     if lead_completed_project_variances:
         average_completed_project_variance = sum(lead_completed_project_variances) / len(
@@ -1668,6 +1695,14 @@ def _build_person_context(
         "lead_completed_projects_avg_early_late": format_average_project_schedule_variance(
             average_completed_project_variance
         ),
+        "project_metric_urls": {
+            "lead_current_projects": linear_project_list_url(current_led_projects),
+            "lead_completed_projects": linear_project_list_url(completed_led_projects),
+            "lead_incomplete_projects": linear_project_list_url(incomplete_led_projects),
+            "lead_completed_projects_avg_early_late": linear_project_list_url(
+                [project for project, _ in completed_project_variances]
+            ),
+        },
         "metric_stdevs": metric_stdevs,
         "regression_metrics_status": (
             "refreshing"

--- a/templates/partials/person_content.html
+++ b/templates/partials/person_content.html
@@ -145,28 +145,28 @@
 <div class="grid">
   <div>
     <article>
-      <header><a href="https://linear.app/differential/projects/all">Current Projects</a></header>
+      <header><a href="{{ project_metric_urls.lead_current_projects }}">Current Projects</a></header>
       {{ metric_heading('lead_current_projects', lead_current_projects) }}
       {{ stdev_badge('lead_current_projects') }}
     </article>
   </div>
   <div>
     <article>
-      <header><a href="https://linear.app/differential/projects/all">Completed Project Weeks</a></header>
+      <header><a href="{{ project_metric_urls.lead_completed_projects }}">Completed Project Weeks</a></header>
       {{ metric_heading('lead_completed_projects', lead_completed_projects) }}
       {{ stdev_badge('lead_completed_projects') }}
     </article>
   </div>
   <div>
     <article>
-      <header><a href="https://linear.app/differential/projects/all">Incomplete Projects</a></header>
+      <header><a href="{{ project_metric_urls.lead_incomplete_projects }}">Incomplete Projects</a></header>
       {{ metric_heading('lead_incomplete_projects', lead_incomplete_projects) }}
       {{ stdev_badge('lead_incomplete_projects') }}
     </article>
   </div>
   <div>
     <article>
-      <header><a href="https://linear.app/differential/projects/all">Avg Days Early/Late</a></header>
+      <header><a href="{{ project_metric_urls.lead_completed_projects_avg_early_late }}">Avg Days Early/Late</a></header>
       {{ metric_heading(
         'lead_completed_projects_avg_early_late',
         lead_completed_projects_avg_early_late or 'n/a'

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -1,6 +1,9 @@
+import base64
+import json
 import unittest
 from pathlib import Path
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 import app as app_module
 import person_stats
@@ -49,6 +52,14 @@ def _outlier_metrics(*, better: bool) -> dict[str, int]:
     for key in person_stats.LOWER_IS_BETTER_METRIC_KEYS:
         metrics[key] = low
     return metrics
+
+
+def _linear_project_link_details(url: str) -> tuple[str, list[str]]:
+    query = parse_qs(urlparse(url).query)
+    encoded_filter = query["filter"][0]
+    encoded_filter += "=" * (-len(encoded_filter) % 4)
+    project_filter = json.loads(base64.urlsafe_b64decode(encoded_filter).decode("utf-8"))
+    return query["layout"][0], project_filter["and"][0]["id"]["in"]
 
 
 class PersonStatsTest(unittest.TestCase):
@@ -258,6 +269,70 @@ class PersonStatsTest(unittest.TestCase):
         styles = Path(__file__).resolve().parents[1].joinpath("static/styles.css").read_text()
         self.assertIn("max-width: min(12rem, calc(100vw - 2rem));", styles)
         self.assertIn("white-space: normal;", styles)
+
+    def test_project_metric_cards_link_to_their_exact_linear_project_lists(self):
+        app_module._build_person_context.cache_clear()
+        self.addCleanup(app_module._build_person_context.cache_clear)
+        config = {
+            "people": {
+                "alice": {
+                    "team": "engineering",
+                    "linear_username": "alice",
+                }
+            }
+        }
+        projects = [
+            _project("Alice", "alice-current", status="In Progress"),
+            _project(
+                "Alice",
+                "alice-completed-with-dates",
+                status="Completed",
+                completed=True,
+                start_date="2026-07-01",
+                target_date="2026-07-30",
+            ),
+            _project(
+                "Alice",
+                "alice-completed-without-dates",
+                status="Completed",
+                completed=True,
+            ),
+            _project("Alice", "alice-incomplete", status="Incomplete"),
+            _project("Alice", "alice-canceled", status="Canceled"),
+            _project("Bob", "bob-current", status="In Progress"),
+        ]
+
+        with (
+            patch.object(app_module, "load_config", return_value=config),
+            patch.object(app_module, "get_open_issues_for_person", return_value=[]),
+            patch.object(app_module, "get_completed_issues_for_person", return_value=[]),
+            patch.object(app_module, "get_projects", return_value=projects),
+            patch.object(app_module, "get_support_slugs", return_value=set()),
+            patch.object(app_module, "get_cached_regression_summary", return_value=None),
+        ):
+            context = app_module._build_person_context("alice", 30, 1)
+
+        expected_project_ids = {
+            "lead_current_projects": ["alice-current"],
+            "lead_completed_projects": [
+                "alice-completed-with-dates",
+                "alice-completed-without-dates",
+            ],
+            "lead_incomplete_projects": ["alice-incomplete"],
+            "lead_completed_projects_avg_early_late": ["alice-completed-with-dates"],
+        }
+        for metric, project_ids in expected_project_ids.items():
+            with self.subTest(metric=metric):
+                layout, linked_project_ids = _linear_project_link_details(
+                    context["project_metric_urls"][metric]
+                )
+                self.assertEqual(layout, "list")
+                self.assertEqual(linked_project_ids, project_ids)
+
+        with app_module.app.test_request_context():
+            body = app_module.render_template("partials/person_content.html", **context)
+        self.assertEqual(body.count("linear.app/differential/projects/all?filter="), 4)
+        self.assertNotIn('href="https://linear.app/differential/projects/all"', body)
 
     def test_completed_project_weeks_treat_two_short_projects_like_one_long_project(self):
         app_module._build_person_context.cache_clear()


### PR DESCRIPTION
## Issue
Person-page project metric titles all opened unfiltered Linear `projects/all`, so Current / Completed / Incomplete / Avg Early-Late did not show only the projects behind that metric, and the destination was not a list.

## Solution
Generate Linear project-list URLs from the exact project IDs that contribute to each metric, encoded as a shareable `filter` with `layout=list`.

Closes #477

## To Test
- Open `/team/vincent`
- Click **Current Projects** and confirm Linear list view is filtered to those current projects
- Click **Completed Project Weeks** and confirm Linear list view is filtered to those completed projects

## Proof
Live `/team/vincent` now points each card at a filtered Linear list URL (`layout=list`) instead of bare `projects/all`.

![Vincent person-page project metric cards](https://github.com/ApollosProject/bug-board/releases/download/proof-482/person-project-cards.png)

Current Projects (7) opens Linear list **Specific project is any of 7 projects**, matching Vincent's current led projects. 249 projects hidden by filters.

![Linear current projects filtered list](https://github.com/ApollosProject/bug-board/releases/download/proof-482/linear-current-projects-list.png)

Completed Project Weeks opens Linear list **Specific project is any of 3 projects** for the completed set (`Move off Heroku`, `Prevent chat spam`, `Airflow Cleanup / Cost Savings`). 253 projects hidden by filters.

![Linear completed projects filtered list](https://github.com/ApollosProject/bug-board/releases/download/proof-482/linear-completed-projects-list.png)