### PR TITLE
Skip relative σ metrics for people outside engineering

### DIFF
--- a/app.py
+++ b/app.py
@@ -1465,9 +1465,14 @@ def _build_person_context(
         for key, info in config.get("people", {}).items()
         if info.get("team") == ENGINEERING_TEAM_SLUG
     }
-    other_engineers = {key: info for key, info in engineering_people.items() if key != slug}
+    include_relative_metrics = slug in engineering_people
+    other_engineers = (
+        {key: info for key, info in engineering_people.items() if key != slug}
+        if include_relative_metrics
+        else {}
+    )
     extra_workers = 0
-    if len(engineering_people) >= 2:
+    if other_engineers:
         extra_workers = len(other_engineers) + sum(
             1
             for info in other_engineers.values()
@@ -1489,7 +1494,7 @@ def _build_person_context(
                 days,
                 window,
             )
-        if len(engineering_people) >= 2:
+        if other_engineers:
             for other_slug, info in other_engineers.items():
                 other_completed_futures[other_slug] = executor.submit(
                     get_completed_issues_for_person,
@@ -1617,7 +1622,7 @@ def _build_person_context(
         "lead_incomplete_projects": lead_incomplete_projects,
         "lead_completed_projects_avg_early_late": average_completed_project_variance,
     }
-    team_metrics = [current_metrics] if slug in engineering_people else []
+    team_metrics = [current_metrics] if include_relative_metrics else []
     for other_slug, info in other_engineers.items():
         completed_future_for_other = other_completed_futures.get(other_slug)
         if completed_future_for_other is None:
@@ -1665,7 +1670,9 @@ def _build_person_context(
                 ),
             }
         )
-    metric_stdevs = metric_stdevs_for_person(current_metrics, team_metrics)
+    metric_stdevs = (
+        metric_stdevs_for_person(current_metrics, team_metrics) if include_relative_metrics else {}
+    )
 
     project_names = {proj.get("name") for proj in cycle_projects if proj.get("name")}
 

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -292,6 +292,62 @@ class PersonStatsTest(unittest.TestCase):
         self.assertIn("max-width: min(12rem, calc(100vw - 2rem));", styles)
         self.assertIn("white-space: normal;", styles)
 
+    def test_non_engineers_skip_relative_metrics_and_peer_fetches(self):
+        app_module._build_person_context.cache_clear()
+        self.addCleanup(app_module._build_person_context.cache_clear)
+        config = {
+            "people": {
+                "andy": {
+                    "team": "unassigned",
+                    "linear_username": "andy",
+                    "github_username": "andy-gh",
+                },
+                "alice": {
+                    "team": "engineering",
+                    "linear_username": "alice",
+                    "github_username": "alice-gh",
+                },
+                "bob": {
+                    "team": "engineering",
+                    "linear_username": "bob",
+                    "github_username": "bob-gh",
+                },
+            }
+        }
+        completed_logins: list[str] = []
+        github_usernames: list[str] = []
+
+        def fake_completed(login, days=30, window=None):
+            completed_logins.append(login)
+            return [_issue(priority=2, bug=True) for _ in range(10)]
+
+        def fake_github(username, days=30, window=None):
+            github_usernames.append(username)
+            return (10, 10)
+
+        with (
+            patch.object(app_module, "load_config", return_value=config),
+            patch.object(app_module, "get_open_issues_for_person", return_value=[]),
+            patch.object(app_module, "get_completed_issues_for_person", side_effect=fake_completed),
+            patch.object(app_module, "get_projects", return_value=[]),
+            patch.object(app_module, "get_merged_pr_counts_for_user", side_effect=fake_github),
+            patch.object(app_module, "get_support_slugs", return_value=set()),
+        ):
+            context = app_module._build_person_context("andy", 30, 1)
+
+        self.assertEqual(context["metric_stdevs"], {})
+        self.assertEqual(context["prs_merged"], 10)
+        self.assertEqual(context["priority_bugs_fixed"], 10)
+        self.assertEqual(completed_logins, ["andy"])
+        self.assertEqual(github_usernames, ["andy-gh"])
+        with app_module.app.test_request_context():
+            body = app_module.render_template("partials/person_content.html", **context)
+        self.assertIn("<h1>10</h1>", body)
+        self.assertNotIn("metric-stdev", body)
+        self.assertNotIn("σ", body)
+        self.assertNotIn('class="high"', body)
+        self.assertNotIn('class="low"', body)
+
     def test_project_metric_cards_link_to_their_exact_linear_project_lists(self):
         app_module._build_person_context.cache_clear()
         self.addCleanup(app_module._build_person_context.cache_clear)


### PR DESCRIPTION
## Summary
- Person pages no longer show or calculate σ badges (vs engineering average) for anyone who is not on the engineering team.
- Absolute counts still render; the extra Linear/GitHub peer fetches used only for that comparison are skipped.
- Closes #497

## Test plan
- [ ] Open an unassigned person page (e.g. Andy) and confirm metric cards have no σ badges or high/low coloring
- [ ] Confirm that page still shows PR, issue, and project counts
- [ ] Open an engineering person page and confirm σ badges and coloring still appear
- [ ] `python -m unittest tests.test_person_stats -v`


Made with [Cursor](https://cursor.com)