### PR TITLE
Explain regression attributions

### DIFF
--- a/app.py
+++ b/app.py
@@ -1766,9 +1766,11 @@ def _build_person_context(
         "regressions_authored": author_regression_metric.get("regression_count", 0),
         "author_regression_rate": author_regression_metric.get("rate"),
         "authored_regression_pull_requests": author_regression_metric.get("pull_requests", []),
+        "authored_regression_attributions": author_regression_metric.get("attributions", []),
         "regressions_approved": reviewer_regression_metric.get("regression_count", 0),
         "reviewer_escape_rate": reviewer_regression_metric.get("rate"),
         "approved_regression_pull_requests": reviewer_regression_metric.get("pull_requests", []),
+        "approved_regression_attributions": reviewer_regression_metric.get("attributions", []),
         "platform_labels": platform_labels,
         "platform_values": platform_values,
     }

--- a/linear/issues.py
+++ b/linear/issues.py
@@ -264,6 +264,7 @@ def get_completed_regression_candidates(
             nodes {
               id
               identifier
+              url
               attachments {
                 nodes {
                   metadata

--- a/regressions.py
+++ b/regressions.py
@@ -84,6 +84,13 @@ def merge_issue_attributions(
     )
     return {
         "identifier": issue.get("identifier"),
+        "issue_url": issue.get("url"),
+        "fixing_urls": fixing_urls,
+        "complete": all(
+            isinstance(result := attributions_by_fix_url.get(url), dict)
+            and result.get("complete", True)
+            for url in fixing_urls
+        ),
         "candidates": candidates,
         "attribution": candidates[0] if candidates else None,
     }
@@ -123,6 +130,7 @@ def apply_regression_overrides(
                     logging.warning("Unable to load regression override: %s", exc)
             if candidate is not None:
                 record["attribution"] = candidate
+                record["manual_override"] = True
         corrected.append(record)
     return corrected
 
@@ -147,13 +155,15 @@ def collect_regression_attributions(
             url = futures[future]
             try:
                 result = future.result()
+                if result is None:
+                    result = {"complete": False, "candidates": []}
                 results[url] = result
-                if result is not None and not result.get("complete", True):
+                if not result.get("complete", True):
                     failed_urls.add(url)
             except Exception as exc:
                 logging.warning("Regression attribution failed for %s: %s", url, exc)
                 failed_urls.add(url)
-                results[url] = None
+                results[url] = {"complete": False, "candidates": []}
     records = [
         merge_issue_attributions(
             issue,
@@ -233,6 +243,45 @@ def _sorted_pull_request_links(
     return sorted(links.values(), key=lambda link: (link["label"].casefold(), link["url"]))
 
 
+def _regression_attribution_detail(record: dict[str, Any]) -> dict[str, Any] | None:
+    attribution = record.get("attribution")
+    if not isinstance(attribution, dict):
+        return None
+    inducing_pr = _pull_request_link(attribution)
+    if inducing_pr is None:
+        return None
+
+    fixing_prs = [
+        link
+        for url in record.get("fixing_urls") or []
+        if (link := _pull_request_link({"url": url})) is not None
+    ]
+    return {
+        "identifier": str(record.get("identifier") or "Regression"),
+        "issue_url": record.get("issue_url"),
+        "inducing_pr": inducing_pr,
+        "fixing_prs": fixing_prs,
+        "line_count": attribution.get("line_count"),
+        "candidate_count": sum(
+            isinstance(candidate, dict) for candidate in record.get("candidates") or []
+        ),
+        "analysis_complete": record.get("complete", True) is True,
+        "manual_override": record.get("manual_override") is True,
+    }
+
+
+def _sorted_regression_attributions(
+    attributions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return sorted(
+        attributions,
+        key=lambda item: (
+            item["identifier"].casefold(),
+            item["inducing_pr"]["url"],
+        ),
+    )
+
+
 def _person_metrics(
     records: list[dict[str, Any]],
     people: dict[str, dict[str, str]],
@@ -248,6 +297,8 @@ def _person_metrics(
     approved_pull_requests: dict[str, dict[str, dict[str, str]]] = {
         username: {} for username in people
     }
+    authored_attributions: dict[str, list[dict[str, Any]]] = {username: [] for username in people}
+    approved_attributions: dict[str, list[dict[str, Any]]] = {username: [] for username in people}
     for record in records:
         attribution = record.get("attribution")
         if not isinstance(attribution, dict):
@@ -256,18 +307,23 @@ def _person_metrics(
         if merged_at is None or not window.start <= merged_at < window.end:
             continue
         pull_request = _pull_request_link(attribution)
+        detail = _regression_attribution_detail(record)
         author = attribution.get("author")
         if isinstance(author, str) and author.casefold() in authored_regressions:
             username = author.casefold()
             authored_regressions[username] += 1
             if pull_request is not None:
                 authored_pull_requests[username].setdefault(pull_request["url"], pull_request)
+            if detail is not None:
+                authored_attributions[username].append(detail)
         for reviewer in attribution.get("reviewers") or []:
             if isinstance(reviewer, str) and reviewer.casefold() in approved_regressions:
                 username = reviewer.casefold()
                 approved_regressions[username] += 1
                 if pull_request is not None:
                     approved_pull_requests[username].setdefault(pull_request["url"], pull_request)
+                if detail is not None:
+                    approved_attributions[username].append(detail)
 
     author_rows, reviewer_rows = [], []
     for username, person in people.items():
@@ -280,6 +336,7 @@ def _person_metrics(
                 "pr_count": authored_count,
                 "rate": _rate(authored_regressions[username], authored_count),
                 "pull_requests": _sorted_pull_request_links(authored_pull_requests[username]),
+                "attributions": _sorted_regression_attributions(authored_attributions[username]),
             }
         )
         reviewer_rows.append(
@@ -289,6 +346,7 @@ def _person_metrics(
                 "pr_count": reviewed_count,
                 "rate": _rate(approved_regressions[username], reviewed_count),
                 "pull_requests": _sorted_pull_request_links(approved_pull_requests[username]),
+                "attributions": _sorted_regression_attributions(approved_attributions[username]),
             }
         )
     return author_rows, reviewer_rows

--- a/static/styles.css
+++ b/static/styles.css
@@ -510,6 +510,11 @@ a.leaderboard-export:is(:hover, :focus) { color: var(--pico-primary); }
   overflow-wrap: anywhere;
 }
 
+.regression-attributions { margin-top: 0.5rem; }
+.regression-attributions summary { font-size: 0.8rem; font-weight: 600; }
+.regression-attributions ol { margin-bottom: 0; padding-left: 1.25rem; }
+.regression-attributions li + li { margin-top: 0.5rem; }
+
 @media (max-width: 32rem) {
   .logout-form button {
     max-width: 32vw;

--- a/templates/partials/person_content.html
+++ b/templates/partials/person_content.html
@@ -18,6 +18,42 @@
   </small>
   {%- endif -%}
 {%- endmacro %}
+{% macro regression_attribution_details(attributions) -%}
+  {%- if attributions -%}
+  <details class="regression-attributions">
+    <summary>Attribution evidence ({{ attributions|length }})</summary>
+    <small>
+      Bug Board traces lines removed by each fixing PR, then ranks the PRs that last changed them.
+    </small>
+    <ol>
+      {% for detail in attributions %}
+      <li>
+        <a href="{{ detail.inducing_pr.url }}">{{ detail.inducing_pr.label }}</a>
+        <small>
+          {% if detail.manual_override %}
+            Manual correction
+          {% else %}
+            {{ detail.line_count }} matching deleted line{{ '' if detail.line_count == 1 else 's' }};
+            ranked first of {{ detail.candidate_count }} candidate{{ '' if detail.candidate_count == 1 else 's' }}
+          {% endif %}
+          for
+          {% if detail.issue_url %}<a href="{{ detail.issue_url }}">{{ detail.identifier }}</a>{% else %}{{ detail.identifier }}{% endif %}.
+          {% if detail.fixing_prs %}
+            Fix{% if detail.fixing_prs|length > 1 %}es{% endif %}:
+            {% for fixing_pr in detail.fixing_prs %}
+              <a href="{{ fixing_pr.url }}">{{ fixing_pr.label }}</a>{% if not loop.last %}, {% else %}.{% endif %}
+            {% endfor %}
+          {% endif %}
+          {% if not detail.analysis_complete %}
+            Blame data was incomplete.
+          {% endif %}
+        </small>
+      </li>
+      {% endfor %}
+    </ol>
+  </details>
+  {%- endif -%}
+{%- endmacro %}
 <h2>{{ 'Current Support Work' if on_call_support else 'Current Project Work' }}</h2>
 {% if open_current_cycle %}
 {% for project, issues in open_current_cycle.items() %}
@@ -88,6 +124,7 @@
       <header>Authored Regressions</header>
       <h1>{{ regressions_authored }}</h1>
       {{ regression_pr_links(authored_regression_pull_requests) }}
+      {{ regression_attribution_details(authored_regression_attributions) }}
       <small>
         {% if author_regression_rate is not none %}
           {{ author_regression_rate }}% of merged PRs
@@ -102,6 +139,7 @@
       <header>Approved Regressions</header>
       <h1>{{ regressions_approved }}</h1>
       {{ regression_pr_links(approved_regression_pull_requests) }}
+      {{ regression_attribution_details(approved_regression_attributions) }}
       <small>
         {% if reviewer_escape_rate is not none %}
           {{ reviewer_escape_rate }}% of approved PRs

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -163,6 +163,26 @@ class NavigationTest(unittest.TestCase):
                                     "label": "apollos-platforms#123",
                                 }
                             ],
+                            "attributions": [
+                                {
+                                    "identifier": "APO-123",
+                                    "issue_url": "https://linear.app/apollos/issue/APO-123/example",
+                                    "inducing_pr": {
+                                        "url": "https://github.com/ApollosProject/apollos-platforms/pull/123",
+                                        "label": "apollos-platforms#123",
+                                    },
+                                    "fixing_prs": [
+                                        {
+                                            "url": "https://github.com/ApollosProject/apollos-platforms/pull/124",
+                                            "label": "apollos-platforms#124",
+                                        }
+                                    ],
+                                    "line_count": 3,
+                                    "candidate_count": 2,
+                                    "analysis_complete": False,
+                                    "manual_override": False,
+                                }
+                            ],
                         }
                     ],
                     "reviewer_metrics": [
@@ -200,6 +220,11 @@ class NavigationTest(unittest.TestCase):
             context["approved_regression_pull_requests"][0]["label"],
             "apollos-cluster#456",
         )
+        self.assertEqual(
+            context["authored_regression_attributions"][0]["identifier"],
+            "APO-123",
+        )
+        self.assertEqual(context["approved_regression_attributions"], [])
         merged_pr_query = parse_qs(urlparse(context["github_merged_prs_url"]).query)["q"][0]
         self.assertIn("author:bkraeling", merged_pr_query)
         self.assertIn("merged:>=2026-07-01", merged_pr_query)
@@ -216,6 +241,12 @@ class NavigationTest(unittest.TestCase):
             '<a href="https://github.com/ApollosProject/apollos-cluster/pull/456">apollos-cluster#456</a>',
             body,
         )
+        self.assertIn("Attribution evidence (1)", body)
+        self.assertIn("APO-123", body)
+        self.assertIn("apollos-platforms#124", body)
+        self.assertIn("3 matching deleted lines;", body)
+        self.assertIn("ranked first of 2 candidates", body)
+        self.assertIn("Blame data was incomplete.", body)
         fetch.assert_called_once_with()
         counts.assert_called_once_with("bkraeling", 30, counts.call_args.args[2])
         support.assert_called_once_with(config=config, projects=projects)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -11,6 +11,7 @@ from regressions import (
     _person_metrics,
     apply_regression_overrides,
     build_regression_summary,
+    collect_regression_attributions,
     extract_fixing_pr_urls,
     load_regression_overrides,
     merge_issue_attributions,
@@ -132,6 +133,22 @@ class RegressionAttributionTest(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertFalse(result["complete"])  # type: ignore[index]
 
+    def test_missing_fixing_pr_metadata_marks_collection_incomplete(self):
+        fixing_url = "https://github.com/example/repo/pull/10"
+        with (
+            patch.dict("os.environ", {"LINEAR_API_KEY": "x", "GITHUB_TOKEN": "x"}),
+            patch("regressions.get_completed_regression_candidates", return_value=[{"id": "1"}]),
+            patch("regressions.extract_fixing_pr_urls", return_value=[fixing_url]),
+            patch("regressions.get_fixing_pr_attribution", return_value=None),
+        ):
+            records, failed_count = collect_regression_attributions(
+                TimeWindow.from_dates(date(2026, 8, 1), date(2026, 8, 31))
+            )
+
+        self.assertEqual(failed_count, 1)
+        self.assertFalse(records[0]["complete"])
+        self.assertIsNone(records[0]["attribution"])
+
     def test_attribution_metadata_filters_human_reviewers(self):
         url = "https://github.com/example/repo/pull/10"
         pull_request = {
@@ -239,16 +256,22 @@ class RegressionAttributionTest(unittest.TestCase):
             "author": "author",
         }
         record = merge_issue_attributions(
-            {"identifier": "APO-123"},
+            {
+                "identifier": "APO-123",
+                "url": "https://linear.app/apollos/issue/APO-123/example",
+            },
             [fixing_url, other_fix],
             {
                 fixing_url: {"candidates": [winner]},
-                other_fix: {"candidates": [later]},
+                other_fix: {"complete": False, "candidates": [later]},
             },
         )
         self.assertEqual(record["attribution"]["score"], 4.0)
         self.assertEqual(record["attribution"]["line_count"], 5)
         self.assertNotIn("age_days", record["attribution"])
+        self.assertEqual(record["issue_url"], "https://linear.app/apollos/issue/APO-123/example")
+        self.assertEqual(record["fixing_urls"], [fixing_url, other_fix])
+        self.assertFalse(record["complete"])
 
         loaded: list[str] = []
         manual = {"url": "https://github.com/example/repo/pull/9"}
@@ -261,7 +284,7 @@ class RegressionAttributionTest(unittest.TestCase):
             metadata_loader=lambda url: loaded.append(url) or manual,
         )
         self.assertEqual(loaded, [manual["url"]])
-        self.assertEqual(corrected, [{**record, "attribution": manual}])
+        self.assertEqual(corrected, [{**record, "attribution": manual, "manual_override": True}])
 
     def test_person_metrics_use_the_inducing_pr_cohort_and_stable_links(self):
         window = TimeWindow.from_dates(date(2026, 8, 1), date(2026, 8, 31))
@@ -271,20 +294,31 @@ class RegressionAttributionTest(unittest.TestCase):
         }
         records = [
             {
+                "identifier": "APO-2",
+                "issue_url": "https://linear.app/apollos/issue/APO-2/example",
+                "fixing_urls": ["https://github.com/example/zeta/pull/4"],
+                "candidates": [{"url": "first"}, {"url": "second"}],
+                "complete": False,
                 "attribution": {
                     "url": " https://github.com/example/zeta/pull/3/ ",
                     "merged_at": "2026-08-10T00:00:00Z",
                     "author": "alice",
                     "reviewers": ["bob"],
-                }
+                    "line_count": 3,
+                },
             },
             {
+                "identifier": "APO-1",
+                "issue_url": "https://linear.app/apollos/issue/APO-1/example",
+                "fixing_urls": ["https://github.com/example/alpha/pull/13"],
+                "candidates": [{"url": "candidate"}],
+                "manual_override": True,
                 "attribution": {
                     "url": "https://github.com/example/alpha/pull/12",
                     "merged_at": "2026-08-11T00:00:00Z",
                     "author": "alice",
                     "reviewers": ["bob"],
-                }
+                },
             },
             {
                 "attribution": {
@@ -311,6 +345,14 @@ class RegressionAttributionTest(unittest.TestCase):
         self.assertEqual(authors[0]["pull_requests"], expected_pull_requests)
         self.assertEqual(reviewers[1]["pull_requests"], expected_pull_requests)
         self.assertEqual(authors[1]["pull_requests"], [])
+        first, second = authors[0]["attributions"]
+        self.assertEqual((first["identifier"], second["identifier"]), ("APO-1", "APO-2"))
+        self.assertTrue(first["manual_override"])
+        self.assertEqual(second["fixing_prs"][0]["label"], "zeta#4")
+        self.assertEqual((second["line_count"], second["candidate_count"]), (3, 2))
+        self.assertFalse(second["analysis_complete"])
+        self.assertEqual(reviewers[1]["attributions"], authors[0]["attributions"])
+        self.assertEqual(authors[1]["attributions"], [])
 
     def test_unconfigured_summary_skips_external_work(self):
         with patch.dict("os.environ", {}, clear=True):


### PR DESCRIPTION
## Issue
Regression cards link to likely inducing PRs, but they do not explain why Bug Board selected them or show the fixing bug and PR chain.

Closes #496

## Solution
- Preserve the Linear issue, fixing PRs, matched deleted-line count, candidate count, and per-record blame completeness in person metrics.
- Add optional collapsed attribution evidence beneath authored and approved regression cards without disrupting older cached summaries.
- Label manual corrections and incomplete blame analysis explicitly, including fixing PRs whose GitHub attribution metadata is unavailable.

## To Test
- Open a person page with authored or approved regressions.
- Expand `Attribution evidence` beneath either regression card.
- Confirm the inducing PR, Linear bug, fixing PRs, deleted-line match count, and candidate rank are shown and linked.

## Validation
- Exact head: `70b2b2cf3aa75785ab26d118b4262488d3f884e3`.
- `python -m unittest discover -s tests -p "test_*.py"` — 186 passed.
- `ruff check .`, `ruff format --check .`, `vulture . --config pyproject.toml`, `mypy .`, and `git diff --check origin/main...HEAD` — passed.
- All five required GitHub checks passed.
- Copilot reviewed the updated head with no new comments after its valid incomplete-analysis finding was fixed.

## Proof
Heroku review release v6 deployed exact head, returned 200 from `/healthz`, and completed a configured 30-day regression pipeline run (`run.7803`, exit 0) while containing unavailable GitHub blame lookups. The preceding live run on the same review app reported 55 regressions with 49 attributions; a focused live count query supplied the 389 authored and 161 reviewed PR denominators used below.

The review app has no Redis cache, so the screenshot uses the exact-head person template with those real Michael attribution rows and denominators injected into a temporary local wrapper.

![Expanded authored and approved attribution evidence](https://github.com/ApollosProject/bug-board/releases/download/proof-501/pr-501-regression-attribution-evidence.png)
