### PR TITLE
Make the brand mark read as a PCB

### DIFF
--- a/static/brand-mark.svg
+++ b/static/brand-mark.svg
@@ -34,29 +34,31 @@
       class="traces"
       fill="none"
       stroke-width="1.15"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      stroke-linecap="butt"
+      stroke-linejoin="miter"
     >
-      <path d="M14.4 5.8v2l-1.5 1.5v3.2L11.4 14v4L10 19.4v4.4H7.8" />
-      <path d="M22.5 13.1H21l-1.2 1.2V16l1 1.2" />
-      <path d="M9.2 26.6h3.1l1.3-1.3h5.5l1.4 1.4h3.3" />
-      <path d="M17 27.9v-1.5l1.1-1.1" />
+      <path d="M13.8 4.8v3l-1.5 1.5v3.5" />
+      <path d="M4.8 23.2h2.8l1.8-1.8v-3.6l1.4-1.4" />
+      <path d="M18.2 5.2v3.6l1.5 1.5v3.4" />
+      <path d="M27.2 24.4h-3.8l-1.8-1.8v-3.8" />
+      <path d="M5.6 26.2h6.3l1.5-1.5" />
+      <path d="M26.4 26.2h-6.3l-1.5-1.5" />
     </g>
     <g class="nodes">
-      <circle cx="12.9" cy="12.5" r="1.15" />
-      <circle cx="7.8" cy="23.8" r="1.3" />
-      <circle cx="20.8" cy="17.2" r="1.15" />
-      <circle cx="9.2" cy="26.6" r="1.25" />
-      <circle cx="18.1" cy="25.3" r="1.1" />
-      <circle cx="23.8" cy="26.7" r="1.25" />
+      <rect x="11.1" y="11.6" width="2.4" height="2.4" rx=".25" />
+      <rect x="9.6" y="15.2" width="2.4" height="2.4" rx=".25" />
+      <rect x="18.5" y="12.5" width="2.4" height="2.4" rx=".25" />
+      <rect x="20.4" y="17.6" width="2.4" height="2.4" rx=".25" />
+      <rect x="12.2" y="23.5" width="2.4" height="2.4" rx=".25" />
+      <rect x="17.4" y="23.5" width="2.4" height="2.4" rx=".25" />
     </g>
     <g class="vias">
-      <circle cx="12.9" cy="12.5" r=".38" />
-      <circle cx="7.8" cy="23.8" r=".42" />
-      <circle cx="20.8" cy="17.2" r=".38" />
-      <circle cx="9.2" cy="26.6" r=".4" />
-      <circle cx="18.1" cy="25.3" r=".36" />
-      <circle cx="23.8" cy="26.7" r=".4" />
+      <rect x="11.9" y="12.4" width=".8" height=".8" />
+      <rect x="10.4" y="16" width=".8" height=".8" />
+      <rect x="19.3" y="13.3" width=".8" height=".8" />
+      <rect x="21.2" y="18.4" width=".8" height=".8" />
+      <rect x="13" y="24.3" width=".8" height=".8" />
+      <rect x="18.2" y="24.3" width=".8" height=".8" />
     </g>
   </g>
 </svg>

--- a/templates/partials/brand_lockup.html
+++ b/templates/partials/brand_lockup.html
@@ -29,29 +29,31 @@
       <g
         class="site-brand-traces"
         fill="none"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        stroke-linecap="butt"
+        stroke-linejoin="miter"
       >
-        <path d="M14.4 5.8v2l-1.5 1.5v3.2L11.4 14v4L10 19.4v4.4H7.8" />
-        <path d="M22.5 13.1H21l-1.2 1.2V16l1 1.2" />
-        <path d="M9.2 26.6h3.1l1.3-1.3h5.5l1.4 1.4h3.3" />
-        <path d="M17 27.9v-1.5l1.1-1.1" />
+        <path d="M13.8 4.8v3l-1.5 1.5v3.5" />
+        <path d="M4.8 23.2h2.8l1.8-1.8v-3.6l1.4-1.4" />
+        <path d="M18.2 5.2v3.6l1.5 1.5v3.4" />
+        <path d="M27.2 24.4h-3.8l-1.8-1.8v-3.8" />
+        <path d="M5.6 26.2h6.3l1.5-1.5" />
+        <path d="M26.4 26.2h-6.3l-1.5-1.5" />
       </g>
       <g class="site-brand-nodes">
-        <circle cx="12.9" cy="12.5" r="1.15" />
-        <circle cx="7.8" cy="23.8" r="1.3" />
-        <circle cx="20.8" cy="17.2" r="1.15" />
-        <circle cx="9.2" cy="26.6" r="1.25" />
-        <circle cx="18.1" cy="25.3" r="1.1" />
-        <circle cx="23.8" cy="26.7" r="1.25" />
+        <rect x="11.1" y="11.6" width="2.4" height="2.4" rx=".25" />
+        <rect x="9.6" y="15.2" width="2.4" height="2.4" rx=".25" />
+        <rect x="18.5" y="12.5" width="2.4" height="2.4" rx=".25" />
+        <rect x="20.4" y="17.6" width="2.4" height="2.4" rx=".25" />
+        <rect x="12.2" y="23.5" width="2.4" height="2.4" rx=".25" />
+        <rect x="17.4" y="23.5" width="2.4" height="2.4" rx=".25" />
       </g>
       <g class="site-brand-vias">
-        <circle cx="12.9" cy="12.5" r=".38" />
-        <circle cx="7.8" cy="23.8" r=".42" />
-        <circle cx="20.8" cy="17.2" r=".38" />
-        <circle cx="9.2" cy="26.6" r=".4" />
-        <circle cx="18.1" cy="25.3" r=".36" />
-        <circle cx="23.8" cy="26.7" r=".4" />
+        <rect x="11.9" y="12.4" width=".8" height=".8" />
+        <rect x="10.4" y="16" width=".8" height=".8" />
+        <rect x="19.3" y="13.3" width=".8" height=".8" />
+        <rect x="21.2" y="18.4" width=".8" height=".8" />
+        <rect x="13" y="24.3" width=".8" height=".8" />
+        <rect x="18.2" y="24.3" width=".8" height=".8" />
       </g>
     </g>
   </svg>

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -57,6 +57,8 @@ class NavigationTest(unittest.TestCase):
         self.assertIn('viewBox="0 0 32 32"', header)
         self.assertIn('clip-path="url(#apollos-a-clip)"', header)
         self.assertIn('class="site-brand-traces"', header)
+        self.assertIn('stroke-linecap="butt"', header)
+        self.assertIn('stroke-linejoin="miter"', header)
         self.assertIn('class="site-brand-nodes"', header)
         self.assertIn('class="site-brand-vias"', header)
         self.assertIn('class="site-brand-name">Apollos</strong>', header)
@@ -73,6 +75,8 @@ class NavigationTest(unittest.TestCase):
             favicon = favicon_file.read()
         self.assertIn('viewBox="0 0 32 32"', favicon)
         self.assertIn('clip-path="url(#apollos-a-clip)"', favicon)
+        self.assertIn('stroke-linecap="butt"', favicon)
+        self.assertIn('stroke-linejoin="miter"', favicon)
         self.assertIn('class="vias"', favicon)
 
     def test_header_menu_overrides_pico_left_aligned_dropdown(self):


### PR DESCRIPTION
## Issue

The brand mark routed one long, rounded trace through the left leg and used round terminals. At the rendered header size, that connected organic silhouette could read as worms instead of a PCB.

Closes #498

## Solution

- replace the winding routes with six independent orthogonal/45-degree traces
- use square through-hole pads with butt caps and mitered joins
- keep the inline header mark and standalone favicon aligned, with rendering assertions for the rigid trace treatment

## To Test

- open `/projects` and inspect the header mark at desktop and mobile widths
- open `/static/brand-mark.svg` and confirm the same PCB layout appears as the standalone mark

## Proof

Local Gunicorn served the same live-data `/projects` header at a 1280×900 viewport. Before is `main` at `baf2193`; after is the exact PR head at `3f97f95`, with zero browser console errors.

**Before — connected rounded traces and round terminals**

![Brand mark before the PCB routing refinement](https://github.com/ApollosProject/bug-board/releases/download/proof-498/issue-498-before.png)

**After — independent rigid traces and square through-hole pads**

![Brand mark after the PCB routing refinement](https://github.com/ApollosProject/bug-board/releases/download/proof-498/issue-498-after.png)

## Validation

- `ruff check .`
- `ruff format --check .`
- `vulture . --config pyproject.toml`
- `mypy .`
- `python -m unittest discover -s tests -p 'test_*.py'` (186 tests)
- `xmllint --noout static/brand-mark.svg`
