### PR TITLE
Include all configured people in leaderboard CSV

### DIFF
--- a/app.py
+++ b/app.py
@@ -620,9 +620,7 @@ def _build_leaderboard_entries(
 ) -> list[LeaderboardEntry]:
     config_data = load_config()
     people_config = config_data.get("people", {})
-    engineering_team_slugs = {
-        slug for slug, info in people_config.items() if info.get("team") == ENGINEERING_TEAM_SLUG
-    }
+    configured_slugs = set(people_config)
 
     alias_to_slug = {}
     github_to_slug = {}
@@ -858,7 +856,7 @@ def _build_leaderboard_entries(
     leaderboard_entries = [
         entry
         for entry in leaderboard_entries
-        if (slug := entry.get("slug")) is not None and slug in engineering_team_slugs
+        if (slug := entry.get("slug")) is not None and slug in configured_slugs
     ]
 
     leaderboard_entries.sort(key=lambda entry: entry["score"], reverse=True)
@@ -1001,17 +999,25 @@ def compute_leaderboard_context(
         cycle_points_future, ({}, {})
     )
 
-    leaderboard_entries = _build_leaderboard_entries(
+    leaderboard_export_entries = _build_leaderboard_entries(
         completed_work=completed_work,
         merged_reviews=merged_reviews,
         merged_authored_prs=merged_authored_prs,
         cycle_lead_points=cycle_lead_points,
         cycle_member_points=cycle_member_points,
     )
+    people_config = load_config().get("people", {})
+    engineering_team_slugs = {
+        slug for slug, info in people_config.items() if info.get("team") == ENGINEERING_TEAM_SLUG
+    }
+    leaderboard_entries = [
+        entry for entry in leaderboard_export_entries if entry.get("slug") in engineering_team_slugs
+    ]
 
     return {
         **window.template_vars(),
         "leaderboard_entries": leaderboard_entries,
+        "leaderboard_export_entries": leaderboard_export_entries,
     }
 
 
@@ -1124,7 +1130,11 @@ def leaderboard_csv():
     )
     return Response(
         render_leaderboard_csv(
-            build_leaderboard_export_rows(context.get("leaderboard_entries") or [])
+            build_leaderboard_export_rows(
+                context.get("leaderboard_export_entries")
+                or context.get("leaderboard_entries")
+                or []
+            )
         ),
         mimetype="text/csv; charset=utf-8",
         headers={

--- a/leaderboard_cache.py
+++ b/leaderboard_cache.py
@@ -29,6 +29,7 @@ def get_cached_leaderboard(days: int) -> dict[str, Any] | None:
     if (
         not isinstance(payload, dict)
         or not isinstance(payload.get("leaderboard_entries"), list)
+        or not isinstance(payload.get("leaderboard_export_entries"), list)
         or payload.get("days") != days
     ):
         return None
@@ -65,6 +66,7 @@ def refresh_leaderboard_cache(days: int = DEFAULT_LEADERBOARD_DAYS) -> dict[str,
         return get_cached_leaderboard(days) or {
             "days": days,
             "leaderboard_entries": [],
+            "leaderboard_export_entries": [],
         }
 
     store_cached_leaderboard(days, context)

--- a/leaderboard_export.py
+++ b/leaderboard_export.py
@@ -81,18 +81,25 @@ def build_leaderboard_export_rows(
         people = {
             slug: info
             for slug, info in load_config().get("people", {}).items()
-            if isinstance(info, Mapping) and info.get("team") == ENGINEERING_TEAM_SLUG
+            if isinstance(info, Mapping)
         }
     seen = {row["slug"] for row in rows if row["slug"]}
     for slug, info in people.items():
         if slug not in seen:
             rows.append(_row({"slug": slug, "score": 0}, _name(slug, info)))
     rows.sort(key=lambda row: (-int(row["score"]), str(row["person"])))
+    engineering_slugs = {
+        slug for slug, info in people.items() if info.get("team") == ENGINEERING_TEAM_SLUG
+    }
+    engineering_rows = [row for row in rows if row["slug"] in engineering_slugs]
     for column in ["score", *POINT_COLS]:
-        values = [float(row[column] or 0) for row in rows]
-        for row, value in zip(rows, values, strict=True):
+        stdev_column = f"{column}_stdev"
+        for row in rows:
+            row[stdev_column] = ""
+        values = [float(row[column] or 0) for row in engineering_rows]
+        for row, value in zip(engineering_rows, values, strict=True):
             z_value = z_score(value, values)
-            row[f"{column}_stdev"] = "" if z_value is None else f"{z_value:.1f}"
+            row[stdev_column] = "" if z_value is None else f"{z_value:.1f}"
     if regression_summary is None:
         regression_summary = get_cached_regression_summary()
     ready = bool(regression_summary and regression_summary.get("configured"))

--- a/tests/test_leaderboard_cache.py
+++ b/tests/test_leaderboard_cache.py
@@ -8,7 +8,11 @@ import leaderboard_cache
 
 class LeaderboardCacheTest(unittest.TestCase):
     def test_roundtrip_rejects_mismatch_and_keeps_cache_on_refresh_failure(self):
-        payload = {"days": 30, "leaderboard_entries": [{"slug": "michael", "score": 10}]}
+        payload = {
+            "days": 30,
+            "leaderboard_entries": [{"slug": "michael", "score": 10}],
+            "leaderboard_export_entries": [{"slug": "michael", "score": 10}],
+        }
         values: dict[str, str] = {}
         client = MagicMock()
         client.get.side_effect = values.get
@@ -19,6 +23,10 @@ class LeaderboardCacheTest(unittest.TestCase):
                 self.assertTrue(leaderboard_cache.store_cached_leaderboard(30, payload))
                 self.assertEqual(leaderboard_cache.get_cached_leaderboard(30), payload)
                 values["leaderboard:index:30"] = json.dumps({"payload": {**payload, "days": 7}})
+                self.assertIsNone(leaderboard_cache.get_cached_leaderboard(30))
+                values["leaderboard:index:30"] = json.dumps(
+                    {"payload": {"days": 30, "leaderboard_entries": []}}
+                )
                 self.assertIsNone(leaderboard_cache.get_cached_leaderboard(30))
 
         with patch.object(leaderboard_cache, "get_cached_leaderboard", return_value=payload):
@@ -33,8 +41,11 @@ class LeaderboardCacheTest(unittest.TestCase):
             "leaderboard_entries": [
                 {"slug": "michael", "display_name": "Michael", "score": 1257, "breakdown": None}
             ],
+            "leaderboard_export_entries": [
+                {"slug": "michael", "display_name": "Michael", "score": 1257, "breakdown": None}
+            ],
         }
-        live = {"days": 7, "leaderboard_entries": []}
+        live = {"days": 7, "leaderboard_entries": [], "leaderboard_export_entries": []}
         client = app_module.app.test_client()
         app_module._build_leaderboard_context.cache_clear()
         self.addCleanup(app_module._build_leaderboard_context.cache_clear)
@@ -59,6 +70,9 @@ class LeaderboardCacheTest(unittest.TestCase):
         live = {
             "days": 30,
             "leaderboard_entries": [
+                {"slug": "michael", "display_name": "Michael", "score": 42, "breakdown": None}
+            ],
+            "leaderboard_export_entries": [
                 {"slug": "michael", "display_name": "Michael", "score": 42, "breakdown": None}
             ],
         }

--- a/tests/test_leaderboard_export.py
+++ b/tests/test_leaderboard_export.py
@@ -1,3 +1,5 @@
+import csv
+import io
 import unittest
 from unittest.mock import patch
 
@@ -6,10 +8,59 @@ from leaderboard_export import build_leaderboard_export_rows, render_leaderboard
 
 
 class LeaderboardExportTest(unittest.TestCase):
+    def test_context_keeps_all_credited_authors_for_export_only(self):
+        config = {
+            "people": {
+                "eng": {
+                    "team": "engineering",
+                    "linear_username": "eng",
+                    "github_username": "eng-gh",
+                },
+                "other": {
+                    "team": "unassigned",
+                    "linear_username": "other",
+                    "github_username": "other-gh",
+                },
+            }
+        }
+        with (
+            patch.object(app_module, "load_config", return_value=config),
+            patch.object(
+                app_module,
+                "get_completed_issues_summary_for_labels",
+                return_value=[],
+            ),
+            patch.object(
+                app_module,
+                "get_merged_pr_activity",
+                # This map is the contract after Cursor co-author attribution.
+                return_value=({"eng-gh": [{}], "other-gh": [{}, {}]}, {}),
+            ),
+            patch.object(app_module, "calculate_cycle_project_points", return_value=({}, {})),
+        ):
+            context = app_module.compute_leaderboard_context(30)
+
+        self.assertEqual([entry["slug"] for entry in context["leaderboard_entries"]], ["eng"])
+        export_entries = {entry["slug"]: entry for entry in context["leaderboard_export_entries"]}
+        self.assertEqual(set(export_entries), {"eng", "other"})
+        self.assertEqual(export_entries["other"]["counts"]["prs"], 2)
+
     def test_csv_lists_score_parameters_and_route(self):
-        people = {"a": {}, "b": {}, "c": {}}
+        people = {
+            "a": {"team": "engineering"},
+            "b": {"team": "engineering"},
+            "c": {"team": "engineering"},
+            "d": {"team": "unassigned"},
+        }
         rows = build_leaderboard_export_rows(
             [
+                {
+                    "slug": "d",
+                    "display_name": "D",
+                    "score": 50,
+                    "points": {"prs": 50},
+                    "counts": {"prs": 50},
+                },
                 {
                     "slug": "a",
                     "display_name": "A",
@@ -31,11 +82,22 @@ class LeaderboardExportTest(unittest.TestCase):
                 "author_metrics": [{"slug": "c", "regression_count": 2, "rate": 4.0}],
             },
         )
-        self.assertEqual([row["slug"] for row in rows], ["a", "b", "c"])
+        self.assertEqual([row["slug"] for row in rows], ["d", "a", "b", "c"])
         self.assertEqual(
-            (rows[0]["urgent_issues"], rows[0]["score_stdev"], rows[2]["regressions_authored"]),
-            (1, "1.4", 2),
+            (
+                rows[0]["prs_merged"],
+                rows[0]["score_stdev"],
+                rows[1]["urgent_issues"],
+                rows[1]["score_stdev"],
+                rows[3]["regressions_authored"],
+            ),
+            (50, "", 1, "1.4", 2),
         )
+        self.assertEqual(
+            (rows[0]["pr_points_stdev"], rows[0]["urgent_points_stdev"]),
+            ("", ""),
+        )
+        self.assertEqual(rows[1]["pr_points_stdev"], "1.4")
         self.assertIn("person,slug,score,score_stdev,urgent_issues", render_leaderboard_csv(rows))
         client = app_module.app.test_client()
         ctx = {
@@ -44,19 +106,39 @@ class LeaderboardExportTest(unittest.TestCase):
             "window_query": {"days": 30},
             "leaderboard_entries": [
                 {
-                    "slug": "a",
-                    "display_name": "A",
+                    "slug": "michael",
+                    "display_name": "Michael",
                     "score": 10,
                     "points": {"prs": 10},
                     "counts": {"prs": 10},
                 }
+            ],
+            "leaderboard_export_entries": [
+                {
+                    "slug": "michael",
+                    "display_name": "Michael",
+                    "score": 10,
+                    "points": {"prs": 10},
+                    "counts": {"prs": 10},
+                },
+                {
+                    "slug": "andy",
+                    "display_name": "Andy",
+                    "score": 5,
+                    "points": {"prs": 5},
+                    "counts": {"prs": 5},
+                },
             ],
         }
         with patch.object(app_module, "_leaderboard_page_context", return_value=ctx):
             csv_text = client.get("/leaderboard.csv").get_data(as_text=True)
             html = client.get("/partials/index/leaderboard").get_data(as_text=True)
         self.assertTrue(csv_text.startswith("person,slug,score"))
-        self.assertIn("a,10,", csv_text)
+        exported = {row["slug"]: row for row in csv.DictReader(io.StringIO(csv_text))}
+        self.assertEqual(exported["andy"]["prs_merged"], "5")
+        self.assertEqual(exported["andy"]["score_stdev"], "")
+        self.assertIn("Michael", html)
+        self.assertNotIn("Andy", html)
         self.assertIn("/leaderboard.csv?days=30", html)
         self.assertIn('class="leaderboard-export"', html)
         self.assertIn(">Export CSV</a>", html)


### PR DESCRIPTION
## Issue

The leaderboard CSV only received the engineering-filtered leaderboard entries. That omitted configured non-engineering people and their activity, including PRs credited through the existing Cursor co-author attribution path. Including those rows directly in the relative calculations would also make non-engineers affect engineering sigma values.

## Solution

- Preserve an all-configured-people activity set for CSV export while keeping the visible leaderboard engineering-only.
- Reuse the existing credited-author activity map, so qualifying Cursor co-authored PRs remain included in PRs merged.
- Add configured people with no activity as zero-value export rows.
- Calculate and populate standard-deviation columns only for engineering members; leave those cells blank for everyone else.
- Require the expanded payload in the leaderboard cache so stale cached data cannot produce an incomplete export.

## To Test

- source venv/bin/activate
- python -m unittest discover -s tests -p 'test_*.py'
- ruff check .
- ruff format --check .
- mypy .
- vulture . --config pyproject.toml
- git diff --check

## Proof

- 192 unit tests pass.
- Focused export coverage proves credited non-engineering PR activity reaches the CSV, inactive configured people are retained, non-engineering sigma cells are blank, and engineering sigma values use only the engineering cohort.
- The HTML leaderboard coverage confirms non-engineering rows remain absent from the on-page leaderboard.
