### PR TITLE
Limit completed-project metrics to the selected time window

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,6 +48,7 @@ from project_dates import (
     format_project_target_status,
     get_project_planned_weeks,
     parse_iso_date,
+    project_completed_in_window,
 )
 from regression_cache import get_cached_regression_summary
 from regressions import REGRESSION_DAYS
@@ -1589,14 +1590,18 @@ def _build_person_context(
         == normalized_person_name
     ]
     current_led_projects = [project for project in led_projects if not project.get("is_inactive")]
-    completed_led_projects = [project for project in led_projects if is_completed_project(project)]
+    completed_led_projects = [
+        project
+        for project in led_projects
+        if is_completed_project(project)
+        and project_completed_in_window(project, window.start, window.end)
+    ]
     incomplete_led_projects = [
         project for project in led_projects if is_incomplete_project(project)
     ]
     completed_project_variances = [
         (project, variance_days)
-        for project in led_projects
-        if is_completed_project(project)
+        for project in completed_led_projects
         for variance_days in [get_project_schedule_variance_days(project)]
         if variance_days is not None
     ]
@@ -1646,10 +1651,15 @@ def _build_person_context(
             if normalize_display_name((project.get("lead") or {}).get("displayName"))
             == normalize_display_name(info.get("linear_display_name") or other_name)
         ]
-        other_variances = [
-            variance_days
+        other_completed_led = [
+            project
             for project in other_led
             if is_completed_project(project)
+            and project_completed_in_window(project, window.start, window.end)
+        ]
+        other_variances = [
+            variance_days
+            for project in other_completed_led
             for variance_days in [get_project_schedule_variance_days(project)]
             if variance_days is not None
         ]
@@ -1661,7 +1671,7 @@ def _build_person_context(
                 "lead_current_projects": sum(
                     1 for project in other_led if not project.get("is_inactive")
                 ),
-                "lead_completed_projects": completed_project_weeks(other_led),
+                "lead_completed_projects": completed_project_weeks(other_completed_led),
                 "lead_incomplete_projects": sum(
                     1 for project in other_led if is_incomplete_project(project)
                 ),

--- a/jobs.py
+++ b/jobs.py
@@ -34,9 +34,15 @@ from linear.issues import (
 from linear.projects import get_projects
 from openai_client import get_chat_function_call
 from person_stats import issue_card_values, performance_outliers
-from project_dates import format_project_target_status, get_project_planned_weeks, parse_iso_date
+from project_dates import (
+    format_project_target_status,
+    get_project_planned_weeks,
+    parse_iso_date,
+    project_completed_in_window,
+)
 from regression_cache import refresh_regression_summary_cache
 from support import get_support_slugs
+from time_window import TimeWindow
 
 load_dotenv()
 
@@ -764,7 +770,13 @@ def _person_led_projects(projects: list[dict], person_key: str, person: dict) ->
 
 
 def _person_card_metrics(
-    completed: list[dict], prs_merged: int, prs_reviewed: int, led: list[dict]
+    completed: list[dict],
+    prs_merged: int,
+    prs_reviewed: int,
+    led: list[dict],
+    *,
+    window_start: datetime,
+    window_end: datetime,
 ) -> dict:
     current = incomplete = weeks = 0
     variances: list[int] = []
@@ -774,7 +786,7 @@ def _person_card_metrics(
         done = status not in {"incomplete", "canceled", "cancelled"} and (
             bool(project.get("completedAt")) or status in {"completed", "released"}
         )
-        if done:
+        if done and project_completed_in_window(project, window_start, window_end):
             weeks += get_project_planned_weeks(project)
             target = parse_iso_date(project.get("targetDate"))
             finished = parse_iso_date(project.get("completedAt"))
@@ -827,6 +839,7 @@ def format_performance_outlier_markdown(
 def post_performance_outliers():
     """Send weekly ±1.5σ outliers so managers know who to praise and coach."""
     days = PERFORMANCE_OUTLIER_DAYS
+    window = TimeWindow.from_days(days)
     people = get_team_members(ENGINEERING_TEAM_SLUG)
     projects = get_projects()
     metrics = {}
@@ -835,16 +848,21 @@ def post_performance_outliers():
         if not login:
             continue
         try:
-            completed = get_completed_issues_for_person(login, days)
+            completed = get_completed_issues_for_person(login, days, window)
         except Exception as exc:
             logging.error("Failed to fetch completed issues for %s: %s", login, exc)
             continue
         prs_merged = prs_reviewed = 0
         github_username = person.get("github_username")
         if github_username:
-            prs_merged, prs_reviewed = get_merged_pr_counts_for_user(github_username, days)
+            prs_merged, prs_reviewed = get_merged_pr_counts_for_user(github_username, days, window)
         metrics[slug] = _person_card_metrics(
-            completed, prs_merged, prs_reviewed, _person_led_projects(projects, slug, person)
+            completed,
+            prs_merged,
+            prs_reviewed,
+            _person_led_projects(projects, slug, person),
+            window_start=window.start,
+            window_end=window.end,
         )
     markdown = format_performance_outlier_markdown(
         performance_outliers(metrics),

--- a/project_dates.py
+++ b/project_dates.py
@@ -5,12 +5,32 @@ from datetime import date, datetime, time, timedelta, timezone
 
 
 def parse_iso_date(value: str | None) -> date | None:
+    parsed = parse_iso_datetime(value)
+    if parsed is None:
+        return None
+    return parsed.date()
+
+
+def parse_iso_datetime(value: str | None) -> datetime | None:
     if not value:
         return None
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
     try:
-        return datetime.fromisoformat(value).date()
+        parsed = datetime.fromisoformat(normalized)
     except ValueError:
         return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def project_completed_in_window(project: dict, start: datetime, end: datetime) -> bool:
+    completed = parse_iso_datetime(project.get("completedAt"))
+    if completed is None:
+        return False
+    return start <= completed < end
 
 
 def get_project_planned_weeks(project: dict) -> int:

--- a/tests/test_failing_dags.py
+++ b/tests/test_failing_dags.py
@@ -946,7 +946,9 @@ class TeamContextProjectFilteringTest(unittest.TestCase):
                                 return_value=[released_project],
                             ):
                                 with patch.object(app_module, "get_support_slugs", return_value=[]):
-                                    context = app_module._build_person_context("darryl", 7, 1)
+                                    context = app_module._build_person_context(
+                                        "darryl", 7, 1, "2025-11-01", "2025-11-30"
+                                    )
 
         self.assertEqual(context["lead_current_projects"], 0)
         self.assertEqual(context["lead_completed_projects"], 2)
@@ -1006,7 +1008,9 @@ class TeamContextProjectFilteringTest(unittest.TestCase):
                                 return_value=completed_projects,
                             ):
                                 with patch.object(app_module, "get_support_slugs", return_value=[]):
-                                    context = app_module._build_person_context("darryl", 7, 1)
+                                    context = app_module._build_person_context(
+                                        "darryl", 7, 1, "2025-11-01", "2025-11-30"
+                                    )
 
         self.assertEqual(context["lead_completed_projects"], 3)
         self.assertEqual(context["lead_completed_projects_avg_early_late"], "1d late")

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,7 +1,7 @@
 import sys
 import types
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -1294,7 +1294,7 @@ class PostPerformanceOutliersTest(unittest.TestCase):
             patch.object(
                 jobs_module,
                 "get_merged_pr_counts_for_user",
-                side_effect=lambda username, days=7: pr_counts[username],
+                side_effect=lambda username, days=7, window=None: pr_counts[username],
             ),
             patch.dict(
                 jobs_module.os.environ,
@@ -1335,6 +1335,34 @@ class PostPerformanceOutliersTest(unittest.TestCase):
             "bob": {"linear_username": "bob", "github_username": "bob-gh"},
         }
         self._run(people, {"alice-gh": (5, 0), "bob-gh": (5, 0)}).assert_not_called()
+
+
+class PersonCardMetricsWindowTest(unittest.TestCase):
+    def test_completed_project_metrics_ignore_projects_outside_window(self):
+        metrics = jobs_module._person_card_metrics(
+            [],
+            0,
+            0,
+            [
+                {
+                    "status": {"name": "Completed"},
+                    "completedAt": "2026-08-20T12:00:00.000Z",
+                    "startDate": "2026-08-10",
+                    "targetDate": "2026-08-18",
+                },
+                {
+                    "status": {"name": "Completed"},
+                    "completedAt": "2026-07-26T22:26:30.129Z",
+                    "startDate": "2026-07-01",
+                    "targetDate": "2026-07-24",
+                },
+            ],
+            window_start=datetime(2026, 8, 14, tzinfo=timezone.utc),
+            window_end=datetime(2026, 8, 22, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(metrics["lead_completed_projects"], 1)
+        self.assertEqual(metrics["lead_completed_projects_avg_early_late"], 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
@@ -29,15 +30,18 @@ def _project(
     *,
     status: str,
     completed: bool = False,
+    completed_at: str | None = None,
     start_date: str | None = None,
     target_date: str | None = None,
 ) -> dict:
+    if completed and completed_at is None:
+        completed_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
     return {
         "id": project_id,
         "name": f"Project {project_id}",
         "url": f"https://linear.example/project/{project_id}",
         "status": {"name": status},
-        "completedAt": "2026-08-01T00:00:00.000Z" if completed else None,
+        "completedAt": completed_at if completed else None,
         "startDate": start_date,
         "targetDate": target_date,
         "lead": {"displayName": lead_name},
@@ -412,6 +416,61 @@ class PersonStatsTest(unittest.TestCase):
             body = app_module.render_template("partials/person_content.html", **context)
         self.assertEqual(body.count("linear.app/differential/projects/all?filter="), 4)
         self.assertNotIn('href="https://linear.app/differential/projects/all"', body)
+
+    def test_completed_project_metrics_follow_selected_time_window(self):
+        app_module._build_person_context.cache_clear()
+        self.addCleanup(app_module._build_person_context.cache_clear)
+        config = {
+            "people": {
+                "alice": {
+                    "team": "engineering",
+                    "linear_username": "alice",
+                }
+            }
+        }
+        projects = [
+            _project(
+                "Alice",
+                "alice-in-window",
+                status="Completed",
+                completed=True,
+                completed_at="2026-08-20T12:00:00.000Z",
+                start_date="2026-08-10",
+                target_date="2026-08-18",
+            ),
+            _project(
+                "Alice",
+                "alice-outside-window",
+                status="Completed",
+                completed=True,
+                completed_at="2026-07-26T22:26:30.129Z",
+                start_date="2026-07-01",
+                target_date="2026-07-24",
+            ),
+            _project("Alice", "alice-current", status="In Progress"),
+        ]
+
+        with (
+            patch.object(app_module, "load_config", return_value=config),
+            patch.object(app_module, "get_open_issues_for_person", return_value=[]),
+            patch.object(app_module, "get_completed_issues_for_person", return_value=[]),
+            patch.object(app_module, "get_projects", return_value=projects),
+            patch.object(app_module, "get_support_slugs", return_value=set()),
+            patch.object(app_module, "get_cached_regression_summary", return_value=None),
+        ):
+            context = app_module._build_person_context("alice", 7, 1, "2026-08-14", "2026-08-21")
+
+        self.assertEqual(context["lead_current_projects"], 1)
+        self.assertEqual(context["lead_completed_projects"], 1)
+        self.assertEqual(context["lead_completed_projects_avg_early_late"], "2d late")
+        _, _, completed_ids = _linear_id_link_details(
+            context["project_metric_urls"]["lead_completed_projects"]
+        )
+        _, _, early_late_ids = _linear_id_link_details(
+            context["project_metric_urls"]["lead_completed_projects_avg_early_late"]
+        )
+        self.assertEqual(completed_ids, ["alice-in-window"])
+        self.assertEqual(early_late_ids, ["alice-in-window"])
 
     def test_issue_metric_cards_link_to_their_exact_linear_issue_lists(self):
         app_module._build_person_context.cache_clear()

--- a/tests/test_project_dates.py
+++ b/tests/test_project_dates.py
@@ -5,6 +5,8 @@ from project_dates import (
     format_project_start_status,
     format_project_target_status,
     get_project_planned_weeks,
+    parse_iso_datetime,
+    project_completed_in_window,
 )
 
 
@@ -76,6 +78,32 @@ class ProjectPlannedWeeksTest(unittest.TestCase):
             get_project_planned_weeks({"startDate": "2026-03-15", "targetDate": "2026-03-02"}),
             2,
         )
+
+
+class ProjectCompletedInWindowTest(unittest.TestCase):
+    def test_includes_completed_at_on_start_and_excludes_end(self):
+        start = datetime(2026, 8, 14, tzinfo=timezone.utc)
+        end = datetime(2026, 8, 21, tzinfo=timezone.utc)
+
+        self.assertTrue(
+            project_completed_in_window({"completedAt": "2026-08-14T00:00:00.000Z"}, start, end)
+        )
+        self.assertFalse(
+            project_completed_in_window({"completedAt": "2026-08-21T00:00:00.000Z"}, start, end)
+        )
+
+    def test_missing_or_invalid_completed_at_is_outside_window(self):
+        start = datetime(2026, 8, 14, tzinfo=timezone.utc)
+        end = datetime(2026, 8, 21, tzinfo=timezone.utc)
+
+        self.assertFalse(project_completed_in_window({}, start, end))
+        self.assertFalse(project_completed_in_window({"completedAt": "not-a-date"}, start, end))
+
+    def test_parse_iso_datetime_accepts_zulu_and_naive_values(self):
+        zulu = parse_iso_datetime("2026-08-20T12:00:00.000Z")
+        naive = parse_iso_datetime("2026-08-20T12:00:00")
+        self.assertEqual(zulu, datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc))
+        self.assertEqual(naive, datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue
Person-page 7d/30d/90d filtered issues and PRs, but Completed Project Weeks and Avg Days Early/Late used every completed project the person leads. Zach’s 7-day Avg Days Early/Late link opened July completions instead of projects closed in the last 7 days.

## Solution
Count those two cards, and their Linear list links, only for projects whose Linear `completedAt` falls in the selected window. Current and Incomplete stay a live snapshot. The Friday manager outlier report uses the same 7-day completed-project window.

## To Test
- Open `/team/zach?days=7` and confirm Completed Project Weeks is `0` and Avg Days Early/Late is `n/a`
- Click those links and confirm Linear is filtered to no projects
- Switch to 30d and confirm weeks `4` / `1d early`, with Kids Club and Ministry Platform in the links
- Confirm Current Projects stays `1` on both windows

## Proof
Live `/team/zach?days=7`: weeks **0**, avg **n/a**, Linear project IDs empty.

![Zach 7-day completed project cards](https://github.com/ApollosProject/bug-board/releases/download/proof-503/zach-7d-project-cards.png)

Same page on 30d: weeks **4**, avg **1d early**, Linear IDs are Kids Club and Ministry Platform.

![Zach 30-day completed project cards](https://github.com/ApollosProject/bug-board/releases/download/proof-503/zach-30d-project-cards.png)