### PR TITLE
Add an unfiltered people stats table

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,6 +42,7 @@ from linear.issues import (
     get_time_data,
 )
 from linear.projects import get_projects
+from people_table import build_people_stats, parse_sort
 from person_stats import issue_card_values, metric_stdevs_for_person
 from project_dates import (
     format_project_start_status,
@@ -1184,6 +1185,26 @@ def projects_content_partial():
     cache_epoch = int(time.time() / INDEX_CACHE_TTL_SECONDS)
     context = _build_team_context(cache_epoch)
     return render_template("partials/team_content.html", **context)
+
+
+@app.route("/people")
+def people():
+    window = _request_time_window()
+    order = parse_sort(request.args.get("sort"))
+    return render_template(
+        "people.html",
+        extra_query={"sort": order.token},
+        sort_token=order.token,
+        **window.template_vars(),
+    )
+
+
+@app.route("/partials/people/table")
+def people_table_partial():
+    window = _request_time_window()
+    order = parse_sort(request.args.get("sort"))
+    stats = build_people_stats(window, order)
+    return render_template("partials/people_table.html", stats=stats)
 
 
 @app.route("/partials/team/<slug>/content")

--- a/people_table.py
+++ b/people_table.py
@@ -1,0 +1,544 @@
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+from collections.abc import Callable, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from enum import StrEnum
+from functools import lru_cache
+from typing import Any, Final
+from urllib.parse import quote
+
+from config import load_config
+from github import get_merged_pr_activity
+from person_stats import format_stdev_label, format_stdev_tooltip, stdev_tone, z_score
+from regressions import (
+    EMPTY_REGRESSION_TALLY,
+    RegressionRef,
+    RegressionTally,
+    collect_regression_attributions,
+    tally_regressions_by_login,
+)
+from time_window import TimeWindow
+
+PEOPLE_STATS_TTL_SECONDS: Final = 60
+STDEV_COHORT_LABEL: Final = "all people"
+MISSING_TEXT: Final = "—"
+CURSOR_APP_LOGIN: Final = "cursor"
+
+
+@dataclass(frozen=True, slots=True)
+class Person:
+    slug: str
+    display_name: str
+    team: str
+    github_login: str | None
+
+    @property
+    def github_key(self) -> str:
+        return (self.github_login or "").casefold()
+
+
+def load_roster() -> tuple[Person, ...]:
+    people = load_config().get("people") or {}
+    roster: list[Person] = []
+    for slug, info in people.items():
+        entry = info or {}
+        raw_login = entry.get("github_username")
+        github_login = (
+            raw_login.strip() if isinstance(raw_login, str) and raw_login.strip() else None
+        )
+        linear_username = entry.get("linear_username") or slug
+        display_name = re.sub(r"[._-]+", " ", str(linear_username)).title()
+        roster.append(
+            Person(
+                slug=str(slug),
+                display_name=display_name,
+                team=str(entry.get("team") or ""),
+                github_login=github_login,
+            )
+        )
+    return tuple(roster)
+
+
+@dataclass(frozen=True, slots=True)
+class AgentCredit:
+    prs: int = 0
+    labels: tuple[str, ...] = ()
+
+
+NO_AGENT_CREDIT: Final = AgentCredit()
+
+
+@dataclass(frozen=True, slots=True)
+class PersonFacts:
+    person: Person
+    prs_merged: int | None
+    prs_reviewed: int | None
+    agent: AgentCredit | None
+    regressions: RegressionTally | None
+
+
+@dataclass(frozen=True, slots=True)
+class StdevBadge:
+    label: str
+    tooltip: str
+    tone: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class Cell:
+    text: str
+    sort_key: tuple[float, str]
+    href: str | None = None
+    note: str | None = None
+    stdev: StdevBadge | None = None
+
+
+class ColumnKey(StrEnum):
+    PERSON = "person"
+    PRS_MERGED = "prs_merged"
+    PRS_REVIEWED = "prs_reviewed"
+    AGENT_PRS = "agent_prs"
+    AGENT_SHARE = "agent_share"
+    REGRESSIONS_AUTHORED = "regressions_authored"
+    REGRESSIONS_APPROVED = "regressions_approved"
+
+
+Measure = Callable[[PersonFacts], float | None]
+Render = Callable[[PersonFacts, float | None], str]
+Link = Callable[[PersonFacts, TimeWindow], str | None]
+Note = Callable[[PersonFacts], str | None]
+
+
+def render_count(_facts: PersonFacts, value: float | None) -> str:
+    if value is None:
+        return MISSING_TEXT
+    return str(int(value))
+
+
+def render_percent(_facts: PersonFacts, value: float | None) -> str:
+    if value is None:
+        return MISSING_TEXT
+    return f"{value:.0%}"
+
+
+def no_link(_facts: PersonFacts, _window: TimeWindow) -> str | None:
+    return None
+
+
+def no_note(_facts: PersonFacts) -> str | None:
+    return None
+
+
+def _github_search_url(query: str) -> str:
+    return f"https://github.com/pulls?q={quote(query, safe='')}"
+
+
+def _merged_prs_link(facts: PersonFacts, window: TimeWindow) -> str | None:
+    login = facts.person.github_login
+    if not login:
+        return None
+    query = f"is:closed is:pr author:{login} archived:false {window.github_merged_qualifier()}"
+    return _github_search_url(query)
+
+
+def _regression_list_url(refs: Sequence[RegressionRef]) -> str | None:
+    identifiers = tuple(dict.fromkeys(ref.identifier for ref in refs if ref.identifier))
+    if not identifiers:
+        return None
+    return f"https://linear.app/differential/issues/{','.join(identifiers)}"
+
+
+def _authored_regressions_link(facts: PersonFacts, _window: TimeWindow) -> str | None:
+    if facts.regressions is None:
+        return None
+    return _regression_list_url(facts.regressions.authored)
+
+
+def _approved_regressions_link(facts: PersonFacts, _window: TimeWindow) -> str | None:
+    if facts.regressions is None:
+        return None
+    return _regression_list_url(facts.regressions.approved)
+
+
+def _agent_share(facts: PersonFacts) -> float | None:
+    if facts.prs_merged is None or facts.agent is None or facts.prs_merged == 0:
+        return None
+    return facts.agent.prs / facts.prs_merged
+
+
+def _agent_prs(facts: PersonFacts) -> float | None:
+    if facts.agent is None:
+        return None
+    return facts.agent.prs
+
+
+def _agent_note(facts: PersonFacts) -> str | None:
+    if facts.agent is None:
+        return None
+    return " · ".join(facts.agent.labels) or None
+
+
+def _authored_count(facts: PersonFacts) -> float | None:
+    if facts.regressions is None:
+        return None
+    return facts.regressions.authored_count
+
+
+def _approved_count(facts: PersonFacts) -> float | None:
+    if facts.regressions is None:
+        return None
+    return facts.regressions.approved_count
+
+
+@dataclass(frozen=True, slots=True)
+class StatColumn:
+    key: ColumnKey
+    label: str
+    measure: Measure
+    render: Render = render_count
+    link: Link = no_link
+    note: Note = no_note
+    stdev: bool = False
+
+
+STAT_COLUMNS: Final[tuple[StatColumn, ...]] = (
+    StatColumn(
+        ColumnKey.PRS_MERGED,
+        "PRs merged",
+        measure=lambda facts: facts.prs_merged,
+        link=_merged_prs_link,
+        stdev=True,
+    ),
+    StatColumn(
+        ColumnKey.PRS_REVIEWED,
+        "PRs reviewed",
+        measure=lambda facts: facts.prs_reviewed,
+        stdev=True,
+    ),
+    StatColumn(
+        ColumnKey.AGENT_PRS,
+        "Agent PRs",
+        measure=_agent_prs,
+        note=_agent_note,
+    ),
+    StatColumn(
+        ColumnKey.AGENT_SHARE,
+        "Agent share",
+        measure=_agent_share,
+        render=render_percent,
+    ),
+    StatColumn(
+        ColumnKey.REGRESSIONS_AUTHORED,
+        "Regressions authored",
+        measure=_authored_count,
+        link=_authored_regressions_link,
+    ),
+    StatColumn(
+        ColumnKey.REGRESSIONS_APPROVED,
+        "Regressions approved",
+        measure=_approved_count,
+        link=_approved_regressions_link,
+    ),
+)
+
+_COLUMN_INDEX: Final[Mapping[ColumnKey, int]] = {
+    column.key: index for index, column in enumerate(STAT_COLUMNS)
+}
+
+
+class Direction(StrEnum):
+    ASC = "asc"
+    DESC = "desc"
+
+
+@dataclass(frozen=True, slots=True)
+class SortOrder:
+    key: ColumnKey
+    direction: Direction
+
+    @property
+    def token(self) -> str:
+        prefix = "-" if self.direction is Direction.DESC else ""
+        return f"{prefix}{self.key.value}"
+
+    @property
+    def descending(self) -> bool:
+        return self.direction is Direction.DESC
+
+    def toggled(self, key: ColumnKey) -> SortOrder:
+        if self.key is key:
+            flipped = Direction.ASC if self.direction is Direction.DESC else Direction.DESC
+            return SortOrder(key, flipped)
+        natural = Direction.ASC if key is ColumnKey.PERSON else Direction.DESC
+        return SortOrder(key, natural)
+
+
+DEFAULT_SORT: Final = SortOrder(ColumnKey.PRS_MERGED, Direction.DESC)
+
+
+def parse_sort(raw: str | None) -> SortOrder:
+    if not raw:
+        return DEFAULT_SORT
+    descending = raw.startswith("-")
+    key_raw = raw[1:] if descending else raw
+    try:
+        key = ColumnKey(key_raw)
+    except ValueError:
+        return DEFAULT_SORT
+    return SortOrder(key, Direction.DESC if descending else Direction.ASC)
+
+
+@dataclass(frozen=True, slots=True)
+class Row:
+    person: Person
+    cells: tuple[Cell, ...]
+
+    def sort_key(self, order: SortOrder) -> tuple[float, str]:
+        if order.key is ColumnKey.PERSON:
+            return (0.0, self.person.display_name.casefold())
+        return self.cells[_COLUMN_INDEX[order.key]].sort_key
+
+
+@dataclass(frozen=True, slots=True)
+class ColumnHeader:
+    key: ColumnKey
+    label: str
+    numeric: bool
+    aria_sort: str
+    sort_query: Mapping[str, str | int]
+
+
+@dataclass(frozen=True, slots=True)
+class PeopleStats:
+    window: TimeWindow
+    order: SortOrder
+    headers: tuple[ColumnHeader, ...]
+    rows: tuple[Row, ...]
+    notes: tuple[str, ...]
+
+    @property
+    def window_query(self) -> Mapping[str, str | int]:
+        return self.window.query_args()
+
+
+@dataclass(frozen=True, slots=True)
+class PeopleStatsInputs:
+    window: TimeWindow
+    roster: tuple[Person, ...]
+    merged_by_login: Mapping[str, int]
+    reviewed_by_login: Mapping[str, int]
+    agent_by_login: Mapping[str, AgentCredit]
+    regressions_by_login: Mapping[str, RegressionTally]
+    notes: tuple[str, ...] = ()
+    github_available: bool = True
+    regressions_available: bool = True
+
+
+def build_people_stats(window: TimeWindow, order: SortOrder) -> PeopleStats:
+    return assemble_people_stats(_gather(*window.cache_parts(), _cache_epoch()), order)
+
+
+def assemble_people_stats(inputs: PeopleStatsInputs, order: SortOrder) -> PeopleStats:
+    facts = tuple(_facts_for(person, inputs) for person in inputs.roster)
+    columns = tuple(_column_cells(column, facts, inputs.window) for column in STAT_COLUMNS)
+    rows = tuple(Row(f.person, tuple(col[i] for col in columns)) for i, f in enumerate(facts))
+    rows = tuple(sorted(rows, key=lambda row: row.sort_key(order), reverse=order.descending))
+    return PeopleStats(
+        window=inputs.window,
+        order=order,
+        headers=_headers(order, inputs.window),
+        rows=rows,
+        notes=inputs.notes,
+    )
+
+
+def _cache_epoch() -> int:
+    return int(time.time() / PEOPLE_STATS_TTL_SECONDS)
+
+
+@lru_cache(maxsize=8)
+def _gather(
+    days: int | None, start: str | None, end: str | None, _cache_epoch: int
+) -> PeopleStatsInputs:
+    notes: list[str] = []
+    window = TimeWindow.resolve(days, start=start, end=end)
+    roster = load_roster()
+    github_ok = bool(os.getenv("GITHUB_TOKEN"))
+    linear_ok = bool(os.getenv("LINEAR_API_KEY"))
+    if not github_ok:
+        notes.append("GitHub credentials are not configured.")
+    if not linear_ok:
+        notes.append("Linear credentials are not configured.")
+
+    merged_by_login: dict[str, int] = {}
+    reviewed_by_login: dict[str, int] = {}
+    agent_by_login: dict[str, AgentCredit] = {}
+    regressions_by_login: dict[str, RegressionTally] = {}
+    github_available = False
+    regressions_available = False
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        github_future = (
+            executor.submit(get_merged_pr_activity, window.duration_days, window)
+            if github_ok
+            else None
+        )
+        regression_future = (
+            executor.submit(collect_regression_attributions, window) if linear_ok else None
+        )
+        if github_future is not None:
+            try:
+                prs_by_author, prs_by_reviewer = github_future.result()
+                merged_by_login, reviewed_by_login, agent_by_login = _counts_from_activity(
+                    prs_by_author, prs_by_reviewer
+                )
+                github_available = True
+            except Exception:
+                logging.exception("Failed to load GitHub PR activity for people stats")
+                notes.append("Unable to load GitHub PR stats.")
+        if regression_future is not None:
+            try:
+                records, _failed = regression_future.result()
+                regressions_by_login = tally_regressions_by_login(records, window)
+                regressions_available = True
+            except Exception:
+                logging.exception("Failed to load regression attributions for people stats")
+                notes.append("Unable to load regression attributions.")
+
+    return PeopleStatsInputs(
+        window=window,
+        roster=roster,
+        merged_by_login=merged_by_login,
+        reviewed_by_login=reviewed_by_login,
+        agent_by_login=agent_by_login,
+        regressions_by_login=regressions_by_login,
+        notes=tuple(notes),
+        github_available=github_available,
+        regressions_available=regressions_available,
+    )
+
+
+def _counts_from_activity(
+    prs_by_author: Mapping[str, Sequence[Mapping[str, Any]]],
+    prs_by_reviewer: Mapping[str, Sequence[Mapping[str, Any]]],
+) -> tuple[dict[str, int], dict[str, int], dict[str, AgentCredit]]:
+    merged_by_login: dict[str, int] = {}
+    agent_by_login: dict[str, AgentCredit] = {}
+    for login, prs in prs_by_author.items():
+        key = login.casefold()
+        merged_by_login[key] = merged_by_login.get(key, 0) + len(prs)
+        credit = _agent_credit(prs)
+        if credit.prs:
+            existing = agent_by_login.get(key, NO_AGENT_CREDIT)
+            labels = tuple(dict.fromkeys((*existing.labels, *credit.labels)))
+            agent_by_login[key] = AgentCredit(existing.prs + credit.prs, labels)
+    reviewed_by_login: dict[str, int] = {}
+    for login, prs in prs_by_reviewer.items():
+        key = login.casefold()
+        reviewed_by_login[key] = reviewed_by_login.get(key, 0) + len(prs)
+    return merged_by_login, reviewed_by_login, agent_by_login
+
+
+def _agent_credit(prs: Sequence[Mapping[str, Any]]) -> AgentCredit:
+    cursor_count = sum(
+        1
+        for pr in prs
+        if ((pr.get("author") or {}).get("login") or "").casefold() == CURSOR_APP_LOGIN
+    )
+    if cursor_count == 0:
+        return NO_AGENT_CREDIT
+    return AgentCredit(prs=cursor_count, labels=("Cursor",))
+
+
+def _facts_for(person: Person, inputs: PeopleStatsInputs) -> PersonFacts:
+    if person.github_login is None:
+        return PersonFacts(person, 0, 0, NO_AGENT_CREDIT, EMPTY_REGRESSION_TALLY)
+    key = person.github_key
+    return PersonFacts(
+        person,
+        inputs.merged_by_login.get(key, 0) if inputs.github_available else None,
+        inputs.reviewed_by_login.get(key, 0) if inputs.github_available else None,
+        inputs.agent_by_login.get(key, NO_AGENT_CREDIT) if inputs.github_available else None,
+        (
+            inputs.regressions_by_login.get(key, EMPTY_REGRESSION_TALLY)
+            if inputs.regressions_available
+            else None
+        ),
+    )
+
+
+def _column_cells(
+    column: StatColumn, facts: Sequence[PersonFacts], window: TimeWindow
+) -> tuple[Cell, ...]:
+    values = [column.measure(fact) for fact in facts]
+    present = [value for value in values if value is not None]
+    badges = _stdev_badges(values, present) if column.stdev else [None] * len(values)
+    cells: list[Cell] = []
+    for fact, value, badge in zip(facts, values, badges, strict=True):
+        magnitude = value if value is not None else float("-inf")
+        cells.append(
+            Cell(
+                text=column.render(fact, value),
+                sort_key=(magnitude, fact.person.display_name.casefold()),
+                href=column.link(fact, window) if value else None,
+                note=column.note(fact),
+                stdev=badge,
+            )
+        )
+    return tuple(cells)
+
+
+def _stdev_badges(
+    values: Sequence[float | None], present: Sequence[float]
+) -> list[StdevBadge | None]:
+    baseline = list(present)
+    badges: list[StdevBadge | None] = []
+    for value in values:
+        if value is None:
+            badges.append(None)
+            continue
+        z = z_score(value, baseline)
+        if z is None:
+            badges.append(None)
+            continue
+        badges.append(
+            StdevBadge(
+                label=format_stdev_label(z),
+                tooltip=format_stdev_tooltip(baseline, cohort=STDEV_COHORT_LABEL),
+                tone=stdev_tone(z),
+            )
+        )
+    return badges
+
+
+def _headers(order: SortOrder, window: TimeWindow) -> tuple[ColumnHeader, ...]:
+    window_query = window.query_args()
+    person = ColumnHeader(
+        key=ColumnKey.PERSON,
+        label="Person",
+        numeric=False,
+        aria_sort=_aria_sort(order, ColumnKey.PERSON),
+        sort_query={**window_query, "sort": order.toggled(ColumnKey.PERSON).token},
+    )
+    rest = tuple(
+        ColumnHeader(
+            key=column.key,
+            label=column.label,
+            numeric=True,
+            aria_sort=_aria_sort(order, column.key),
+            sort_query={**window_query, "sort": order.toggled(column.key).token},
+        )
+        for column in STAT_COLUMNS
+    )
+    return (person, *rest)
+
+
+def _aria_sort(order: SortOrder, key: ColumnKey) -> str:
+    if order.key is not key:
+        return "none"
+    return "descending" if order.descending else "ascending"

--- a/people_table.py
+++ b/people_table.py
@@ -298,10 +298,12 @@ class Row:
     person: Person
     cells: tuple[Cell, ...]
 
-    def sort_key(self, order: SortOrder) -> tuple[float, str]:
+    def sort_key(self, order: SortOrder) -> tuple[float, str, str]:
+        name = self.person.display_name.casefold()
         if order.key is ColumnKey.PERSON:
-            return (0.0, self.person.display_name.casefold())
-        return self.cells[_COLUMN_INDEX[order.key]].sort_key
+            return (0.0, name, self.person.team)
+        magnitude, _name = self.cells[_COLUMN_INDEX[order.key]].sort_key
+        return (magnitude, name, self.person.team)
 
 
 @dataclass(frozen=True, slots=True)
@@ -481,15 +483,16 @@ def _column_cells(
     cells: list[Cell] = []
     for fact, value, badge in zip(facts, values, badges, strict=True):
         magnitude = value if value is not None else float("-inf")
-        cells.append(
-            Cell(
-                text=column.render(fact, value),
-                sort_key=(magnitude, fact.person.display_name.casefold()),
-                href=column.link(fact, window) if value else None,
-                note=column.note(fact),
-                stdev=badge,
-            )
+        cell = Cell(
+            text=column.render(fact, value),
+            sort_key=(magnitude, fact.person.display_name.casefold()),
+            href=column.link(fact, window) if value else None,
+            note=column.note(fact),
+            stdev=badge,
         )
+        if not value and cell.href is not None:
+            raise RuntimeError("zero and unavailable cells cannot link")
+        cells.append(cell)
     return tuple(cells)
 
 
@@ -535,7 +538,16 @@ def _headers(order: SortOrder, window: TimeWindow) -> tuple[ColumnHeader, ...]:
         )
         for column in STAT_COLUMNS
     )
-    return (person, *rest)
+    headers = (person, *rest)
+    allowed_aria = {"none", "ascending", "descending"}
+    for header in headers:
+        if header.aria_sort not in allowed_aria:
+            raise RuntimeError("invalid aria-sort")
+        if "sort" not in header.sort_query:
+            raise RuntimeError("sort query missing token")
+        if header.numeric is (header.key is ColumnKey.PERSON):
+            raise RuntimeError("only metric columns are numeric")
+    return headers
 
 
 def _aria_sort(order: SortOrder, key: ColumnKey) -> str:

--- a/person_stats.py
+++ b/person_stats.py
@@ -128,11 +128,14 @@ def stdev_tone(z: float, *, threshold: float = STDEV_COLOR_THRESHOLD) -> str | N
     return None
 
 
-def format_stdev_tooltip(values: list[float], *, hint: str | None = None) -> str:
+def format_stdev_tooltip(
+    values: list[float], *, hint: str | None = None, cohort: str = "eng"
+) -> str:
     baseline, trimmed = _stdev_baseline(values)
     qualifier = " trimmed" if trimmed else ""
     tooltip = (
-        f"eng{qualifier} avg {statistics.fmean(baseline):.1f} · σ {statistics.pstdev(baseline):.1f}"
+        f"{cohort}{qualifier} avg {statistics.fmean(baseline):.1f}"
+        f" · σ {statistics.pstdev(baseline):.1f}"
     )
     return f"{tooltip} · {hint}" if hint else tooltip
 

--- a/regressions.py
+++ b/regressions.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import logging
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Final
 
 import yaml
 
@@ -25,6 +26,30 @@ REGRESSION_DAYS = 30
 REGRESSION_OVERRIDES_PATH = Path(__file__).with_name("regression_overrides.yml")
 FIXING_LINK_KINDS = {"closes", "contributes"}
 MAX_ATTRIBUTION_WORKERS = 2
+
+
+@dataclass(frozen=True, slots=True)
+class RegressionRef:
+    identifier: str
+    issue_url: str | None
+    inducing_pr_url: str
+
+
+@dataclass(frozen=True, slots=True)
+class RegressionTally:
+    authored: tuple[RegressionRef, ...] = ()
+    approved: tuple[RegressionRef, ...] = ()
+
+    @property
+    def authored_count(self) -> int:
+        return len(self.authored)
+
+    @property
+    def approved_count(self) -> int:
+        return len(self.approved)
+
+
+EMPTY_REGRESSION_TALLY: Final = RegressionTally()
 
 
 def extract_fixing_pr_urls(issue: dict[str, Any]) -> list[str]:
@@ -280,6 +305,41 @@ def _sorted_regression_attributions(
             item["inducing_pr"]["url"],
         ),
     )
+
+
+def tally_regressions_by_login(
+    records: list[dict[str, Any]], window: TimeWindow
+) -> dict[str, RegressionTally]:
+    authored: dict[str, list[RegressionRef]] = {}
+    approved: dict[str, list[RegressionRef]] = {}
+    for record in records:
+        attribution = record.get("attribution")
+        if not isinstance(attribution, dict):
+            continue
+        merged_at = _parse_datetime(attribution.get("merged_at"))
+        if merged_at is None or not window.start <= merged_at < window.end:
+            continue
+        raw_url = attribution.get("url")
+        inducing_pr_url = raw_url.strip() if isinstance(raw_url, str) else ""
+        issue_url = record.get("issue_url")
+        ref = RegressionRef(
+            identifier=str(record.get("identifier") or "Regression"),
+            issue_url=issue_url if isinstance(issue_url, str) else None,
+            inducing_pr_url=inducing_pr_url,
+        )
+        author = attribution.get("author")
+        if isinstance(author, str) and author:
+            authored.setdefault(author.casefold(), []).append(ref)
+        for reviewer in attribution.get("reviewers") or []:
+            if isinstance(reviewer, str) and reviewer:
+                approved.setdefault(reviewer.casefold(), []).append(ref)
+    return {
+        login: RegressionTally(
+            authored=tuple(authored.get(login, ())),
+            approved=tuple(approved.get(login, ())),
+        )
+        for login in set(authored) | set(approved)
+    }
 
 
 def _person_metrics(

--- a/static/styles.css
+++ b/static/styles.css
@@ -513,6 +513,52 @@ a.leaderboard-export:is(:hover, :focus) { color: var(--pico-primary); }
   opacity: 0.7;
 }
 
+.metric-stdev.high {
+  color: #3b3;
+  opacity: 1;
+}
+
+.metric-stdev.low {
+  color: #b33;
+  opacity: 1;
+}
+
+.people-stats-wrap {
+  overflow-x: auto;
+}
+
+.people-stats th.numeric,
+.people-stats td.numeric {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.people-stats th[aria-sort] a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.people-stats th[aria-sort="ascending"] a::after {
+  content: " \2191";
+}
+
+.people-stats th[aria-sort="descending"] a::after {
+  content: " \2193";
+}
+
+.people-stats-note {
+  color: var(--pico-muted-color);
+}
+
+.agent-note {
+  color: var(--pico-muted-color);
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
 .metric-stdev[data-tooltip]::before {
   max-width: min(12rem, calc(100vw - 2rem));
   overflow: hidden;

--- a/templates/base.html
+++ b/templates/base.html
@@ -64,6 +64,7 @@
                 </span>
               </summary>
               <ul>
+                <li><a href="{{ url_for('people') }}">People</a></li>
                 <li><a href="{{ url_for('apps_dashboard') }}">Apps</a></li>
                 <li><a href="{{ url_for('projects') }}">Projects</a></li>
                 <li><a href="{{ url_for('dags_dashboard') }}">DAGs</a></li>

--- a/templates/partials/people_table.html
+++ b/templates/partials/people_table.html
@@ -1,0 +1,49 @@
+{% if stats.notes %}
+<div class="people-stats-notes">
+  {% for note in stats.notes %}
+  <p class="people-stats-note">{{ note }}</p>
+  {% endfor %}
+</div>
+{% endif %}
+<div class="people-stats-wrap">
+  <table class="people-stats">
+    <thead>
+      <tr>
+        {% for header in stats.headers %}
+        <th
+          {% if header.numeric %}class="numeric"{% endif %}
+          aria-sort="{{ header.aria_sort }}"
+        >
+          <a href="{{ url_for('people', **header.sort_query) }}">{{ header.label }}</a>
+        </th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in stats.rows %}
+      <tr>
+        <th scope="row">
+          <a href="{{ url_for('team_slug', slug=row.person.slug, **stats.window_query) }}">{{ row.person.display_name }}</a>
+        </th>
+        {% for cell in row.cells %}
+        <td class="numeric">
+          {% if cell.href %}
+          <a href="{{ cell.href }}">{{ cell.text }}</a>
+          {% else %}
+          {{ cell.text }}
+          {% endif %}
+          {% if cell.note %}<small class="agent-note">{{ cell.note }}</small>{% endif %}
+          {% if cell.stdev %}
+          <small
+            class="metric-stdev{% if cell.stdev.tone %} {{ cell.stdev.tone }}{% endif %}"
+            data-tooltip="{{ cell.stdev.tooltip }}"
+            data-placement="bottom"
+          >{{ cell.stdev.label }}</small>
+          {% endif %}
+        </td>
+        {% endfor %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>

--- a/templates/partials/time_window_controls.html
+++ b/templates/partials/time_window_controls.html
@@ -9,6 +9,9 @@
       aria-pressed="{{ 'true' if preset_days == n else 'false' }}"
     >{{ n }}d</button>
     {% endfor %}
+    {% for name, value in (extra_query | default({})).items() %}
+    <input type="hidden" name="{{ name }}" value="{{ value }}">
+    {% endfor %}
   </form>
   <form
     method="get"
@@ -24,5 +27,8 @@
       <input type="date" name="end" value="{{ end or '' }}" required aria-label="End date">
     </label>
     <button type="submit">Apply</button>
+    {% for name, value in (extra_query | default({})).items() %}
+    <input type="hidden" name="{{ name }}" value="{{ value }}">
+    {% endfor %}
   </form>
 </div>

--- a/templates/people.html
+++ b/templates/people.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block title %}People{% endblock %}
+
+{% block content %}
+    <h1>People</h1>
+    {% include "partials/time_window_controls.html" %}
+    <section id="people-table" aria-busy="true"></section>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+  const windowQuery = {{ window_query | tojson }};
+  const sortToken = {{ sort_token | tojson }};
+  const params = new URLSearchParams(windowQuery);
+  params.set('sort', sortToken);
+
+  async function loadSection(id, url) {
+    const container = document.getElementById(id);
+    if (!container) {
+      return;
+    }
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Failed to load ${id}`);
+      }
+      container.innerHTML = await response.text();
+      container.removeAttribute('aria-busy');
+    } catch (error) {
+      container.innerHTML = '<article>Unable to load section.</article>';
+      container.removeAttribute('aria-busy');
+    }
+  }
+
+  loadSection('people-table', `/partials/people/table?${params}`);
+</script>
+{% endblock %}

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -28,12 +28,16 @@ class NavigationTest(unittest.TestCase):
         self.assertIn('class="dropdown site-menu"', header)
         self.assertIn('aria-label="Open local pages menu"', header)
         self.assertIn('href="/apps"', header)
+        self.assertIn(">Apps</a>", header)
+        self.assertIn('href="/people"', header)
+        self.assertIn(">People</a>", header)
         self.assertIn('href="/projects"', header)
         self.assertIn(">Projects</a>", header)
         self.assertIn('href="/dags"', header)
         self.assertIn(">DAGs</a>", header)
 
         self.assertNotIn('href="/apps"', footer)
+        self.assertNotIn('href="/people"', footer)
         self.assertNotIn('href="/projects"', footer)
         self.assertNotIn('href="/dags"', footer)
 
@@ -337,6 +341,45 @@ class NavigationTest(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("<title>Projects</title>", response.get_data(as_text=True))
+
+    def test_people_page_returns_200_and_lists_unfiltered_roster(self):
+        import people_table as people_table_module
+        from constants import ENGINEERING_TEAM_SLUG
+        from people_table import load_roster
+
+        page = self.client.get("/people")
+        body = page.get_data(as_text=True)
+        self.assertEqual(page.status_code, 200)
+        header = body.split("</header>", 1)[0]
+        footer = body.split("<footer", 1)[1]
+        self.assertIn("<title>People</title>", body)
+        self.assertIn('href="/people"', header)
+        self.assertIn(">People</a>", header)
+        self.assertNotIn('href="/people"', footer)
+        self.assertIn("`/partials/people/table?", body)
+
+        with patch.object(app_module, "datetime", FixedDateTime):
+            sorted_page = self.client.get("/people?days=7&sort=prs_merged")
+        sorted_body = sorted_page.get_data(as_text=True)
+        self.assertEqual(sorted_page.status_code, 200)
+        self.assertIn('name="sort" value="prs_merged"', sorted_body)
+
+        roster = load_roster()
+        engineering = [person for person in roster if person.team == ENGINEERING_TEAM_SLUG]
+        self.assertGreater(len(roster), len(engineering))
+
+        people_table_module._gather.cache_clear()
+        with (
+            patch.object(app_module, "datetime", FixedDateTime),
+            patch("people_table.get_merged_pr_activity", return_value=({}, {})),
+            patch("people_table.collect_regression_attributions", return_value=([], 0)),
+        ):
+            partial = self.client.get("/partials/people/table")
+        people_table_module._gather.cache_clear()
+        partial_body = partial.get_data(as_text=True)
+        self.assertEqual(partial.status_code, 200)
+        for person in roster:
+            self.assertIn(person.display_name, partial_body)
 
 
 if __name__ == "__main__":

--- a/tests/test_people_table.py
+++ b/tests/test_people_table.py
@@ -1,0 +1,363 @@
+import os
+import unittest
+from datetime import date
+from unittest.mock import patch
+from urllib.parse import parse_qs, unquote, urlparse
+
+import github
+import people_table
+from people_table import (
+    DEFAULT_SORT,
+    AgentCredit,
+    ColumnKey,
+    Direction,
+    PeopleStatsInputs,
+    Person,
+    SortOrder,
+    assemble_people_stats,
+    build_people_stats,
+    load_roster,
+    parse_sort,
+)
+from regressions import RegressionRef, RegressionTally
+from time_window import TimeWindow
+
+
+def _window() -> TimeWindow:
+    return TimeWindow.from_dates(date(2026, 8, 1), date(2026, 8, 31))
+
+
+def _person(
+    slug: str,
+    *,
+    team: str = "engineering",
+    github_login: str | None = "",
+    display_name: str | None = None,
+) -> Person:
+    login = slug if github_login == "" else github_login
+    return Person(slug, display_name or slug.title(), team, login)
+
+
+def _tally(*, authored: int = 0, approved: int = 0) -> RegressionTally:
+    authored_refs = tuple(
+        RegressionRef(f"APO-A{index}", None, f"https://github.com/example/repo/pull/{index}")
+        for index in range(authored)
+    )
+    approved_refs = tuple(
+        RegressionRef(f"APO-R{index}", None, f"https://github.com/example/repo/pull/{index + 50}")
+        for index in range(approved)
+    )
+    return RegressionTally(authored=authored_refs, approved=approved_refs)
+
+
+def _inputs(
+    roster: tuple[Person, ...],
+    *,
+    merged: dict[str, int] | None = None,
+    reviewed: dict[str, int] | None = None,
+    agent: dict[str, AgentCredit] | None = None,
+    regressions: dict[str, RegressionTally] | None = None,
+    notes: tuple[str, ...] = (),
+    github_available: bool = True,
+    regressions_available: bool = True,
+) -> PeopleStatsInputs:
+    return PeopleStatsInputs(
+        window=_window(),
+        roster=roster,
+        merged_by_login=merged or {},
+        reviewed_by_login=reviewed or {},
+        agent_by_login=agent or {},
+        regressions_by_login=regressions or {},
+        notes=notes,
+        github_available=github_available,
+        regressions_available=regressions_available,
+    )
+
+
+def _cell(row, key: ColumnKey):
+    return row.cells[people_table._COLUMN_INDEX[key]]
+
+
+def _row(stats, slug: str):
+    return next(row for row in stats.rows if row.person.slug == slug)
+
+
+class PeopleTableTest(unittest.TestCase):
+    def setUp(self):
+        people_table._gather.cache_clear()
+        self.addCleanup(people_table._gather.cache_clear)
+        env = patch.dict(os.environ, {"GITHUB_TOKEN": "test-token", "LINEAR_API_KEY": "test-key"})
+        env.start()
+        self.addCleanup(env.stop)
+
+    def test_every_configured_person_appears_with_no_team_filter(self):
+        roster = (
+            _person("eng", team="engineering"),
+            _person("other", team="unassigned"),
+        )
+        stats = assemble_people_stats(_inputs(roster), DEFAULT_SORT)
+        self.assertEqual({row.person.slug for row in stats.rows}, {"eng", "other"})
+        self.assertEqual({row.person.team for row in stats.rows}, {"engineering", "unassigned"})
+
+    def test_missing_github_login_is_zero_with_no_links(self):
+        roster = (
+            _person("casey", github_login=None, display_name="Casey"),
+            _person("alice", display_name="Alice"),
+        )
+        stats = assemble_people_stats(
+            _inputs(roster, merged={"alice": 4}),
+            DEFAULT_SORT,
+        )
+        casey = _row(stats, "casey")
+        self.assertEqual([cell.text for cell in casey.cells], ["0", "0", "0", "—", "0", "0"])
+        self.assertTrue(all(cell.href is None for cell in casey.cells))
+
+    def test_assemble_people_stats_never_calls_the_network(self):
+        roster = (_person("alice"),)
+        with (
+            patch.object(people_table, "get_merged_pr_activity") as activity,
+            patch.object(people_table, "collect_regression_attributions") as collect,
+            patch.object(github, "get_merged_pr_counts_for_user") as counts,
+        ):
+            assemble_people_stats(_inputs(roster, merged={"alice": 1}), DEFAULT_SORT)
+        activity.assert_not_called()
+        collect.assert_not_called()
+        counts.assert_not_called()
+
+    def test_build_people_stats_uses_one_bulk_github_fetch(self):
+        window = _window()
+        roster = (_person("alice"),)
+        with (
+            patch.object(people_table, "load_roster", return_value=roster),
+            patch.object(
+                people_table,
+                "get_merged_pr_activity",
+                return_value=({"alice": [{"author": {"login": "alice"}}]}, {}),
+            ) as activity,
+            patch.object(
+                people_table, "collect_regression_attributions", return_value=([], 0)
+            ) as collect,
+            patch.object(github, "get_merged_pr_counts_for_user") as counts,
+        ):
+            stats = build_people_stats(window, DEFAULT_SORT)
+        activity.assert_called_once()
+        self.assertEqual(activity.call_args.args[0], window.duration_days)
+        self.assertEqual(activity.call_args.args[1].start, window.start)
+        self.assertEqual(activity.call_args.args[1].end, window.end)
+        collect.assert_called_once()
+        self.assertEqual(collect.call_args.args[0].start, window.start)
+        self.assertEqual(collect.call_args.args[0].end, window.end)
+        counts.assert_not_called()
+        self.assertEqual(_cell(_row(stats, "alice"), ColumnKey.PRS_MERGED).text, "1")
+
+    def test_cursor_credited_prs_increment_agent_count_and_merged(self):
+        window = _window()
+        roster = (_person("alice"),)
+        prs = [
+            {"author": {"login": "alice"}},
+            {"author": {"login": "alice"}},
+            {"author": {"login": "cursor"}},
+        ]
+        with (
+            patch.object(people_table, "load_roster", return_value=roster),
+            patch.object(people_table, "get_merged_pr_activity", return_value=({"alice": prs}, {})),
+            patch.object(people_table, "collect_regression_attributions", return_value=([], 0)),
+        ):
+            stats = build_people_stats(window, DEFAULT_SORT)
+        alice = _row(stats, "alice")
+        self.assertEqual(_cell(alice, ColumnKey.PRS_MERGED).text, "3")
+        self.assertEqual(_cell(alice, ColumnKey.AGENT_PRS).text, "1")
+        self.assertEqual(_cell(alice, ColumnKey.AGENT_PRS).note, "Cursor")
+        self.assertEqual(_cell(alice, ColumnKey.AGENT_SHARE).text, "33%")
+
+    def test_agent_share_is_missing_when_merged_is_zero(self):
+        roster = (_person("alice"),)
+        stats = assemble_people_stats(_inputs(roster), DEFAULT_SORT)
+        self.assertEqual(_cell(_row(stats, "alice"), ColumnKey.AGENT_SHARE).text, "—")
+
+    def test_parse_sort_is_total_and_signed(self):
+        self.assertEqual(parse_sort(None), DEFAULT_SORT)
+        self.assertEqual(parse_sort(""), DEFAULT_SORT)
+        self.assertEqual(parse_sort("nope"), DEFAULT_SORT)
+        self.assertEqual(parse_sort("-nope"), DEFAULT_SORT)
+        self.assertEqual(parse_sort("prs_merged"), SortOrder(ColumnKey.PRS_MERGED, Direction.ASC))
+        self.assertEqual(parse_sort("-prs_merged"), SortOrder(ColumnKey.PRS_MERGED, Direction.DESC))
+        self.assertEqual(DEFAULT_SORT.token, "-prs_merged")
+        self.assertEqual(parse_sort("person").token, "person")
+        self.assertEqual(parse_sort("-agent_share").key, ColumnKey.AGENT_SHARE)
+
+    def test_sort_by_each_column(self):
+        roster = (
+            _person("alice", display_name="Alice"),
+            _person("bob", display_name="Bob"),
+            _person("dana", display_name="Dana"),
+        )
+        inputs = _inputs(
+            roster,
+            merged={"alice": 10, "bob": 5, "dana": 1},
+            reviewed={"alice": 1, "bob": 8, "dana": 3},
+            agent={
+                "alice": AgentCredit(1, ("Cursor",)),
+                "bob": AgentCredit(5, ("Cursor",)),
+            },
+            regressions={
+                "alice": _tally(approved=3),
+                "bob": _tally(authored=2, approved=1),
+                "dana": _tally(authored=1),
+            },
+        )
+        expected = {
+            ColumnKey.PERSON: ["Alice", "Bob", "Dana"],
+            ColumnKey.PRS_MERGED: ["Alice", "Bob", "Dana"],
+            ColumnKey.PRS_REVIEWED: ["Bob", "Dana", "Alice"],
+            ColumnKey.AGENT_PRS: ["Bob", "Alice", "Dana"],
+            ColumnKey.AGENT_SHARE: ["Bob", "Alice", "Dana"],
+            ColumnKey.REGRESSIONS_AUTHORED: ["Bob", "Dana", "Alice"],
+            ColumnKey.REGRESSIONS_APPROVED: ["Alice", "Bob", "Dana"],
+        }
+        for key, names in expected.items():
+            direction = Direction.ASC if key is ColumnKey.PERSON else Direction.DESC
+            stats = assemble_people_stats(inputs, SortOrder(key, direction))
+            self.assertEqual(
+                [row.person.display_name for row in stats.rows],
+                names,
+                key,
+            )
+
+    def test_header_toggle_preserves_window_args(self):
+        roster = (_person("alice"),)
+        stats = assemble_people_stats(_inputs(roster), DEFAULT_SORT)
+        merged = next(header for header in stats.headers if header.key is ColumnKey.PRS_MERGED)
+        person = next(header for header in stats.headers if header.key is ColumnKey.PERSON)
+        self.assertEqual(merged.sort_query["start"], "2026-08-01")
+        self.assertEqual(merged.sort_query["end"], "2026-08-31")
+        self.assertEqual(merged.sort_query["sort"], "prs_merged")
+        self.assertEqual(person.sort_query["sort"], "person")
+        self.assertEqual(merged.aria_sort, "descending")
+        self.assertEqual(person.aria_sort, "none")
+        toggled = assemble_people_stats(_inputs(roster), parse_sort("prs_merged"))
+        merged_asc = next(
+            header for header in toggled.headers if header.key is ColumnKey.PRS_MERGED
+        )
+        self.assertEqual(merged_asc.sort_query["sort"], "-prs_merged")
+        self.assertEqual(merged_asc.sort_query["start"], "2026-08-01")
+
+    def test_zero_cells_have_no_href(self):
+        roster = (
+            _person("alice"),
+            _person("bob"),
+        )
+        stats = assemble_people_stats(
+            _inputs(
+                roster,
+                merged={"alice": 2},
+                reviewed={"alice": 1},
+                regressions={"alice": _tally(authored=1)},
+            ),
+            DEFAULT_SORT,
+        )
+        bob = _row(stats, "bob")
+        self.assertTrue(all(cell.href is None for cell in bob.cells))
+        alice = _row(stats, "alice")
+        self.assertIsNotNone(_cell(alice, ColumnKey.PRS_MERGED).href)
+        self.assertIsNone(_cell(alice, ColumnKey.PRS_REVIEWED).href)
+        self.assertIsNone(_cell(alice, ColumnKey.AGENT_PRS).href)
+        self.assertIsNone(_cell(alice, ColumnKey.REGRESSIONS_APPROVED).href)
+        merged_query = parse_qs(urlparse(_cell(alice, ColumnKey.PRS_MERGED).href).query)["q"][0]
+        self.assertIn("author:alice", unquote(merged_query))
+        self.assertIn("is:closed", unquote(merged_query))
+        self.assertNotIn("reviewed-by:", unquote(merged_query))
+        authored_href = _cell(alice, ColumnKey.REGRESSIONS_AUTHORED).href
+        self.assertIn("/issues/APO-A0", authored_href)
+
+    def test_failed_github_load_is_unavailable_not_a_measured_zero(self):
+        roster = (
+            _person("casey", github_login=None, display_name="Casey"),
+            _person("alice", display_name="Alice"),
+            _person("bob", display_name="Bob"),
+        )
+        stats = assemble_people_stats(
+            _inputs(
+                roster,
+                merged={"alice": 10, "bob": 4},
+                notes=("Unable to load GitHub PR stats.",),
+                github_available=False,
+            ),
+            DEFAULT_SORT,
+        )
+        alice = _row(stats, "alice")
+        casey = _row(stats, "casey")
+        self.assertEqual(_cell(alice, ColumnKey.PRS_MERGED).text, "—")
+        self.assertEqual(_cell(alice, ColumnKey.PRS_REVIEWED).text, "—")
+        self.assertEqual(_cell(alice, ColumnKey.AGENT_SHARE).text, "—")
+        self.assertIsNone(_cell(alice, ColumnKey.PRS_MERGED).href)
+        self.assertIsNone(_cell(alice, ColumnKey.PRS_MERGED).stdev)
+        self.assertEqual(_cell(casey, ColumnKey.PRS_MERGED).text, "0")
+        self.assertIsNone(_cell(casey, ColumnKey.PRS_MERGED).stdev)
+        self.assertIn("Unable to load GitHub PR stats.", stats.notes)
+
+    def test_missing_credentials_skip_fetches(self):
+        roster = (_person("alice"),)
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.object(people_table, "load_roster", return_value=roster),
+            patch.object(people_table, "get_merged_pr_activity") as activity,
+            patch.object(people_table, "collect_regression_attributions") as collect,
+        ):
+            people_table._gather.cache_clear()
+            stats = build_people_stats(_window(), DEFAULT_SORT)
+        activity.assert_not_called()
+        collect.assert_not_called()
+        alice = _row(stats, "alice")
+        self.assertEqual(_cell(alice, ColumnKey.PRS_MERGED).text, "—")
+        self.assertEqual(_cell(alice, ColumnKey.REGRESSIONS_AUTHORED).text, "—")
+        self.assertIn("GitHub credentials are not configured.", stats.notes)
+        self.assertIn("Linear credentials are not configured.", stats.notes)
+
+    def test_stdev_tooltip_uses_all_people_and_includes_zeros(self):
+        roster = (
+            _person("alice", display_name="Alice"),
+            _person("bob", display_name="Bob"),
+        )
+        stats = assemble_people_stats(
+            _inputs(roster, merged={"alice": 10, "bob": 0}),
+            DEFAULT_SORT,
+        )
+        alice_badge = _cell(_row(stats, "alice"), ColumnKey.PRS_MERGED).stdev
+        bob_badge = _cell(_row(stats, "bob"), ColumnKey.PRS_MERGED).stdev
+        self.assertIsNotNone(alice_badge)
+        self.assertIsNotNone(bob_badge)
+        self.assertIn("all people", alice_badge.tooltip)
+        self.assertEqual(alice_badge.tooltip, bob_badge.tooltip)
+        self.assertEqual(alice_badge.label, "+1.0σ")
+        self.assertEqual(bob_badge.label, "−1.0σ")
+
+    def test_blank_github_username_normalizes_to_none(self):
+        config = {
+            "people": {
+                "casey": {
+                    "team": "unassigned",
+                    "linear_username": "casey",
+                    "github_username": "",
+                },
+                "justin": {
+                    "team": "unassigned",
+                    "linear_username": "justin.isenhart",
+                    "github_username": None,
+                },
+                "alice": {
+                    "team": "engineering",
+                    "linear_username": "alice",
+                    "github_username": "Alice",
+                },
+            }
+        }
+        with patch("people_table.load_config", return_value=config):
+            roster = load_roster()
+        self.assertEqual([person.github_login for person in roster], [None, None, "Alice"])
+        self.assertEqual(roster[1].display_name, "Justin Isenhart")
+        self.assertEqual(roster[2].github_key, "alice")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_person_stats.py
+++ b/tests/test_person_stats.py
@@ -72,6 +72,10 @@ class PersonStatsTest(unittest.TestCase):
         self.assertIsNone(person_stats.z_score(9, [4, 4]))
         self.assertEqual(person_stats.z_score(10, [10, 2]), 1.0)
         self.assertEqual(person_stats.format_stdev_tooltip([10, 2]), "eng avg 6.0 · σ 4.0")
+        self.assertEqual(
+            person_stats.format_stdev_tooltip([10, 2], cohort="all people"),
+            "all people avg 6.0 · σ 4.0",
+        )
 
     def test_z_scores_trim_extremes_without_clipping_exceptional_people(self):
         prs_merged = [378, 77, 9, 81, 0, 99, 60, 26]

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -15,6 +15,7 @@ from regressions import (
     extract_fixing_pr_urls,
     load_regression_overrides,
     merge_issue_attributions,
+    tally_regressions_by_login,
 )
 from time_window import TimeWindow
 
@@ -353,6 +354,67 @@ class RegressionAttributionTest(unittest.TestCase):
         self.assertFalse(second["analysis_complete"])
         self.assertEqual(reviewers[1]["attributions"], authors[0]["attributions"])
         self.assertEqual(authors[1]["attributions"], [])
+
+    def test_tally_regressions_by_login_uses_inducing_pr_window(self):
+        window = TimeWindow.from_dates(date(2026, 8, 1), date(2026, 8, 31))
+        records = [
+            {
+                "identifier": "APO-2",
+                "issue_url": "https://linear.app/apollos/issue/APO-2/example",
+                "attribution": {
+                    "url": " https://github.com/example/zeta/pull/3/ ",
+                    "merged_at": "2026-08-10T00:00:00Z",
+                    "author": "Alice",
+                    "reviewers": ["bob"],
+                },
+            },
+            {
+                "identifier": "APO-1",
+                "issue_url": "https://linear.app/apollos/issue/APO-1/example",
+                "attribution": {
+                    "url": "https://github.com/example/alpha/pull/12",
+                    "merged_at": "2026-08-11T00:00:00Z",
+                    "author": "alice",
+                    "reviewers": ["Bob"],
+                },
+            },
+            {
+                "identifier": "APO-old",
+                "attribution": {
+                    "url": "https://github.com/example/repo/pull/11",
+                    "merged_at": "2025-08-10T00:00:00Z",
+                    "author": "alice",
+                    "reviewers": ["bob"],
+                },
+            },
+            {
+                "identifier": "APO-reviewer-only",
+                "issue_url": "https://linear.app/apollos/issue/APO-reviewer-only/example",
+                "attribution": {
+                    "url": "https://github.com/example/repo/pull/20",
+                    "merged_at": "2026-08-12T00:00:00Z",
+                    "author": "carol",
+                    "reviewers": ["alice"],
+                },
+            },
+            {"identifier": "APO-missing"},
+        ]
+        tallies = tally_regressions_by_login(records, window)
+        self.assertEqual(tallies["alice"].authored_count, 2)
+        self.assertEqual(tallies["alice"].approved_count, 1)
+        self.assertEqual(tallies["bob"].authored_count, 0)
+        self.assertEqual(tallies["bob"].approved_count, 2)
+        self.assertEqual(tallies["carol"].authored_count, 1)
+        self.assertEqual(tallies["carol"].approved_count, 0)
+        self.assertEqual(
+            [ref.identifier for ref in tallies["alice"].authored],
+            ["APO-2", "APO-1"],
+        )
+        self.assertEqual(
+            tallies["alice"].authored[0].inducing_pr_url,
+            "https://github.com/example/zeta/pull/3/",
+        )
+        self.assertNotIn("APO-old", [ref.identifier for ref in tallies["alice"].authored])
 
     def test_unconfigured_summary_skips_external_work(self):
         with patch.dict("os.environ", {}, clear=True):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The homepage leaderboard is `team: engineering` only. This adds `/people`, a table of every person in `config.yml`, with the same date-range controls as the rest of Bug Board and click-to-sort columns.

**Why**

We needed a roster view that is not filtered the way `/` is, and that can sort by merged PRs, reviews, Cursor credit, and regression blame for a chosen window.

**Scope**

- `/people` shell plus `/partials/people/table`
- People link in the header menu
- Columns: PRs merged, PRs reviewed, Agent PRs, Agent share, regressions authored, regressions approved
- σ vs every row on this table, including known zeros for people with no GitHub login
- Default sort: PRs merged descending. Sort token is one query param (`-prs_merged`, `person`, …)
- Date presets 7 / 30 / 90. Changing the window keeps the current sort
- Cursor credit is split out of the bulk merged-PR lists (`author.login == "cursor"`). No extra GitHub search. No Claude/Copilot columns
- Live `collect_regression_attributions(window)` via a new `tally_regressions_by_login` helper. The homepage 30-day cache is not used here

**Tradeoffs**

- Reviewed cells are plain text. A `reviewed-by:` search is a broader set than the APPROVED-only count we show
- A failed GitHub or Linear load is a notice plus `—`, not a measured zero, so it does not enter σ. People with a blank GitHub login stay known zeros
- Merged-PR links reuse the existing person-page search (`is:closed is:pr author:…`). That under-matches Cursor-credited PRs. Changing it would change another page
- `_person_metrics` is unchanged. The table consumes the new tally helper; migrating the person page is follow-up

**Blast radius**

- `templates/partials/time_window_controls.html` can take `extra_query` hidden fields. Index and person pages omit it and keep current behavior
- `format_stdev_tooltip` takes an optional `cohort` label. Default remains `"eng"`
- `github.py` is unchanged

**To test**

Review app (this SHA):

- https://bug-board-cursor-people-7op9xy.herokuapp.com/people — all 18 people, People in the hamburger, 30d default, sort by PRs merged desc. The table is a slow partial (live GitHub + Linear). Wait for it.
- https://bug-board-cursor-people-7op9xy.herokuapp.com/people?days=7&sort=person — 7d window, name sort. Hidden `sort` fields should keep that token when you change the window.
- https://bug-board-cursor-people-7op9xy.herokuapp.com/ — homepage should look as it did. Date controls must not have a hidden sort field.

Local fallback:

```bash
source venv/bin/activate
gunicorn app:app --bind 127.0.0.1:8000 --workers 1
```

Without API keys, Casey, Justin Isenhart, and Tyler Vance show `0`. Everyone else shows `—`. Person names go to `/team/<slug>`. Merged counts with a value > 0 go to GitHub. Reviewed counts do not.

```bash
ruff check .
ruff format --check .
mypy .
python -m unittest discover -s tests -p 'test_*.py'
```

Screenshots from local, no API keys:

[People table default: 30d, sorted by PRs merged descending. Blank GitHub rows are 0; others are unavailable dashes.](https://cursor.com/agents/bc-66209b3f-7c35-42f6-be45-07ed64add342/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fpeople-desktop-default.png)

Default `/people`. Tyler Vance, Justin Isenhart, and Casey are known zeros. Other rows are `—` because credentials are missing.

[People table sorted A-Z by name, URL has days=30 and sort=person](https://cursor.com/agents/bc-66209b3f-7c35-42f6-be45-07ed64add342/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fpeople-desktop-sorted-name.png)

After clicking Person. URL is `/people?days=30&sort=person`.

[People table on the 7d preset with sort still in the URL](https://cursor.com/agents/bc-66209b3f-7c35-42f6-be45-07ed64add342/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fpeople-desktop-7d.png)

7d pressed, URL has `days=7` and a sort token. This shot was taken before a gunicorn reload, so numeric cells look like zeros across the board. After reload, blank-GitHub rows stay 0 and the rest become `—`.

[Mobile 390px people page with hamburger open to People, Apps, Projects, DAGs](https://cursor.com/agents/bc-66209b3f-7c35-42f6-be45-07ed64add342/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fpeople-mobile.png)

390px viewport. Hamburger still has People. The table scrolls horizontally.

[Homepage date controls with no hidden sort field](https://cursor.com/agents/bc-66209b3f-7c35-42f6-be45-07ed64add342/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Findex-desktop.png)

Index after the `extra_query` change. No hidden `sort` field.

Posted by Cursor on behalf of @conrad


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66209b3f-7c35-42f6-be45-07ed64add342?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66209b3f-7c35-42f6-be45-07ed64add342&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

