### PR TITLE
Prevent truncated GitHub activity exports

### DIFF
--- a/github.py
+++ b/github.py
@@ -3,7 +3,7 @@ import os
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from functools import lru_cache
 from typing import Any, Dict, List
 
@@ -37,6 +37,10 @@ _cursor_pr_cache_lock = threading.Lock()
 
 class GitHubDataError(RuntimeError):
     """Raised when GitHub data would otherwise be silently incomplete."""
+
+
+class _GitHubSearchLimitExceeded(RuntimeError):
+    """Raised when a search must be partitioned to stay below GitHub's result cap."""
 
 
 _thread_local = threading.local()
@@ -343,7 +347,9 @@ def _merged_search_qualifier(days: int = 30, window: TimeWindow | None = None) -
     return TimeWindow.resolve(days, window=window).github_merged_qualifier()
 
 
-def _search_prs(query, search_query: str) -> List[Dict[str, Any]]:
+def _search_prs(
+    query, search_query: str, *, require_complete: bool = False
+) -> List[Dict[str, Any]]:
     prs: List[Dict[str, Any]] = []
     cursor = None
     for _ in range(10):
@@ -352,6 +358,8 @@ def _search_prs(query, search_query: str) -> List[Dict[str, Any]]:
         except Exception:
             return []
         payload = data.get("search", {}) or {}
+        if require_complete and (payload.get("issueCount", 0) or 0) > 1000:
+            raise _GitHubSearchLimitExceeded
         prs.extend(node for node in payload.get("nodes", []) or [] if node)
         page_info = payload.get("pageInfo", {}) or {}
         next_cursor = page_info.get("endCursor") if page_info.get("hasNextPage") else None
@@ -359,6 +367,48 @@ def _search_prs(query, search_query: str) -> List[Dict[str, Any]]:
             break
         cursor = next_cursor
     return prs
+
+
+def _search_complete_merged_pr_range(
+    query,
+    org_filter: str,
+    start: date,
+    end: date,
+    *,
+    parallel_depth: int = 0,
+) -> List[Dict[str, Any]]:
+    date_filter = f"merged:{start.isoformat()}..{end.isoformat()}"
+    search_query = f"{org_filter} is:pr is:merged {date_filter}"
+    try:
+        return _search_prs(query, search_query, require_complete=True)
+    except _GitHubSearchLimitExceeded:
+        if start >= end:
+            raise GitHubDataError(
+                f"GitHub merged PR search exceeds the 1,000-result limit for {start.isoformat()}"
+            ) from None
+        midpoint = start + timedelta(days=(end - start).days // 2)
+        if parallel_depth > 0:
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                earlier = executor.submit(
+                    _search_complete_merged_pr_range,
+                    query,
+                    org_filter,
+                    start,
+                    midpoint,
+                    parallel_depth=parallel_depth - 1,
+                )
+                later = executor.submit(
+                    _search_complete_merged_pr_range,
+                    query,
+                    org_filter,
+                    midpoint + timedelta(days=1),
+                    end,
+                    parallel_depth=parallel_depth - 1,
+                )
+            return earlier.result() + later.result()
+        return _search_complete_merged_pr_range(
+            query, org_filter, start, midpoint
+        ) + _search_complete_merged_pr_range(query, org_filter, midpoint + timedelta(days=1), end)
 
 
 @lru_cache(maxsize=32)
@@ -451,15 +501,15 @@ def _get_merged_prs(days: int = 30, window: TimeWindow | None = None):
     if not orgs:
         return []
     org_filter = " ".join(f"org:{org}" for org in orgs)
-    search_query = f"{org_filter} is:pr is:merged {_merged_search_qualifier(days, window)}"
     query = gql(
         """
         query SearchMergedPRs($query: String!, $cursor: String) {
           search(type: ISSUE, query: $query, first: 100, after: $cursor) {
+            issueCount
             nodes {
               ... on PullRequest {
                 author { login }
-                reviews(first: 10, states: [APPROVED]) {
+                reviews(first: 100, states: [APPROVED]) {
                   nodes {
                     author { login }
                     state
@@ -475,7 +525,14 @@ def _get_merged_prs(days: int = 30, window: TimeWindow | None = None):
         }
         """
     )
-    return _search_prs(query, search_query)
+    resolved_window = TimeWindow.resolve(days, window=window)
+    return _search_complete_merged_pr_range(
+        query,
+        org_filter,
+        resolved_window.start.date(),
+        resolved_window.inclusive_end_date,
+        parallel_depth=2,
+    )
 
 
 def get_merged_pr_counts_for_user(
@@ -569,11 +626,19 @@ def _group_merged_prs_by_author(prs: List[Dict[str, Any]]) -> Dict[str, List[Dic
 
 def _group_merged_prs_by_reviewer(prs: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
     prs_by_reviewer: Dict[str, List[Dict[str, Any]]] = {}
+    canonical_logins: Dict[str, str] = {}
     for pr in prs:
+        seen_reviewers = set()
         for review in pr.get("reviews", {}).get("nodes", []):
-            if review.get("author") and review.get("state") == "APPROVED":
-                reviewer = review["author"]["login"]
-                prs_by_reviewer.setdefault(reviewer, []).append(pr)
+            reviewer = ((review.get("author") or {}).get("login") or "").strip()
+            if not reviewer or review.get("state") != "APPROVED":
+                continue
+            normalized_reviewer = reviewer.casefold()
+            if normalized_reviewer in seen_reviewers:
+                continue
+            seen_reviewers.add(normalized_reviewer)
+            reviewer = canonical_logins.setdefault(normalized_reviewer, reviewer)
+            prs_by_reviewer.setdefault(reviewer, []).append(pr)
     return prs_by_reviewer
 
 

--- a/github.py
+++ b/github.py
@@ -355,7 +355,11 @@ def _search_prs(
     for _ in range(10):
         try:
             data = _execute(query, variable_values={"query": search_query, "cursor": cursor})
-        except Exception:
+        except Exception as exc:
+            if require_complete:
+                raise GitHubDataError(
+                    f"GitHub merged PR search failed: {_format_exception(exc)}"
+                ) from exc
             return []
         payload = data.get("search", {}) or {}
         if require_complete and (payload.get("issueCount", 0) or 0) > 1000:

--- a/tests/test_gql_client_requests.py
+++ b/tests/test_gql_client_requests.py
@@ -139,6 +139,11 @@ class GraphQLClientRequestTests(unittest.TestCase):
         self.assertTrue(any("merged:2026-01-01..2026-01-02" in q for q in searches))
         self.assertTrue(any("merged:2026-01-03..2026-01-04" in q for q in searches))
 
+    def test_complete_merged_pr_search_fails_closed_on_api_error(self):
+        with patch.object(github, "_execute", side_effect=RuntimeError("boom")):
+            with self.assertRaisesRegex(github.GitHubDataError, "boom"):
+                github._search_prs(None, "query", require_complete=True)
+
     @staticmethod
     def _cursor_pr(*coauthors):
         return {

--- a/tests/test_gql_client_requests.py
+++ b/tests/test_gql_client_requests.py
@@ -1,11 +1,12 @@
 import unittest
-from datetime import datetime
+from datetime import date, datetime
 from unittest.mock import patch
 
 from gql import GraphQLRequest, gql
 
 import github
 from linear import client as linear_client
+from time_window import TimeWindow
 
 
 class _RecordingClient:
@@ -76,7 +77,12 @@ class GraphQLClientRequestTests(unittest.TestCase):
         prs = [
             {
                 "author": {"login": "alice"},
-                "reviews": {"nodes": [{"author": {"login": "bob"}, "state": "APPROVED"}]},
+                "reviews": {
+                    "nodes": [
+                        {"author": {"login": "bob"}, "state": "APPROVED"},
+                        {"author": {"login": "BOB"}, "state": "APPROVED"},
+                    ]
+                },
             },
             {
                 "author": {"login": "bob"},
@@ -96,6 +102,42 @@ class GraphQLClientRequestTests(unittest.TestCase):
         self.assertEqual(list(reviewed), ["bob", "alice"])
         self.assertEqual((len(authored["alice"]), len(authored["CARA"])), (2, 2))
         self.assertEqual(len(reviewed["bob"]), 1)
+
+    def test_merged_pr_search_splits_date_ranges_above_github_limit(self):
+        window = TimeWindow.from_dates(date(2026, 1, 1), date(2026, 1, 4))
+        searches = []
+
+        def execute(_query, variable_values):
+            search = variable_values["query"]
+            searches.append(search)
+            if "merged:2026-01-01..2026-01-04" in search:
+                return {
+                    "search": {
+                        "issueCount": 1500,
+                        "nodes": [],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            author = "alice" if "merged:2026-01-01..2026-01-02" in search else "bob"
+            return {
+                "search": {
+                    "issueCount": 1,
+                    "nodes": [{"author": {"login": author}, "reviews": {"nodes": []}}],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+
+        with (
+            patch.object(github, "token", "token"),
+            patch.object(github, "get_github_orgs", return_value=["apollosproject"]),
+            patch.object(github, "_execute", side_effect=execute),
+        ):
+            prs = github._get_merged_prs(window=window)
+
+        self.assertEqual([pr["author"]["login"] for pr in prs], ["alice", "bob"])
+        self.assertEqual(len(searches), 3)
+        self.assertTrue(any("merged:2026-01-01..2026-01-02" in q for q in searches))
+        self.assertTrue(any("merged:2026-01-03..2026-01-04" in q for q in searches))
 
     @staticmethod
     def _cursor_pr(*coauthors):

--- a/tests/test_time_window.py
+++ b/tests/test_time_window.py
@@ -16,7 +16,7 @@ class TimeWindowTest(unittest.TestCase):
         self.assertEqual(custom.linear_bounds()["before"], "2026-02-01T00:00:00.000Z")
         self.assertEqual(
             custom.github_merged_qualifier(),
-            "merged:>=2026-01-01 merged:<=2026-01-31",
+            "merged:2026-01-01..2026-01-31",
         )
         self.assertEqual(swapped.start.date().isoformat(), "2026-02-01")
         self.assertEqual(

--- a/time_window.py
+++ b/time_window.py
@@ -81,7 +81,7 @@ class TimeWindow:
         start = self.start.date().isoformat()
         if self.preset_days is not None:
             return f"merged:>={start}"
-        return f"merged:>={start} merged:<={self.inclusive_end_date.isoformat()}"
+        return f"merged:{start}..{self.inclusive_end_date.isoformat()}"
 
     def query_args(self) -> dict[str, str | int]:
         if self.preset_days is not None:


### PR DESCRIPTION
## Issue

Follow-up to #504. GitHub Search exposes at most 1,000 results, while the combined 90-day organization query currently matches 2,662 merged PRs. The aggregate path silently stopped at 1,000, so the CSV reported 25 credited PRs for Zach while his scoped person-page query correctly reported 50.

The aggregate review path could also count multiple approvals by the same person on one PR, while person pages count one reviewed PR.

## Solution

- Read the aggregate search issue count and recursively split oversized windows into disjoint GitHub date ranges.
- Fetch independent ranges in parallel so the complete 90-day query remains below the web-process timeout.
- Use GitHub's supported merged-date range syntax for bounded/custom windows.
- Fetch up to 100 approvals per PR and count each reviewer once per PR, case-insensitively.
- Fail closed when a complete search encounters an API error or a single day exceeds GitHub's 1,000-result limit.

## To Test

- source venv/bin/activate
- python -m unittest discover -s tests -p 'test_*.py'
- ruff check .
- ruff format --check .
- mypy .
- vulture . --config pyproject.toml
- git diff --check

## Proof

Exact head 84bc5d79c2a3bec9d8d4108969bf630c40ae4495 queried live GitHub data through both production count paths for solideo-gloria over the same 90-day window:

    person_credited_prs: 50
    aggregate_credited_prs: 50
    person_reviews: 97
    aggregate_reviews: 97
    aggregate_elapsed_seconds: 22.7

Before this fix, the same live comparison returned 50 person-page PRs but only 25 aggregate-report PRs. Local validation passes all 194 unit tests plus Ruff, formatting, mypy, vulture, and diff checks.
