### PR TITLE
Prevent outliers from skewing relative metrics

### DIFF
--- a/person_stats.py
+++ b/person_stats.py
@@ -45,6 +45,7 @@ STDEV_DIRECTION_HINTS = {
 }
 
 STDEV_COLOR_THRESHOLD = 1.5
+STDEV_TRIM_PROPORTION = 0.2
 
 MetricValue = float | int | None
 
@@ -89,13 +90,26 @@ def performance_outliers(
     return outliers
 
 
+def _stdev_baseline(values: list[float]) -> tuple[list[float], bool]:
+    """Return a central cohort whose spread is not dominated by either tail."""
+    trim_count = int(len(values) * STDEV_TRIM_PROPORTION)
+    if trim_count == 0 or len(values) - (trim_count * 2) < 2:
+        return values, False
+
+    trimmed = sorted(values)[trim_count:-trim_count]
+    if statistics.pstdev(trimmed) == 0:
+        return values, False
+    return trimmed, True
+
+
 def z_score(value: float, values: list[float]) -> float | None:
     if len(values) < 2:
         return None
-    stdev = statistics.pstdev(values)
+    baseline, _trimmed = _stdev_baseline(values)
+    stdev = statistics.pstdev(baseline)
     if stdev == 0:
         return None
-    return (value - statistics.fmean(values)) / stdev
+    return (value - statistics.fmean(baseline)) / stdev
 
 
 def format_stdev_label(z: float) -> str:
@@ -114,7 +128,11 @@ def stdev_tone(z: float, *, threshold: float = STDEV_COLOR_THRESHOLD) -> str | N
 
 
 def format_stdev_tooltip(values: list[float], *, hint: str | None = None) -> str:
-    tooltip = f"eng avg {statistics.fmean(values):.1f} · σ {statistics.pstdev(values):.1f}"
+    baseline, trimmed = _stdev_baseline(values)
+    qualifier = " trimmed" if trimmed else ""
+    tooltip = (
+        f"eng{qualifier} avg {statistics.fmean(baseline):.1f} · σ {statistics.pstdev(baseline):.1f}"
+    )
     return f"{tooltip} · {hint}" if hint else tooltip
 
 

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -69,6 +69,27 @@ class PersonStatsTest(unittest.TestCase):
         self.assertEqual(person_stats.z_score(10, [10, 2]), 1.0)
         self.assertEqual(person_stats.format_stdev_tooltip([10, 2]), "eng avg 6.0 · σ 4.0")
 
+    def test_z_scores_trim_extremes_without_clipping_exceptional_people(self):
+        prs_merged = [378, 77, 9, 81, 0, 99, 60, 26]
+        team_metrics = [{"prs_merged": value} for value in prs_merged]
+
+        low = person_stats.metric_stdevs_for_person({"prs_merged": 9}, team_metrics)["prs_merged"]
+        high = person_stats.metric_stdevs_for_person({"prs_merged": 378}, team_metrics)[
+            "prs_merged"
+        ]
+
+        self.assertEqual(low["label"], "−1.6σ")
+        self.assertEqual(low["tone"], "low")
+        self.assertEqual(low["tooltip"], "eng trimmed avg 58.7 · σ 31.6")
+        self.assertEqual(high["label"], "+10.1σ")
+        self.assertEqual(high["tone"], "high")
+
+    def test_z_scores_fall_back_when_trimming_removes_all_variance(self):
+        values = [20, 10, 10, 10, 0]
+
+        self.assertAlmostEqual(person_stats.z_score(20, values) or 0, 1.58, places=2)
+        self.assertEqual(person_stats.format_stdev_tooltip(values), "eng avg 10.0 · σ 6.3")
+
     def test_every_card_metric_has_an_explicit_stdev_direction(self):
         classified = person_stats.LOWER_IS_BETTER_METRIC_KEYS | frozenset(
             {


### PR DESCRIPTION
## Issue

A massive high performer inflates both the engineering average and standard deviation, making other engineers look deceptively close to average. In the current 30-day PR data, 9 merged PRs rendered at `−0.7σ` because a 378-PR outlier dominated the baseline.

## Solution

Build the comparison baseline from the central cohort by trimming 20% from each tail when at least five comparable values are available, while scoring every person with their real, uncapped value. Cohorts below five values, or trimmed cohorts with zero variance, fall back to the full cohort. Card tooltips identify when the baseline is trimmed.

The shared z-score helper keeps person cards, leaderboard CSV standard-deviation fields, and weekly performance-outlier reporting aligned.

Closes #449

## To Test

- Open `/team/vitor?days=30` and confirm PRs Merged is low/red
- Open `/team/michael?days=30` and confirm the exceptional PR count remains strongly high/green
- Confirm cohorts below five values, or flat trimmed cohorts, use the full engineering baseline

## Proof

### Before — `origin/main` (`beee589`)

Vitor at 9 merged PRs is neutral at `−0.7σ`; the 378-PR outlier stretches the engineering average to 91.4 and σ to 113.4.

![Vitor before: neutral at minus 0.7 sigma](https://github.com/ApollosProject/bug-board/releases/download/proof-490/vitor-before.png)

### After — exact PR head (`514d31d`)

The same live person page renders Vitor low/red at `−1.6σ` against the trimmed baseline.

![Vitor after: low at minus 1.6 sigma](https://github.com/ApollosProject/bug-board/releases/download/proof-490/vitor-after.png)

The exceptional high performer remains uncapped: 378 merged PRs renders high/green at `+10.0σ`.

![High performer remains high at plus 10.0 sigma](https://github.com/ApollosProject/bug-board/releases/download/proof-490/high-performer-after.png)

## Validation

- `python -m unittest discover -s tests -p "test_*.py"` — 180 passed
- `ruff check .` — passed
- `ruff format --check .` — passed
- `mypy .` — passed
- `vulture . --config pyproject.toml` — passed