### PR TITLE
Add checkbox to hide Merged/Done issues in Open Items

### DIFF
--- a/linear/issues.py
+++ b/linear/issues.py
@@ -42,6 +42,9 @@ def get_open_issues(priority, label):
                   name
                 }
               }
+              state {
+                name
+              }
               createdAt
               updatedAt
               priority

--- a/templates/partials/index_open_items.html
+++ b/templates/partials/index_open_items.html
@@ -45,4 +45,9 @@
   .hide-merged-done-toggle:checked ~ details .card[data-status="Done"] {
     display: none;
   }
+  .hide-merged-done-toggle,
+  label[for="hide-merged-done-issues"] {
+    display: inline-block;
+    margin-bottom: 1rem;
+  }
 </style>

--- a/templates/partials/index_open_items.html
+++ b/templates/partials/index_open_items.html
@@ -1,9 +1,11 @@
 <h2>Open Items</h2>
+<input type="checkbox" id="hide-merged-done-issues" class="hide-merged-done-toggle" />
+<label for="hide-merged-done-issues">Hide Merged/Done</label>
 <details open>
   <summary>Priority</summary>
   {% if priority_issues %}
     {% for issue in priority_issues %}
-    <div class="card">
+    <div class="card" data-status="{{ issue.state.name if issue.state else '' }}">
       <article>
         <a href="{{ issue.url }}">{{ issue.title }}</a>
         <small
@@ -23,7 +25,7 @@
   <summary>Non-priority</summary>
   {% if open_assigned_work %}
     {% for issue in open_assigned_work %}
-    <div class="card">
+    <div class="card" data-status="{{ issue.state.name if issue.state else '' }}">
       <article>
         <a href="{{ issue.url }}">{{ issue.title }}</a>
         <small
@@ -38,3 +40,9 @@
   {% endif %}
 </details>
 <hr />
+<style>
+  .hide-merged-done-toggle:checked ~ details .card[data-status="Merged"],
+  .hide-merged-done-toggle:checked ~ details .card[data-status="Done"] {
+    display: none;
+  }
+</style>


### PR DESCRIPTION
## Summary
- The Open Items list can show Linear issues with a "Merged" workflow state (it's a started-type state, so it still passes the open-issue query filter) even though the PR has already landed, plus occasionally "Done" issues that haven't fully synced out of the query yet.
- Adds a "Hide Merged/Done" checkbox above the list that filters those cards out client-side.
- Fetches `state { name }` on each Linear issue so the card can carry its status, then hides matching cards via a pure-CSS sibling-selector toggle — no `<script>`, since this partial is injected via `fetch` + `innerHTML` on the index page, which wouldn't execute a script tag anyway.

## Test plan
- [x] `pytest` full suite passes (194 passed)
- [x] Rendered the partial with sample Merged/Done/In-Progress issues and verified in browser: unchecked shows all issues, checking "Hide Merged/Done" hides Merged and Done cards in both the Priority and Non-priority sections, unchecking restores them

## 📸 Screenshots (demo data)

This sandbox has no `LINEAR_API_KEY`/`GITHUB_TOKEN`, so these are captured against the
**real Flask app / real Jinja templates / real CSS**, with `get_open_issues` stubbed to
return a handful of synthetic Linear issues (including Merged/Done ones) so the new
checkbox has something to filter. Everything downstream of that data — routing,
rendering, the checkbox and CSS filter under test — is untouched. Headless Playwright
run, assertions in-line (all passed).

Filter off — Merged/Done issues show:

| Desktop | Mobile |
| --- | --- |
| ![](https://github.com/user-attachments/assets/eae15f1a-3e35-4be4-bb95-51437813a85b) | ![](https://github.com/user-attachments/assets/4e076ffd-2df8-4531-a38d-59d767b02d6b) |

Filter on — Merged/Done issues hidden:

| Desktop | Mobile |
| --- | --- |
| ![](https://github.com/user-attachments/assets/137f54bc-dc37-421f-9d11-03c501c4837b) | ![](https://github.com/user-attachments/assets/e23f2901-1a9c-418d-8978-409eae11b3ef) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
