### PR TITLE
Add circuit-board Apollos branding

### DIFF
--- a/static/brand-mark.svg
+++ b/static/brand-mark.svg
@@ -37,28 +37,26 @@
       stroke-linecap="round"
       stroke-linejoin="round"
     >
-      <path d="M14.5 5.8V7.7L13 9.2V11L11.2 16.2 9.6 21.2v3.2H7.8" />
-      <path d="M17.5 5.8V7.7L19 9.2V11l1.8 5.2 1.6 5v3.2h1.8" />
-      <path d="M11.4 26h9.2" />
-      <path d="M16 27.8V26" />
+      <path d="M14.4 5.8v2l-1.5 1.5v3.2L11.4 14v4L10 19.4v4.4H7.8" />
+      <path d="M22.5 13.1H21l-1.2 1.2V16l1 1.2" />
+      <path d="M9.2 26.6h3.1l1.3-1.3h5.5l1.4 1.4h3.3" />
+      <path d="M17 27.9v-1.5l1.1-1.1" />
     </g>
     <g class="nodes">
-      <circle cx="13" cy="11" r="1.3" />
-      <circle cx="19" cy="11" r="1.3" />
-      <circle cx="7.8" cy="24.4" r="1.3" />
-      <circle cx="24.2" cy="24.4" r="1.3" />
-      <circle cx="11.4" cy="26" r="1.3" />
-      <circle cx="16" cy="26" r="1.3" />
-      <circle cx="20.6" cy="26" r="1.3" />
+      <circle cx="12.9" cy="12.5" r="1.15" />
+      <circle cx="7.8" cy="23.8" r="1.3" />
+      <circle cx="20.8" cy="17.2" r="1.15" />
+      <circle cx="9.2" cy="26.6" r="1.25" />
+      <circle cx="18.1" cy="25.3" r="1.1" />
+      <circle cx="23.8" cy="26.7" r="1.25" />
     </g>
     <g class="vias">
-      <circle cx="13" cy="11" r=".42" />
-      <circle cx="19" cy="11" r=".42" />
-      <circle cx="7.8" cy="24.4" r=".42" />
-      <circle cx="24.2" cy="24.4" r=".42" />
-      <circle cx="11.4" cy="26" r=".42" />
-      <circle cx="16" cy="26" r=".42" />
-      <circle cx="20.6" cy="26" r=".42" />
+      <circle cx="12.9" cy="12.5" r=".38" />
+      <circle cx="7.8" cy="23.8" r=".42" />
+      <circle cx="20.8" cy="17.2" r=".38" />
+      <circle cx="9.2" cy="26.6" r=".4" />
+      <circle cx="18.1" cy="25.3" r=".36" />
+      <circle cx="23.8" cy="26.7" r=".4" />
     </g>
   </g>
 </svg>

--- a/static/brand-mark.svg
+++ b/static/brand-mark.svg
@@ -1,35 +1,64 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <style>
-    .board { fill: #00676d; }
+    .board { fill: #00676d; stroke: #00676d; }
     .traces { stroke: #b8eee0; }
-    .nodes { fill: #17b582; }
+    .nodes { fill: #b8eee0; }
+    .vias { fill: #00676d; }
     @media (prefers-color-scheme: dark) {
-      .board { fill: #17b582; }
+      .board { fill: #17b582; stroke: #17b582; }
       .traces { stroke: #024c50; }
-      .nodes { fill: #d5fff2; }
+      .nodes { fill: #024c50; }
+      .vias { fill: #17b582; }
     }
   </style>
-  <path
+  <defs>
+    <path
+      id="apollos-a-shape"
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M8.848 0h4.91l8.848 24H0L8.848 0Zm-2.322 19.44h9.566L11.45 5.836h-.281L6.526 19.44Z"
+    />
+    <clipPath id="apollos-a-clip">
+      <use href="#apollos-a-shape" transform="translate(4.697 4)" />
+    </clipPath>
+  </defs>
+  <use
     class="board"
-    fill-rule="evenodd"
-    clip-rule="evenodd"
-    d="M8.848 0h4.91l8.848 24H0L8.848 0Zm-2.322 19.44h9.566L11.45 5.836h-.281L6.526 19.44Z"
+    href="#apollos-a-shape"
+    transform="translate(4.697 4)"
+    stroke-width="1.2"
+    stroke-linejoin="miter"
   />
-  <g class="traces" fill="none" stroke-width=".72" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M11.3.9v2.8H9.4v2" />
-    <path d="M12.7 1.5v2.2h1.7v3" />
-    <path d="M2.8 21.8h2.3l3-8.4h.8" />
-    <path d="M19.8 21.8h-2.3l-3-8.4h-.8" />
-    <path d="M7.3 21.8h8" />
-    <path d="M11.3 23.2v-2.8" />
-  </g>
-  <g class="nodes">
-    <circle cx="9.4" cy="5.7" r=".65" />
-    <circle cx="14.4" cy="6.7" r=".65" />
-    <circle cx="8.9" cy="13.4" r=".65" />
-    <circle cx="12.7" cy="13.4" r=".65" />
-    <circle cx="2.8" cy="21.8" r=".65" />
-    <circle cx="19.8" cy="21.8" r=".65" />
-    <circle cx="11.3" cy="20.4" r=".65" />
+  <g clip-path="url(#apollos-a-clip)">
+    <g
+      class="traces"
+      fill="none"
+      stroke-width="1.15"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M14.5 5.8V7.7L13 9.2V11L11.2 16.2 9.6 21.2v3.2H7.8" />
+      <path d="M17.5 5.8V7.7L19 9.2V11l1.8 5.2 1.6 5v3.2h1.8" />
+      <path d="M11.4 26h9.2" />
+      <path d="M16 27.8V26" />
+    </g>
+    <g class="nodes">
+      <circle cx="13" cy="11" r="1.3" />
+      <circle cx="19" cy="11" r="1.3" />
+      <circle cx="7.8" cy="24.4" r="1.3" />
+      <circle cx="24.2" cy="24.4" r="1.3" />
+      <circle cx="11.4" cy="26" r="1.3" />
+      <circle cx="16" cy="26" r="1.3" />
+      <circle cx="20.6" cy="26" r="1.3" />
+    </g>
+    <g class="vias">
+      <circle cx="13" cy="11" r=".42" />
+      <circle cx="19" cy="11" r=".42" />
+      <circle cx="7.8" cy="24.4" r=".42" />
+      <circle cx="24.2" cy="24.4" r=".42" />
+      <circle cx="11.4" cy="26" r=".42" />
+      <circle cx="16" cy="26" r=".42" />
+      <circle cx="20.6" cy="26" r=".42" />
+    </g>
   </g>
 </svg>

--- a/static/brand-mark.svg
+++ b/static/brand-mark.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <style>
+    .board { fill: #00676d; }
+    .traces { stroke: #b8eee0; }
+    .nodes { fill: #17b582; }
+    @media (prefers-color-scheme: dark) {
+      .board { fill: #17b582; }
+      .traces { stroke: #024c50; }
+      .nodes { fill: #d5fff2; }
+    }
+  </style>
+  <path
+    class="board"
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M8.848 0h4.91l8.848 24H0L8.848 0Zm-2.322 19.44h9.566L11.45 5.836h-.281L6.526 19.44Z"
+  />
+  <g class="traces" fill="none" stroke-width=".72" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M11.3.9v2.8H9.4v2" />
+    <path d="M12.7 1.5v2.2h1.7v3" />
+    <path d="M2.8 21.8h2.3l3-8.4h.8" />
+    <path d="M19.8 21.8h-2.3l-3-8.4h-.8" />
+    <path d="M7.3 21.8h8" />
+    <path d="M11.3 23.2v-2.8" />
+  </g>
+  <g class="nodes">
+    <circle cx="9.4" cy="5.7" r=".65" />
+    <circle cx="14.4" cy="6.7" r=".65" />
+    <circle cx="8.9" cy="13.4" r=".65" />
+    <circle cx="12.7" cy="13.4" r=".65" />
+    <circle cx="2.8" cy="21.8" r=".65" />
+    <circle cx="19.8" cy="21.8" r=".65" />
+    <circle cx="11.3" cy="20.4" r=".65" />
+  </g>
+</svg>

--- a/static/styles.css
+++ b/static/styles.css
@@ -119,9 +119,9 @@
 .site-brand-mark {
   display: block;
   flex: 0 0 auto;
-  height: 2.35rem;
+  height: 2.55rem;
   transition: transform 160ms ease;
-  width: 2.35rem;
+  width: 2.55rem;
 }
 
 .site-brand:is(:hover, :focus-visible) .site-brand-mark {
@@ -130,15 +130,22 @@
 
 .site-brand-board {
   fill: var(--brand-board);
+  stroke: var(--brand-board);
+  stroke-linejoin: miter;
+  stroke-width: 1.2;
 }
 
 .site-brand-traces {
   stroke: var(--brand-trace);
-  stroke-width: 0.72;
+  stroke-width: 1.15;
 }
 
 .site-brand-nodes {
-  fill: var(--brand-node);
+  fill: var(--brand-trace);
+}
+
+.site-brand-vias {
+  fill: var(--brand-board);
 }
 
 .site-brand-copy {
@@ -501,8 +508,8 @@ a.leaderboard-export:is(:hover, :focus) { color: var(--pico-primary); }
   }
 
   .site-brand-mark {
-    height: 2rem;
-    width: 2rem;
+    height: 2.15rem;
+    width: 2.15rem;
   }
 
   .site-brand-product {

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,3 +1,187 @@
+:root {
+  --apollos-brand: #00676d;
+  --apollos-action: #17b582;
+  --apollos-accent: #6ec5b8;
+  --brand-board: var(--apollos-brand);
+  --brand-circuit-line: rgba(0, 103, 109, 0.32);
+  --brand-header-border: rgba(0, 103, 109, 0.16);
+  --brand-header-surface: rgba(0, 103, 109, 0.025);
+  --brand-node: var(--apollos-action);
+  --brand-trace: #b8eee0;
+}
+
+:root:not([data-theme="dark"]),
+[data-theme="light"] {
+  --pico-primary: var(--apollos-brand);
+  --pico-primary-background: var(--apollos-brand);
+  --pico-primary-border: var(--apollos-brand);
+  --pico-primary-focus: rgba(23, 181, 130, 0.3);
+  --pico-primary-hover: #004f54;
+  --pico-primary-hover-background: #00575c;
+  --pico-primary-hover-border: #00575c;
+  --pico-primary-hover-underline: rgba(0, 79, 84, 0.5);
+  --pico-primary-underline: rgba(0, 103, 109, 0.5);
+  --pico-text-selection-color: rgba(23, 181, 130, 0.24);
+}
+
+[data-theme="dark"] {
+  --brand-board: var(--apollos-action);
+  --brand-circuit-line: rgba(110, 197, 184, 0.34);
+  --brand-header-border: rgba(110, 197, 184, 0.18);
+  --brand-header-surface: rgba(23, 181, 130, 0.025);
+  --brand-node: #d5fff2;
+  --brand-trace: #024c50;
+  --pico-primary: var(--apollos-action);
+  --pico-primary-background: #087d68;
+  --pico-primary-border: #087d68;
+  --pico-primary-focus: rgba(110, 197, 184, 0.36);
+  --pico-primary-hover: #85ddcf;
+  --pico-primary-hover-background: #0a7664;
+  --pico-primary-hover-border: #0a7664;
+  --pico-primary-hover-underline: rgba(133, 221, 207, 0.5);
+  --pico-primary-underline: rgba(23, 181, 130, 0.5);
+  --pico-text-selection-color: rgba(23, 181, 130, 0.24);
+}
+
+@media only screen and (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --brand-board: var(--apollos-action);
+    --brand-circuit-line: rgba(110, 197, 184, 0.34);
+    --brand-header-border: rgba(110, 197, 184, 0.18);
+    --brand-header-surface: rgba(23, 181, 130, 0.025);
+    --brand-node: #d5fff2;
+    --brand-trace: #024c50;
+    --pico-primary: var(--apollos-action);
+    --pico-primary-background: #087d68;
+    --pico-primary-border: #087d68;
+    --pico-primary-focus: rgba(110, 197, 184, 0.36);
+    --pico-primary-hover: #85ddcf;
+    --pico-primary-hover-background: #0a7664;
+    --pico-primary-hover-border: #0a7664;
+    --pico-primary-hover-underline: rgba(133, 221, 207, 0.5);
+    --pico-primary-underline: rgba(23, 181, 130, 0.5);
+    --pico-text-selection-color: rgba(23, 181, 130, 0.24);
+  }
+}
+
+.site-header {
+  background: linear-gradient(90deg, var(--brand-header-surface), transparent 55%);
+  border-bottom: 1px solid var(--brand-header-border);
+  position: relative;
+}
+
+.site-header::after {
+  background:
+    radial-gradient(circle at 18% 50%, var(--brand-circuit-line) 0 2px, transparent 2.5px),
+    radial-gradient(circle at 72% 50%, var(--brand-circuit-line) 0 2px, transparent 2.5px),
+    linear-gradient(
+      90deg,
+      transparent 0 18%,
+      var(--brand-circuit-line) 18% 72%,
+      transparent 72%
+    );
+  bottom: -2px;
+  content: "";
+  height: 3px;
+  inset-inline: 0;
+  opacity: 0.75;
+  pointer-events: none;
+  position: absolute;
+}
+
+.site-header nav {
+  min-height: 4.4rem;
+}
+
+.site-header nav > ul:first-child > li {
+  padding-block: 0.55rem;
+}
+
+.site-brand {
+  align-items: center;
+  color: var(--pico-color);
+  display: inline-flex;
+  gap: 0.7rem;
+  text-decoration: none;
+}
+
+.site-brand:is(:hover, :focus) {
+  color: var(--pico-color);
+  text-decoration: none;
+}
+
+.site-brand:focus-visible {
+  border-radius: 0.3rem;
+  box-shadow: 0 0 0 0.15rem var(--pico-primary-focus);
+  outline: none;
+}
+
+.site-brand-mark {
+  display: block;
+  flex: 0 0 auto;
+  height: 2.35rem;
+  transition: transform 160ms ease;
+  width: 2.35rem;
+}
+
+.site-brand:is(:hover, :focus-visible) .site-brand-mark {
+  transform: translateY(-0.08rem);
+}
+
+.site-brand-board {
+  fill: var(--brand-board);
+}
+
+.site-brand-traces {
+  stroke: var(--brand-trace);
+  stroke-width: 0.72;
+}
+
+.site-brand-nodes {
+  fill: var(--brand-node);
+}
+
+.site-brand-copy {
+  display: grid;
+}
+
+.site-brand-name {
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.site-brand-product {
+  align-items: center;
+  color: var(--pico-muted-color);
+  display: flex;
+  font-family: var(--pico-font-family-monospace);
+  font-size: 0.52rem;
+  font-weight: 700;
+  gap: 0.35rem;
+  letter-spacing: 0.075em;
+  line-height: 1;
+  margin-top: 0.3rem;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.site-brand-node {
+  background: var(--brand-node);
+  border-radius: 50%;
+  display: inline-block;
+  height: 0.26rem;
+  width: 0.26rem;
+}
+
+.site-footer {
+  border-top: 1px solid var(--brand-header-border);
+  margin-top: 3rem;
+  padding-top: 2rem;
+}
+
 footer ul,
 footer ol {
   list-style: none;
@@ -306,4 +490,28 @@ a.leaderboard-export:is(:hover, :focus) { color: var(--pico-primary); }
   overflow: hidden;
   text-align: left;
   white-space: normal;
+}
+
+@media (max-width: 32rem) {
+  .logout-form button {
+    max-width: 32vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .site-brand-mark {
+    height: 2rem;
+    width: 2rem;
+  }
+
+  .site-brand-product {
+    display: none;
+  }
+}
+
+@media (max-width: 26rem) {
+  .site-brand-copy {
+    display: none;
+  }
 }

--- a/templates/auth.html
+++ b/templates/auth.html
@@ -4,43 +4,178 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
-    <title>{{ title }} · Bug Board</title>
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f8faf9" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0d1718" />
+    <title>{{ title }} · Apollos Engineering</title>
     <style>
       :root {
-        font-family: system-ui, sans-serif;
         color-scheme: light dark;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        --auth-action: #00676d;
+        --auth-bg: #f8faf9;
+        --auth-border: rgba(0, 103, 109, 0.18);
+        --auth-card: #ffffff;
+        --auth-muted: #536563;
+        --auth-text: #17302f;
+        --brand-board: #00676d;
+        --brand-node: #17b582;
+        --brand-trace: #b8eee0;
+      }
+      * {
+        box-sizing: border-box;
       }
       body {
         display: grid;
         min-height: 100vh;
         margin: 0;
+        padding: 2rem 0;
         place-items: center;
-        background: Canvas;
-        color: CanvasText;
+        background-color: var(--auth-bg);
+        background-image:
+          radial-gradient(circle at 1px 1px, var(--auth-border) 1px, transparent 0),
+          linear-gradient(135deg, rgba(110, 197, 184, 0.08), transparent 45%);
+        background-size: 28px 28px, 100% 100%;
+        color: var(--auth-text);
       }
       main {
-        width: min(32rem, calc(100% - 3rem));
+        width: min(34rem, calc(100% - 2rem));
         text-align: center;
       }
-      a {
-        display: inline-block;
-        margin-top: 1rem;
-        padding: 0.7rem 1rem;
-        border-radius: 0.4rem;
-        background: #24292f;
-        color: #fff;
-        font-weight: 600;
+      .site-brand {
+        align-items: center;
+        color: var(--auth-text);
+        display: inline-flex;
+        gap: 0.75rem;
+        margin-bottom: 1.5rem;
+        text-align: left;
         text-decoration: none;
+      }
+      .site-brand-mark {
+        display: block;
+        height: 2.65rem;
+        width: 2.65rem;
+      }
+      .site-brand-board { fill: var(--brand-board); }
+      .site-brand-traces {
+        stroke: var(--brand-trace);
+        stroke-width: 0.72;
+      }
+      .site-brand-nodes { fill: var(--brand-node); }
+      .site-brand-copy { display: grid; }
+      .site-brand-name {
+        font-size: 1rem;
+        font-weight: 800;
+        letter-spacing: 0.14em;
+        line-height: 1;
+        text-transform: uppercase;
+      }
+      .site-brand-product {
+        align-items: center;
+        color: var(--auth-muted);
+        display: flex;
+        font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+        font-size: 0.62rem;
+        font-weight: 700;
+        gap: 0.4rem;
+        letter-spacing: 0.08em;
+        margin-top: 0.3rem;
+        text-transform: uppercase;
+      }
+      .site-brand-node {
+        background: var(--brand-node);
+        border-radius: 50%;
+        display: inline-block;
+        height: 0.3rem;
+        width: 0.3rem;
+      }
+      .auth-card {
+        background: var(--auth-card);
+        border: 1px solid var(--auth-border);
+        border-radius: 0.8rem;
+        box-shadow: 0 1.5rem 4rem rgba(0, 52, 55, 0.08);
+        overflow: hidden;
+        padding: clamp(2rem, 7vw, 3.5rem);
+        position: relative;
+      }
+      .auth-card::before {
+        background:
+          radial-gradient(circle at 18% 50%, var(--brand-node) 0 3px, transparent 3.5px),
+          radial-gradient(circle at 82% 50%, var(--brand-node) 0 3px, transparent 3.5px),
+          linear-gradient(90deg, transparent 0 18%, var(--brand-node) 18% 82%, transparent 82%);
+        content: "";
+        height: 6px;
+        inset: 0 0 auto;
+        opacity: 0.7;
+        position: absolute;
+      }
+      h1 {
+        font-size: clamp(1.8rem, 7vw, 2.4rem);
+        letter-spacing: -0.035em;
+        margin: 0;
+      }
+      p {
+        color: var(--auth-muted);
+        line-height: 1.6;
+        margin: 1rem auto 0;
+        max-width: 27rem;
+      }
+      .auth-action {
+        background: var(--auth-action);
+        border: 1px solid var(--auth-action);
+        border-radius: 0.45rem;
+        color: #ffffff;
+        display: inline-block;
+        font-weight: 700;
+        margin-top: 1.5rem;
+        padding: 0.75rem 1rem;
+        text-decoration: none;
+      }
+      .auth-action:is(:hover, :focus-visible) {
+        background: #004f54;
+        border-color: #004f54;
+      }
+      .auth-action:focus-visible,
+      .site-brand:focus-visible {
+        outline: 3px solid rgba(23, 181, 130, 0.35);
+        outline-offset: 3px;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --auth-action: #087d68;
+          --auth-bg: #0d1718;
+          --auth-border: rgba(110, 197, 184, 0.2);
+          --auth-card: #142021;
+          --auth-muted: #9cb4b0;
+          --auth-text: #f4f7f8;
+          --brand-board: #17b582;
+          --brand-node: #d5fff2;
+          --brand-trace: #024c50;
+        }
+        body {
+          background-image:
+            radial-gradient(circle at 1px 1px, rgba(110, 197, 184, 0.14) 1px, transparent 0),
+            linear-gradient(135deg, rgba(23, 181, 130, 0.08), transparent 45%);
+        }
+        .auth-card {
+          box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.24);
+        }
+        .auth-action:is(:hover, :focus-visible) {
+          background: #0a7664;
+          border-color: #0a7664;
+        }
       }
     </style>
   </head>
   <body>
     <main>
-      <h1>{{ title }}</h1>
-      <p>{{ message }}</p>
-      {% if allow_retry %}
-        <a href="{{ url_for('github_login') }}">Sign in with GitHub</a>
-      {% endif %}
+      {% include "partials/brand_lockup.html" %}
+      <section class="auth-card">
+        <h1>{{ title }}</h1>
+        <p>{{ message }}</p>
+        {% if allow_retry %}
+          <a class="auth-action" href="{{ url_for('github_login') }}">Sign in with GitHub</a>
+        {% endif %}
+      </section>
     </main>
   </body>
 </html>

--- a/templates/auth.html
+++ b/templates/auth.html
@@ -52,15 +52,21 @@
       }
       .site-brand-mark {
         display: block;
-        height: 2.65rem;
-        width: 2.65rem;
+        height: 2.9rem;
+        width: 2.9rem;
       }
-      .site-brand-board { fill: var(--brand-board); }
+      .site-brand-board {
+        fill: var(--brand-board);
+        stroke: var(--brand-board);
+        stroke-linejoin: miter;
+        stroke-width: 1.2;
+      }
       .site-brand-traces {
         stroke: var(--brand-trace);
-        stroke-width: 0.72;
+        stroke-width: 1.15;
       }
-      .site-brand-nodes { fill: var(--brand-node); }
+      .site-brand-nodes { fill: var(--brand-trace); }
+      .site-brand-vias { fill: var(--brand-board); }
       .site-brand-copy { display: grid; }
       .site-brand-name {
         font-size: 1rem;

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,13 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#13171f" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="{{ url_for('static', filename='brand-mark.svg') }}"
+    />
     <link
       rel="stylesheet"
       href="{{ url_for('static', filename='pico.min.css') }}"
@@ -16,10 +23,14 @@
     {% block extra_head %}{% endblock %}
   </head>
   <body>
-    <header class="container">
-      <nav>
+    <header class="site-header">
+      <nav class="container">
         <ul>
-          <li><a href="{{ url_for('index') }}">Bug Board</a></li>
+          <li>
+            {% with brand_href=url_for('index') %}
+              {% include "partials/brand_lockup.html" %}
+            {% endwith %}
+          </li>
         </ul>
         <ul>
           {% if session.get('github_login') %}
@@ -52,7 +63,7 @@
       </nav>
     </header>
     <main class="container">{% block content %}{% endblock %}</main>
-    <footer class="container">
+    <footer class="container site-footer">
       <div class="grid">
         <div>
           <h6>SRE</h6>

--- a/templates/partials/brand_lockup.html
+++ b/templates/partials/brand_lockup.html
@@ -1,0 +1,42 @@
+<a
+  class="site-brand"
+  href="{{ brand_href | default('/') }}"
+  aria-label="Apollos Engineering Bug Board home"
+>
+  <svg
+    class="site-brand-mark"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path
+      class="site-brand-board"
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M8.848 0h4.91l8.848 24H0L8.848 0Zm-2.322 19.44h9.566L11.45 5.836h-.281L6.526 19.44Z"
+    />
+    <g class="site-brand-traces" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M11.3.9v2.8H9.4v2" />
+      <path d="M12.7 1.5v2.2h1.7v3" />
+      <path d="M2.8 21.8h2.3l3-8.4h.8" />
+      <path d="M19.8 21.8h-2.3l-3-8.4h-.8" />
+      <path d="M7.3 21.8h8" />
+      <path d="M11.3 23.2v-2.8" />
+    </g>
+    <g class="site-brand-nodes">
+      <circle cx="9.4" cy="5.7" r=".65" />
+      <circle cx="14.4" cy="6.7" r=".65" />
+      <circle cx="8.9" cy="13.4" r=".65" />
+      <circle cx="12.7" cy="13.4" r=".65" />
+      <circle cx="2.8" cy="21.8" r=".65" />
+      <circle cx="19.8" cy="21.8" r=".65" />
+      <circle cx="11.3" cy="20.4" r=".65" />
+    </g>
+  </svg>
+  <span class="site-brand-copy">
+    <strong class="site-brand-name">Apollos</strong>
+    <span class="site-brand-product">
+      Engineering <span class="site-brand-node" aria-hidden="true"></span> Bug Board
+    </span>
+  </span>
+</a>

--- a/templates/partials/brand_lockup.html
+++ b/templates/partials/brand_lockup.html
@@ -32,28 +32,26 @@
         stroke-linecap="round"
         stroke-linejoin="round"
       >
-        <path d="M14.5 5.8V7.7L13 9.2V11L11.2 16.2 9.6 21.2v3.2H7.8" />
-        <path d="M17.5 5.8V7.7L19 9.2V11l1.8 5.2 1.6 5v3.2h1.8" />
-        <path d="M11.4 26h9.2" />
-        <path d="M16 27.8V26" />
+        <path d="M14.4 5.8v2l-1.5 1.5v3.2L11.4 14v4L10 19.4v4.4H7.8" />
+        <path d="M22.5 13.1H21l-1.2 1.2V16l1 1.2" />
+        <path d="M9.2 26.6h3.1l1.3-1.3h5.5l1.4 1.4h3.3" />
+        <path d="M17 27.9v-1.5l1.1-1.1" />
       </g>
       <g class="site-brand-nodes">
-        <circle cx="13" cy="11" r="1.3" />
-        <circle cx="19" cy="11" r="1.3" />
-        <circle cx="7.8" cy="24.4" r="1.3" />
-        <circle cx="24.2" cy="24.4" r="1.3" />
-        <circle cx="11.4" cy="26" r="1.3" />
-        <circle cx="16" cy="26" r="1.3" />
-        <circle cx="20.6" cy="26" r="1.3" />
+        <circle cx="12.9" cy="12.5" r="1.15" />
+        <circle cx="7.8" cy="23.8" r="1.3" />
+        <circle cx="20.8" cy="17.2" r="1.15" />
+        <circle cx="9.2" cy="26.6" r="1.25" />
+        <circle cx="18.1" cy="25.3" r="1.1" />
+        <circle cx="23.8" cy="26.7" r="1.25" />
       </g>
       <g class="site-brand-vias">
-        <circle cx="13" cy="11" r=".42" />
-        <circle cx="19" cy="11" r=".42" />
-        <circle cx="7.8" cy="24.4" r=".42" />
-        <circle cx="24.2" cy="24.4" r=".42" />
-        <circle cx="11.4" cy="26" r=".42" />
-        <circle cx="16" cy="26" r=".42" />
-        <circle cx="20.6" cy="26" r=".42" />
+        <circle cx="12.9" cy="12.5" r=".38" />
+        <circle cx="7.8" cy="23.8" r=".42" />
+        <circle cx="20.8" cy="17.2" r=".38" />
+        <circle cx="9.2" cy="26.6" r=".4" />
+        <circle cx="18.1" cy="25.3" r=".36" />
+        <circle cx="23.8" cy="26.7" r=".4" />
       </g>
     </g>
   </svg>

--- a/templates/partials/brand_lockup.html
+++ b/templates/partials/brand_lockup.html
@@ -5,32 +5,56 @@
 >
   <svg
     class="site-brand-mark"
-    viewBox="0 0 24 24"
+    viewBox="0 0 32 32"
     aria-hidden="true"
     focusable="false"
   >
-    <path
+    <defs>
+      <path
+        id="apollos-a-shape"
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M8.848 0h4.91l8.848 24H0L8.848 0Zm-2.322 19.44h9.566L11.45 5.836h-.281L6.526 19.44Z"
+      />
+      <clipPath id="apollos-a-clip">
+        <use href="#apollos-a-shape" transform="translate(4.697 4)" />
+      </clipPath>
+    </defs>
+    <use
       class="site-brand-board"
-      fill-rule="evenodd"
-      clip-rule="evenodd"
-      d="M8.848 0h4.91l8.848 24H0L8.848 0Zm-2.322 19.44h9.566L11.45 5.836h-.281L6.526 19.44Z"
+      href="#apollos-a-shape"
+      transform="translate(4.697 4)"
     />
-    <g class="site-brand-traces" fill="none" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M11.3.9v2.8H9.4v2" />
-      <path d="M12.7 1.5v2.2h1.7v3" />
-      <path d="M2.8 21.8h2.3l3-8.4h.8" />
-      <path d="M19.8 21.8h-2.3l-3-8.4h-.8" />
-      <path d="M7.3 21.8h8" />
-      <path d="M11.3 23.2v-2.8" />
-    </g>
-    <g class="site-brand-nodes">
-      <circle cx="9.4" cy="5.7" r=".65" />
-      <circle cx="14.4" cy="6.7" r=".65" />
-      <circle cx="8.9" cy="13.4" r=".65" />
-      <circle cx="12.7" cy="13.4" r=".65" />
-      <circle cx="2.8" cy="21.8" r=".65" />
-      <circle cx="19.8" cy="21.8" r=".65" />
-      <circle cx="11.3" cy="20.4" r=".65" />
+    <g clip-path="url(#apollos-a-clip)">
+      <g
+        class="site-brand-traces"
+        fill="none"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M14.5 5.8V7.7L13 9.2V11L11.2 16.2 9.6 21.2v3.2H7.8" />
+        <path d="M17.5 5.8V7.7L19 9.2V11l1.8 5.2 1.6 5v3.2h1.8" />
+        <path d="M11.4 26h9.2" />
+        <path d="M16 27.8V26" />
+      </g>
+      <g class="site-brand-nodes">
+        <circle cx="13" cy="11" r="1.3" />
+        <circle cx="19" cy="11" r="1.3" />
+        <circle cx="7.8" cy="24.4" r="1.3" />
+        <circle cx="24.2" cy="24.4" r="1.3" />
+        <circle cx="11.4" cy="26" r="1.3" />
+        <circle cx="16" cy="26" r="1.3" />
+        <circle cx="20.6" cy="26" r="1.3" />
+      </g>
+      <g class="site-brand-vias">
+        <circle cx="13" cy="11" r=".42" />
+        <circle cx="19" cy="11" r=".42" />
+        <circle cx="7.8" cy="24.4" r=".42" />
+        <circle cx="24.2" cy="24.4" r=".42" />
+        <circle cx="11.4" cy="26" r=".42" />
+        <circle cx="16" cy="26" r=".42" />
+        <circle cx="20.6" cy="26" r=".42" />
+      </g>
     </g>
   </svg>
   <span class="site-brand-copy">

--- a/tests/test_github_oauth.py
+++ b/tests/test_github_oauth.py
@@ -237,6 +237,11 @@ class GitHubOAuthTest(unittest.TestCase):
         post_response = self.client.post("/logout")
         self.assertEqual(post_response.status_code, 200)
         self.assertIn("Signed out", post_response.get_data(as_text=True))
+        self.assertIn(
+            'aria-label="Apollos Engineering Bug Board home"',
+            post_response.get_data(as_text=True),
+        )
+        self.assertIn('class="auth-card"', post_response.get_data(as_text=True))
         with self.client.session_transaction() as signed_out_session:
             self.assertNotIn("github_login", signed_out_session)
             self.assertNotIn("github_user_id", signed_out_session)

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -49,8 +49,11 @@ class NavigationTest(unittest.TestCase):
         self.assertIn("brand-mark.svg", head)
         self.assertIn('aria-label="Apollos Engineering Bug Board home"', header)
         self.assertIn('class="site-brand-mark"', header)
+        self.assertIn('viewBox="0 0 32 32"', header)
+        self.assertIn('clip-path="url(#apollos-a-clip)"', header)
         self.assertIn('class="site-brand-traces"', header)
         self.assertIn('class="site-brand-nodes"', header)
+        self.assertIn('class="site-brand-vias"', header)
         self.assertIn('class="site-brand-name">Apollos</strong>', header)
         self.assertIn("Engineering", header)
         self.assertIn("Bug Board", header)
@@ -60,6 +63,12 @@ class NavigationTest(unittest.TestCase):
         self.assertIn("--apollos-brand: #00676d;", styles)
         self.assertIn("--apollos-action: #17b582;", styles)
         self.assertIn("--apollos-accent: #6ec5b8;", styles)
+
+        with open("static/brand-mark.svg") as favicon_file:
+            favicon = favicon_file.read()
+        self.assertIn('viewBox="0 0 32 32"', favicon)
+        self.assertIn('clip-path="url(#apollos-a-clip)"', favicon)
+        self.assertIn('class="vias"', favicon)
 
     def test_header_menu_overrides_pico_left_aligned_dropdown(self):
         with open("static/styles.css") as styles_file:

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -37,6 +37,30 @@ class NavigationTest(unittest.TestCase):
         self.assertNotIn('href="/projects"', footer)
         self.assertNotIn('href="/dags"', footer)
 
+    def test_apollos_engineering_brand_renders_in_the_site_chrome(self):
+        response = self.client.get("/projects")
+
+        body = response.get_data(as_text=True)
+        self.assertEqual(response.status_code, 200)
+
+        head = body.split("</head>", 1)[0]
+        header = body.split("</header>", 1)[0]
+        self.assertIn('rel="icon"', head)
+        self.assertIn("brand-mark.svg", head)
+        self.assertIn('aria-label="Apollos Engineering Bug Board home"', header)
+        self.assertIn('class="site-brand-mark"', header)
+        self.assertIn('class="site-brand-traces"', header)
+        self.assertIn('class="site-brand-nodes"', header)
+        self.assertIn('class="site-brand-name">Apollos</strong>', header)
+        self.assertIn("Engineering", header)
+        self.assertIn("Bug Board", header)
+
+        with open("static/styles.css") as styles_file:
+            styles = styles_file.read()
+        self.assertIn("--apollos-brand: #00676d;", styles)
+        self.assertIn("--apollos-action: #17b582;", styles)
+        self.assertIn("--apollos-accent: #6ec5b8;", styles)
+
     def test_header_menu_overrides_pico_left_aligned_dropdown(self):
         with open("static/styles.css") as styles_file:
             styles = styles_file.read()


### PR DESCRIPTION
## Summary

- introduce a circuit-board adaptation of the existing Apollos A mark and use it as the site lockup and favicon
- apply the Figma-linked Apollos brand palette to the existing Pico theme in accessible light and dark states
- carry the brand through the responsive header, footer, and self-contained GitHub OAuth status pages

## Design direction

The mark preserves the existing Apollos A silhouette while adding PCB traces and solder pads. The UI remains intentionally restrained so operational dashboards and status colors keep their existing hierarchy.

## Verification

- ruff check .
- ruff format --check .
- mypy .
- python -m unittest discover -s tests -p test_*.py (178 tests)
- xmllint --noout static/brand-mark.svg
- Gunicorn smoke test: /projects, /healthz, and /static/brand-mark.svg returned 200
- light and dark foreground/button combinations checked at WCAG AA contrast