### PR TITLE
Upgrade Heroku stack to heroku-26

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,8 @@
+{
+  "name": "bug-board",
+  "description": "Internal engineering dashboard for Linear issues, GitHub PR stats, and Airflow fleet health.",
+  "repository": "https://github.com/ApollosProject/bug-board",
+  "website": "https://engineering.apollos.app",
+  "stack": "heroku-26",
+  "success_url": "/healthz"
+}


### PR DESCRIPTION
## Issue
Production `apollos-bug-board` is on heroku-24 and Settings shows **Upgrade Stack**. heroku-26 is the current stack.

## Solution
Add `app.json` with `"stack": "heroku-26"` so Review Apps build on heroku-26. Production is already queued with `heroku stack:set heroku-26`; merging this PR is the rebuild.

Closes #480

## To Test
- Confirm this PR's Review App reports stack `heroku-26`
- After merge, confirm production `apollos-bug-board` is on heroku-26

## Proof
Before: production Settings on heroku-24 with **Upgrade Stack**.

![Production heroku-24 with Upgrade Stack](https://github.com/ApollosProject/bug-board/releases/download/proof-483/before-heroku-24.png)

After: this PR's Review App built and is running on heroku-26.

![Review app stack heroku-26](https://github.com/ApollosProject/bug-board/releases/download/proof-483/review-stack.png)

![Review app build log Building on the Heroku-26 stack](https://github.com/ApollosProject/bug-board/releases/download/proof-483/build-log.png)

Production remains on heroku-24 until this deploy, with the next build targeting heroku-26.

![Production next build heroku-26](https://github.com/ApollosProject/bug-board/releases/download/proof-483/prod-pending.png)