### PR TITLE
Link person issue metrics to filtered Linear lists

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,7 +95,27 @@ def linear_project_list_url(projects: list[dict[str, Any]]) -> str:
 
 
 def linear_issue_list_url(issues: list[dict[str, Any]]) -> str:
-    return linear_id_list_url(f"team/{get_linear_team_key()}/all", issues)
+    identifiers = list(
+        dict.fromkeys(
+            identifier
+            for issue in issues
+            if isinstance((identifier := _linear_issue_identifier(issue)), str) and identifier
+        )
+    )
+    if not identifiers:
+        return f"https://linear.app/differential/team/{get_linear_team_key()}/all?layout=list"
+    return f"https://linear.app/differential/issues/{','.join(identifiers)}"
+
+
+def _linear_issue_identifier(issue: dict[str, Any]) -> str | None:
+    identifier = issue.get("identifier")
+    if isinstance(identifier, str) and identifier:
+        return identifier
+    url = issue.get("url")
+    if not isinstance(url, str):
+        return None
+    match = re.search(r"/issue/([A-Z0-9]+-\d+)", url)
+    return match.group(1) if match else None
 
 
 def _request_time_window() -> TimeWindow:

--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 from airflow_fleet_health import AirflowFleetHealthError, evaluate_fleet_health
 from app_versions import get_app_versions_context
-from config import load_config
+from config import get_linear_team_key, load_config
 from constants import ENGINEERING_TEAM_SLUG, PRIORITY_TO_SCORE
 from fleet_health_cache import (
     get_cached_fleet_health,
@@ -74,21 +74,28 @@ def github_merged_prs_url(username: str, days: int, window: TimeWindow | None = 
     return f"https://github.com/pulls?q={quote(query, safe='')}"
 
 
-def linear_project_list_url(projects: list[dict[str, Any]]) -> str:
-    project_ids = list(
+def linear_id_list_url(path: str, items: list[dict[str, Any]]) -> str:
+    item_ids = list(
         dict.fromkeys(
-            project_id
-            for project in projects
-            if isinstance((project_id := project.get("id")), str) and project_id
+            item_id for item in items if isinstance((item_id := item.get("id")), str) and item_id
         )
     )
-    project_filter = {"and": [{"id": {"in": project_ids}}]}
     encoded_filter = (
-        base64.urlsafe_b64encode(json.dumps(project_filter, separators=(",", ":")).encode("utf-8"))
+        base64.urlsafe_b64encode(
+            json.dumps({"and": [{"id": {"in": item_ids}}]}, separators=(",", ":")).encode("utf-8")
+        )
         .decode("ascii")
         .rstrip("=")
     )
-    return f"https://linear.app/differential/projects/all?filter={encoded_filter}&layout=list"
+    return f"https://linear.app/differential/{path}?filter={encoded_filter}&layout=list"
+
+
+def linear_project_list_url(projects: list[dict[str, Any]]) -> str:
+    return linear_id_list_url("projects/all", projects)
+
+
+def linear_issue_list_url(issues: list[dict[str, Any]]) -> str:
+    return linear_id_list_url(f"team/{get_linear_team_key()}/all", issues)
 
 
 def _request_time_window() -> TimeWindow:
@@ -1494,18 +1501,18 @@ def _build_person_context(
         else:
             prs_merged = prs_reviewed = 0
 
-    priority_fix_times = []
-    priority_bugs_fixed = 0
-    for issue in completed_items:
-        is_priority_bug = issue.get("priority", 5) <= 2 and any(
-            lbl.get("name") == "Bug" for lbl in issue.get("labels", {}).get("nodes", [])
-        )
-        if not is_priority_bug:
-            continue
-        priority_bugs_fixed += 1
-        if issue.get("assignee_time_to_fix") is not None:
-            fix_time = issue["assignee_time_to_fix"]
-            priority_fix_times.append(fix_time)
+    priority_bugs = [
+        issue
+        for issue in completed_items
+        if issue.get("priority", 5) <= 2
+        and any(lbl.get("name") == "Bug" for lbl in issue.get("labels", {}).get("nodes", []))
+    ]
+    priority_bugs_fixed = len(priority_bugs)
+    priority_fix_times = [
+        issue["assignee_time_to_fix"]
+        for issue in priority_bugs
+        if issue.get("assignee_time_to_fix") is not None
+    ]
 
     if priority_fix_times:
         avg_priority_bug_fix = int(sum(priority_fix_times) / len(priority_fix_times))
@@ -1716,6 +1723,10 @@ def _build_person_context(
             "lead_completed_projects_avg_early_late": linear_project_list_url(
                 [project for project, _ in completed_project_variances]
             ),
+        },
+        "issue_metric_urls": {
+            "priority_bugs_fixed": linear_issue_list_url(priority_bugs),
+            "all_work_done": linear_issue_list_url(completed_items),
         },
         "metric_stdevs": metric_stdevs,
         "regression_metrics_status": (

--- a/linear/issues.py
+++ b/linear/issues.py
@@ -683,6 +683,7 @@ def get_completed_issues_for_person(login: str, days=30, window: TimeWindow | No
           ) {
             nodes {
               id
+              identifier
               title
               url
               completedAt

--- a/templates/partials/person_content.html
+++ b/templates/partials/person_content.html
@@ -104,7 +104,7 @@
 <div class="grid">
   <div>
     <article>
-      <header><a href="https://linear.app/differential/view/sla-issues-7e2098ebf79e">Priority Bugs Fixed</a></header>
+      <header><a href="{{ issue_metric_urls.priority_bugs_fixed }}">Priority Bugs Fixed</a></header>
       {{ metric_heading('priority_bugs_fixed', priority_bugs_fixed) }}
       {{ stdev_badge('priority_bugs_fixed') }}
     </article>
@@ -125,7 +125,7 @@
   <div>
     <article>
       <header>
-        <a href="https://linear.app/differential/profiles/{{ linear_username }}">All Work Done</a>
+        <a href="{{ issue_metric_urls.all_work_done }}">All Work Done</a>
       </header>
       {{ metric_heading('all_work_done', all_work_done) }}
       {{ stdev_badge('all_work_done') }}

--- a/tests/test_linear_issues.py
+++ b/tests/test_linear_issues.py
@@ -50,10 +50,11 @@ class GetCompletedIssuesForPersonTest(unittest.TestCase):
         self.assertIn("after", captured["variables"])
         self.assertIn("before", captured["variables"])
         self.assertNotIn("days", captured["variables"])
-        normalized_query = " ".join(captured["query"].split())
-        self.assertIn('state: { type: { in: ["completed"] } }', normalized_query)
-        self.assertIn("completedAt: { gte: $after, lt: $before }", normalized_query)
-        self.assertNotIn('state: { name: { in: ["Done"] } }', normalized_query)
+        normalized_query = "".join(captured["query"].split())
+        self.assertIn('state:{type:{in:["completed"]}}', normalized_query)
+        self.assertIn("completedAt:{gte:$after,lt:$before}", normalized_query)
+        self.assertIn("identifier", normalized_query)
+        self.assertNotIn('state:{name:{in:["Done"]}}', normalized_query)
 
 
 if __name__ == "__main__":

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -54,12 +54,13 @@ def _outlier_metrics(*, better: bool) -> dict[str, int]:
     return metrics
 
 
-def _linear_project_link_details(url: str) -> tuple[str, list[str]]:
-    query = parse_qs(urlparse(url).query)
+def _linear_id_link_details(url: str) -> tuple[str, str, list[str]]:
+    parsed = urlparse(url)
+    query = parse_qs(parsed.query)
     encoded_filter = query["filter"][0]
     encoded_filter += "=" * (-len(encoded_filter) % 4)
-    project_filter = json.loads(base64.urlsafe_b64decode(encoded_filter).decode("utf-8"))
-    return query["layout"][0], project_filter["and"][0]["id"]["in"]
+    id_filter = json.loads(base64.urlsafe_b64decode(encoded_filter).decode("utf-8"))
+    return parsed.path, query["layout"][0], id_filter["and"][0]["id"]["in"]
 
 
 class PersonStatsTest(unittest.TestCase):
@@ -323,9 +324,10 @@ class PersonStatsTest(unittest.TestCase):
         }
         for metric, project_ids in expected_project_ids.items():
             with self.subTest(metric=metric):
-                layout, linked_project_ids = _linear_project_link_details(
+                path, layout, linked_project_ids = _linear_id_link_details(
                     context["project_metric_urls"][metric]
                 )
+                self.assertEqual(path, "/differential/projects/all")
                 self.assertEqual(layout, "list")
                 self.assertEqual(linked_project_ids, project_ids)
 
@@ -333,6 +335,64 @@ class PersonStatsTest(unittest.TestCase):
             body = app_module.render_template("partials/person_content.html", **context)
         self.assertEqual(body.count("linear.app/differential/projects/all?filter="), 4)
         self.assertNotIn('href="https://linear.app/differential/projects/all"', body)
+
+    def test_issue_metric_cards_link_to_their_exact_linear_issue_lists(self):
+        app_module._build_person_context.cache_clear()
+        self.addCleanup(app_module._build_person_context.cache_clear)
+        config = {
+            "people": {
+                "alice": {
+                    "team": "engineering",
+                    "linear_username": "alice",
+                }
+            }
+        }
+        completed = [
+            {
+                **_issue(priority=1, bug=True),
+                "id": "alice-priority-bug",
+                "title": "Urgent bug",
+            },
+            {
+                **_issue(priority=4, bug=False),
+                "id": "alice-other-work",
+                "title": "Chore",
+            },
+            {
+                **_issue(priority=2, bug=False),
+                "id": "alice-high-non-bug",
+                "title": "High chore",
+            },
+        ]
+
+        with (
+            patch.object(app_module, "load_config", return_value=config),
+            patch.object(app_module, "get_open_issues_for_person", return_value=[]),
+            patch.object(app_module, "get_completed_issues_for_person", return_value=completed),
+            patch.object(app_module, "get_projects", return_value=[]),
+            patch.object(app_module, "get_support_slugs", return_value=set()),
+            patch.object(app_module, "get_cached_regression_summary", return_value=None),
+        ):
+            context = app_module._build_person_context("alice", 30, 1)
+
+        expected_issue_ids = {
+            "priority_bugs_fixed": ["alice-priority-bug"],
+            "all_work_done": ["alice-priority-bug", "alice-other-work", "alice-high-non-bug"],
+        }
+        for metric, issue_ids in expected_issue_ids.items():
+            with self.subTest(metric=metric):
+                path, layout, linked_issue_ids = _linear_id_link_details(
+                    context["issue_metric_urls"][metric]
+                )
+                self.assertEqual(path, "/differential/team/APO/all")
+                self.assertEqual(layout, "list")
+                self.assertEqual(linked_issue_ids, issue_ids)
+
+        with app_module.app.test_request_context():
+            body = app_module.render_template("partials/person_content.html", **context)
+        self.assertEqual(body.count("linear.app/differential/team/APO/all?filter="), 2)
+        self.assertNotIn("sla-issues-7e2098ebf79e", body)
+        self.assertNotIn("linear.app/differential/profiles/alice", body)
 
     def test_completed_project_weeks_treat_two_short_projects_like_one_long_project(self):
         app_module._build_person_context.cache_clear()

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -367,6 +367,7 @@ class PersonStatsTest(unittest.TestCase):
 
         with (
             patch.object(app_module, "load_config", return_value=config),
+            patch.object(app_module, "get_linear_team_key", return_value="APO"),
             patch.object(app_module, "get_open_issues_for_person", return_value=[]),
             patch.object(app_module, "get_completed_issues_for_person", return_value=completed),
             patch.object(app_module, "get_projects", return_value=[]),

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -351,23 +351,25 @@ class PersonStatsTest(unittest.TestCase):
             {
                 **_issue(priority=1, bug=True),
                 "id": "alice-priority-bug",
+                "identifier": "APO-1",
                 "title": "Urgent bug",
             },
             {
                 **_issue(priority=4, bug=False),
                 "id": "alice-other-work",
+                "identifier": "APO-2",
                 "title": "Chore",
             },
             {
                 **_issue(priority=2, bug=False),
                 "id": "alice-high-non-bug",
+                "identifier": "APO-3",
                 "title": "High chore",
             },
         ]
 
         with (
             patch.object(app_module, "load_config", return_value=config),
-            patch.object(app_module, "get_linear_team_key", return_value="APO"),
             patch.object(app_module, "get_open_issues_for_person", return_value=[]),
             patch.object(app_module, "get_completed_issues_for_person", return_value=completed),
             patch.object(app_module, "get_projects", return_value=[]),
@@ -376,22 +378,19 @@ class PersonStatsTest(unittest.TestCase):
         ):
             context = app_module._build_person_context("alice", 30, 1)
 
-        expected_issue_ids = {
-            "priority_bugs_fixed": ["alice-priority-bug"],
-            "all_work_done": ["alice-priority-bug", "alice-other-work", "alice-high-non-bug"],
-        }
-        for metric, issue_ids in expected_issue_ids.items():
-            with self.subTest(metric=metric):
-                path, layout, linked_issue_ids = _linear_id_link_details(
-                    context["issue_metric_urls"][metric]
-                )
-                self.assertEqual(path, "/differential/team/APO/all")
-                self.assertEqual(layout, "list")
-                self.assertEqual(linked_issue_ids, issue_ids)
+        self.assertEqual(
+            context["issue_metric_urls"]["priority_bugs_fixed"],
+            "https://linear.app/differential/issues/APO-1",
+        )
+        self.assertEqual(
+            context["issue_metric_urls"]["all_work_done"],
+            "https://linear.app/differential/issues/APO-1,APO-2,APO-3",
+        )
 
         with app_module.app.test_request_context():
             body = app_module.render_template("partials/person_content.html", **context)
-        self.assertEqual(body.count("linear.app/differential/team/APO/all?filter="), 2)
+        self.assertEqual(body.count("linear.app/differential/issues/APO-"), 2)
+        self.assertNotIn("linear.app/differential/team/APO/all?filter=", body)
         self.assertNotIn("sla-issues-7e2098ebf79e", body)
         self.assertNotIn("linear.app/differential/profiles/alice", body)
 


### PR DESCRIPTION
## Issue
Person-page **Priority Bugs Fixed** opened a generic SLA view, and **All Work Done** opened the Linear profile. Encoding Linear issue UUIDs into `team/APO/all?filter=` also failed: Vincent's 32 completed issues opened as **Done 27 / 1,817** because the issue list UI does not apply that UUID filter.

## Solution
Open those cards with Linear's documented identifier list, `/issues/APO-1,APO-2,…`, so the destination is the exact issues behind the count.

Closes #484

## To Test
- Open `/team/vincent`
- Click **All Work Done** and confirm Linear lists the same 32 issues as the card
- Click **Priority Bugs Fixed** and confirm it opens `APO-10678`

## Proof
Live `/team/vincent` (30d): **All Work Done** is 32 and the link contains 32 `APO-` identifiers (`https://linear.app/differential/issues/APO-11488,…,APO-10498`). **Priority Bugs Fixed** is 1 and opens `APO-10678`.

![Vincent person-page issue metric cards](https://github.com/ApollosProject/bug-board/releases/download/proof-488/vincent-metrics-32.png)

![All Work Done 32](https://github.com/ApollosProject/bug-board/releases/download/proof-488/all-work-done-32.png)