### PR TITLE
Keep metric cards from shrinking off the page

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -356,6 +356,12 @@ details.dropdown.site-menu > summary + ul {
   padding: 0 0.75rem;
 }
 
+@media (min-width: 768px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @keyframes busy-spinner {
   to {
     transform: rotate(360deg);

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -102,6 +102,15 @@ class NavigationTest(unittest.TestCase):
             styles,
         )
 
+    def test_metric_grids_wrap_to_two_columns_instead_of_shrinking(self):
+        with open("static/styles.css") as styles_file:
+            styles = styles_file.read()
+
+        self.assertIn("@media (min-width: 768px)", styles)
+        grid_override = styles.split("@media (min-width: 768px)", 1)[1]
+        grid_rule = grid_override.split(".grid {", 1)[1].split("}", 1)[0]
+        self.assertIn("grid-template-columns: repeat(2, minmax(0, 1fr));", grid_rule)
+
     def test_busy_indicators_use_a_css_rotation_animation(self):
         with open("static/styles.css") as styles_file:
             styles = styles_file.read()


### PR DESCRIPTION
## Issue
At laptop width (~1280px), person-page project metric cards were squeezed into one four-column row. Pico's `.grid` uses `repeat(auto-fit, minmax(0%, 1fr))`, which never wraps, so titles like **Completed Project Weeks** wrapped and looked cut off.

## Solution
Override `.grid` from 768px up to two columns so those four cards wrap 2×2 instead of shrinking.

Closes #492

## To Test
- Open `/team/vitor?days=30` around 1280px wide
- Confirm **Current Projects**, **Completed Project Weeks**, **Incomplete Projects**, and **Avg Days Early/Late** sit in two columns with full titles

## Proof
Live `/team/vitor` at 1279px. Before: four 223px columns, **Completed Project Weeks** wraps to two lines. After: two 466px columns, all four titles stay on one line.

**Before**
![Four cramped project metric cards](https://github.com/ApollosProject/bug-board/releases/download/proof-493/before-1279-projects.png)

**After**
![Project metric cards wrapping two by two](https://github.com/ApollosProject/bug-board/releases/download/proof-493/after-1279-projects.png)